### PR TITLE
Modified checksumtype.type name to avoid naming conflicts

### DIFF
--- a/ds3-autogen-net/src/main/resources/tmpls/net/request/common/optional_checksum.ftl
+++ b/ds3-autogen-net/src/main/resources/tmpls/net/request/common/optional_checksum.ftl
@@ -1,14 +1,14 @@
         private ChecksumType _checksum = ChecksumType.None;
-        private ChecksumType.Type _type;
+        private ChecksumType.Type _ctype;
 
         internal override ChecksumType ChecksumValue
         {
             get { return this._checksum; }
         }
 
-        internal override ChecksumType.Type Type
+        internal override ChecksumType.Type CType
         {
-            get { return this._type; }
+            get { return this._ctype; }
         }
 
         public ChecksumType Checksum
@@ -17,9 +17,9 @@
             set { this.WithChecksum(value); }
         }
 
-        public ${name} WithChecksum(ChecksumType checksum, ChecksumType.Type type = ChecksumType.Type.MD5)
+        public ${name} WithChecksum(ChecksumType checksum, ChecksumType.Type ctype = ChecksumType.Type.MD5)
         {
             this._checksum = checksum;
-            this._type = type;
+            this._ctype = ctype;
             return this;
         }

--- a/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/NetCodeGenerator_Test.java
+++ b/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/NetCodeGenerator_Test.java
@@ -49,7 +49,7 @@ import static org.mockito.Mockito.mock;
 public class NetCodeGenerator_Test {
 
     private final static Logger LOG = LoggerFactory.getLogger(NetCodeGenerator_Test.class);
-    private final static GeneratedCodeLogger CODE_LOGGER = new GeneratedCodeLogger(FileTypeToLog.CLIENT, LOG);
+    private final static GeneratedCodeLogger CODE_LOGGER = new GeneratedCodeLogger(FileTypeToLog.REQUEST, LOG);
 
     @Rule
     public TemporaryFolder tempFolder = new TemporaryFolder();

--- a/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/utils/TestHelper.java
+++ b/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/utils/TestHelper.java
@@ -60,11 +60,11 @@ public final class TestHelper {
      */
     public static boolean hasOptionalChecksum(final String requestName, final String generatedCode) {
         return generatedCode.contains("private ChecksumType _checksum = ChecksumType.None")
-                && generatedCode.contains("private ChecksumType.Type _type")
+                && generatedCode.contains("private ChecksumType.Type _ctype")
                 && generatedCode.contains("internal override ChecksumType ChecksumValue")
-                && generatedCode.contains("internal override ChecksumType.Type Type")
+                && generatedCode.contains("internal override ChecksumType.Type CType")
                 && generatedCode.contains("public ChecksumType Checksum")
-                && generatedCode.contains("public " + requestName + " WithChecksum(ChecksumType checksum, ChecksumType.Type type = ChecksumType.Type.MD5)");
+                && generatedCode.contains("public " + requestName + " WithChecksum(ChecksumType checksum, ChecksumType.Type ctype = ChecksumType.Type.MD5)");
     }
 
     /**


### PR DESCRIPTION
The checksum type object being named Type was creating warnings as it conflicts with other elements that can be named type in net sdk. Renaming the checksum type removed 17 warnings in net sdk.