### PR TITLE
Create package ds3autogen.utils & move Helper from ds3autogen.java; r…

### DIFF
--- a/ds3-autogen-api/src/main/java/com/spectralogic/ds3autogen/api/models/Arguments.java
+++ b/ds3-autogen-api/src/main/java/com/spectralogic/ds3autogen/api/models/Arguments.java
@@ -13,7 +13,7 @@
  * ****************************************************************************
  */
 
-package com.spectralogic.ds3autogen.java.models;
+package com.spectralogic.ds3autogen.api.models;
 
 public class Arguments {
     final private String type;

--- a/ds3-autogen-java/build.gradle
+++ b/ds3-autogen-java/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
     compile project(':ds3-autogen-api')
+    compile project(':ds3-autogen-utils')
     testCompile project(':ds3-autogen')
 }

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/converters/RequestConverter.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/converters/RequestConverter.java
@@ -21,7 +21,7 @@ import com.spectralogic.ds3autogen.api.models.Classification;
 import com.spectralogic.ds3autogen.api.models.Ds3Param;
 import com.spectralogic.ds3autogen.api.models.Ds3Request;
 import com.spectralogic.ds3autogen.api.models.Requirement;
-import com.spectralogic.ds3autogen.java.models.Arguments;
+import com.spectralogic.ds3autogen.api.models.Arguments;
 import com.spectralogic.ds3autogen.java.models.Request;
 
 public class RequestConverter {

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/Request.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/Request.java
@@ -16,8 +16,9 @@
 package com.spectralogic.ds3autogen.java.models;
 
 import com.google.common.collect.ImmutableList;
+import com.spectralogic.ds3autogen.api.models.Arguments;
 import com.spectralogic.ds3autogen.api.models.HttpVerb;
-import com.spectralogic.ds3autogen.java.helper.Helper;
+import com.spectralogic.ds3autogen.utils.Helper;
 
 public class Request {
     private final String packageName;

--- a/ds3-autogen-utils/build.gradle
+++ b/ds3-autogen-utils/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+    compile project(':ds3-autogen-api')
+}

--- a/ds3-autogen-utils/src/main/java/com/spectralogic/ds3autogen/utils/Helper.java
+++ b/ds3-autogen-utils/src/main/java/com/spectralogic/ds3autogen/utils/Helper.java
@@ -13,11 +13,11 @@
  * ****************************************************************************
  */
 
-package com.spectralogic.ds3autogen.java.helper;
+package com.spectralogic.ds3autogen.utils;
 
 import com.google.common.base.CaseFormat;
 import com.google.common.collect.ImmutableList;
-import com.spectralogic.ds3autogen.java.models.Arguments;
+import com.spectralogic.ds3autogen.api.models.Arguments;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-include 'ds3-autogen', 'ds3-autogen-api', 'ds3-autogen-c', 'ds3-autogen-java', 'ds3-autogen-net', 'ds3-autogen-python', 'ds3-autogen-cli'
+include 'ds3-autogen', 'ds3-autogen-api', 'ds3-autogen-c', 'ds3-autogen-java', 'ds3-autogen-net', 'ds3-autogen-python', 'ds3-autogen-cli', 'ds3-autogen-utils'


### PR DESCRIPTION
…efactor all references

All Java module tests still pass.

Testing started at 11:17 AM ...
11:17:00 AM: Executing external tasks 'cleanTest test'...
:ds3-autogen-java:cleanTest UP-TO-DATE
:ds3-autogen-api:compileJava
:ds3-autogen-api:processResources UP-TO-DATE
:ds3-autogen-api:classes
:ds3-autogen-api:jar
:ds3-autogen:compileJava
:ds3-autogen:processResources UP-TO-DATE
:ds3-autogen:classes
:ds3-autogen:jar
:ds3-autogen-utils:compileJava
:ds3-autogen-utils:processResources UP-TO-DATE
:ds3-autogen-utils:classes
:ds3-autogen-utils:jar
:ds3-autogen-java:compileJava
:ds3-autogen-java:processResources
:ds3-autogen-java:classes
:ds3-autogen-java:compileTestJava
:ds3-autogen-java:processTestResources
:ds3-autogen-java:testClasses
:ds3-autogen-java:test
[Test worker] INFO com.spectralogic.ds3autogen.java.JavaCodeGenerator - Getting outputstream for file:./ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/AbortMultiPartUploadRequestHandler.java
[Test worker] INFO com.spectralogic.ds3autogen.java.JavaCodeGenerator - Getting outputstream for file:./ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/CompleteMultiPartUploadRequestHandler.java
[Test worker] ERROR com.spectralogic.ds3autogen.java.utils.TestFileUtilImpl - Attempted to create folder that already exists -- ignoring
java.io.IOException: a folder with the name 'commands' already exists
    at org.junit.rules.TemporaryFolder.newFolder(TemporaryFolder.java:100)
    at com.spectralogic.ds3autogen.java.utils.TestFileUtilImpl.getOutputFile(TestFileUtilImpl.java:30)
...
    public UUID getUploadId() {
        return this.uploadId;
    }

```
public long getOffset() {
    return this.offset;
}
```

}
BUILD SUCCESSFUL
Total time: 10.652 secs
11:17:12 AM: External tasks execution finished 'cleanTest test'.
