### PR TITLE
fixed bug where generic error was printed if all args not present in cli usage

### DIFF
--- a/ds3-autogen-cli/src/main/java/com/spectralogic/autogen/cli/Arguments.java
+++ b/ds3-autogen-cli/src/main/java/com/spectralogic/autogen/cli/Arguments.java
@@ -2,16 +2,27 @@ package com.spectralogic.autogen.cli;
 
 
 public class Arguments {
-    private final String targetDir;
-    private final GeneratorType type;
-    private final String inputSpec;
-    private final boolean help;
+    private String targetDir;
+    private GeneratorType type;
+    private String inputSpec;
+    private boolean help;
 
-    public Arguments(final String targetDir, final GeneratorType type, final String inputSpec, final boolean help) {
+    public Arguments() { }
+
+    public void setTargetDir(final String targetDir) {
         this.targetDir = targetDir;
+    }
+
+    public void setType(final GeneratorType type) {
         this.type = type;
-        this.help = help;
+    }
+
+    public void setInputSpec(final String inputSpec) {
         this.inputSpec = inputSpec;
+    }
+
+    public void setHelp(final boolean help) {
+        this.help = help;
     }
 
     public String getTargetDir() {

--- a/ds3-autogen-cli/src/main/java/com/spectralogic/autogen/cli/CLI.java
+++ b/ds3-autogen-cli/src/main/java/com/spectralogic/autogen/cli/CLI.java
@@ -36,12 +36,20 @@ public class CLI {
         final CommandLineParser parser = new BasicParser();
         final CommandLine cmd = parser.parse(options, args);
 
-        final String directory = cmd.getOptionValue("d");
-        final GeneratorType language = Guards.returnIfNull(cmd.getOptionValue("l").toUpperCase(), GeneratorType::valueOf);
-        final String inputSpec = cmd.getOptionValue("i");
-        final boolean help = cmd.hasOption("h");
+        final Arguments arguments = new Arguments();
 
-        final Arguments arguments = new Arguments(directory, language, inputSpec, help);
+        if (cmd.hasOption("d")) {
+            arguments.setTargetDir(cmd.getOptionValue("d"));
+        }
+        if (cmd.hasOption("l")) {
+            arguments.setType(Guards.returnIfNull(cmd.getOptionValue("l").toUpperCase(), GeneratorType::valueOf));
+        }
+        if (cmd.hasOption("i")) {
+            arguments.setInputSpec(cmd.getOptionValue("i"));
+        }
+        if (cmd.hasOption("h")) {
+            arguments.setHelp(true);
+        }
 
         validateArguments(arguments);
 


### PR DESCRIPTION
A generic error was printing when using the cli while not including all required arguments (i.e. -h did not produce proper message unless it also included all other arguments as expected)