### PR TITLE
Parsing code implemented in BaseResponseParser in java module

### DIFF
--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responseparser/BaseResponseParserGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responseparser/BaseResponseParserGenerator.java
@@ -19,16 +19,25 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3Request;
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3ResponseCode;
+import com.spectralogic.ds3autogen.api.models.apispec.Ds3ResponseType;
 import com.spectralogic.ds3autogen.java.models.Constants;
+import com.spectralogic.ds3autogen.java.models.ResponseCode;
 import com.spectralogic.ds3autogen.java.models.ResponseParser;
+import com.spectralogic.ds3autogen.java.models.parseresponse.BaseParseResponse;
+import com.spectralogic.ds3autogen.java.models.parseresponse.EmptyParseResponse;
+import com.spectralogic.ds3autogen.java.models.parseresponse.ParseResponse;
+import com.spectralogic.ds3autogen.java.models.parseresponse.StringParseResponse;
 import com.spectralogic.ds3autogen.utils.collections.GuavaCollectors;
 
+import java.util.stream.Collectors;
+
+import static com.spectralogic.ds3autogen.java.helpers.JavaHelper.convertType;
 import static com.spectralogic.ds3autogen.java.utils.JavaModuleUtil.getCommandPackage;
 import static com.spectralogic.ds3autogen.java.utils.ResponseAndParserUtils.getImportListFromResponseCodes;
 import static com.spectralogic.ds3autogen.java.utils.ResponseAndParserUtils.removeErrorResponseCodes;
-import static com.spectralogic.ds3autogen.utils.NormalizingContractNamesUtil.removePath;
-import static com.spectralogic.ds3autogen.utils.NormalizingContractNamesUtil.toResponseName;
-import static com.spectralogic.ds3autogen.utils.NormalizingContractNamesUtil.toResponseParserName;
+import static com.spectralogic.ds3autogen.utils.ConverterUtil.isEmpty;
+import static com.spectralogic.ds3autogen.utils.Helper.stripPath;
+import static com.spectralogic.ds3autogen.utils.NormalizingContractNamesUtil.*;
 
 public class BaseResponseParserGenerator implements ResponseParserGenerator<ResponseParser>, ResponseParserGeneratorUtil {
 
@@ -39,7 +48,13 @@ public class BaseResponseParserGenerator implements ResponseParserGenerator<Resp
         final String parserName = toResponseParserName(ds3Request.getName());
         final String responseName = toResponseName(ds3Request.getName());
         final String parentClass = getParentClass();
-        final ImmutableList<Ds3ResponseCode> responseCodes = toResponseCodes(ds3Request); //TODO change to template model for generating response switch
+
+        final ImmutableList<ResponseCode> responseCodes = toResponseCodeList(
+                ds3Request.getDs3ResponseCodes(),
+                responseName);
+
+        final String expectedStatusCodes = toStatusCodeList(responseCodes);
+
         final ImmutableSet<String> imports = toImportList(
                 responseName,
                 ds3Request,
@@ -50,16 +65,73 @@ public class BaseResponseParserGenerator implements ResponseParserGenerator<Resp
                 responseName,
                 packageName,
                 parentClass,
-                imports);
+                expectedStatusCodes,
+                imports,
+                responseCodes);
     }
 
     /**
-     * Gets the response codes required to generate this response
+     * Creates a comma-separated list of all expected status codes
+     */
+    protected static String toStatusCodeList(final ImmutableList<ResponseCode> responseCodes) {
+        if (isEmpty(responseCodes)) {
+            return "";
+        }
+        return responseCodes.stream()
+                .map(code -> Integer.toString(code.getCode()))
+                .collect(Collectors.joining(", "));
+    }
+
+    /**
+     * Gets the non-error response codes required to generate this response
      */
     @Override
-    public ImmutableList<Ds3ResponseCode> toResponseCodes(
-            final Ds3Request request) {
-        return removeErrorResponseCodes(request.getDs3ResponseCodes());
+    public ImmutableList<ResponseCode> toResponseCodeList(
+            final ImmutableList<Ds3ResponseCode> ds3ResponseCodes,
+            final String responseName) {
+        return removeErrorResponseCodes(ds3ResponseCodes).stream()
+                .map(rc -> toResponseCode(rc, responseName))
+                .collect(GuavaCollectors.immutableList());
+    }
+
+    /**
+     * Converts a Ds3 Response Code into the Response Code model
+     * @param responseName Name of the response handler
+     */
+    protected static ResponseCode toResponseCode(final Ds3ResponseCode ds3ResponseCode, final String responseName) {
+        final ParseResponse parseResponse = toParseResponse(ds3ResponseCode, responseName);
+
+        return new ResponseCode(
+                ds3ResponseCode.getCode(),
+                parseResponse.toJavaCode());
+    }
+
+    /**
+     * Converts a Ds3ResponseCode into a Parse Response model which can be used to
+     * generate the java code for parsing a response payload
+     * @param responseName Name of the response handler
+     */
+    protected static ParseResponse toParseResponse(
+            final Ds3ResponseCode ds3ResponseCode,
+            final String responseName) {
+        if (isEmpty(ds3ResponseCode.getDs3ResponseTypes())) {
+            throw new IllegalArgumentException("Response code does not contain any response types: " + ds3ResponseCode.getCode());
+        }
+        final Ds3ResponseType ds3ResponseType = ds3ResponseCode.getDs3ResponseTypes().get(0);
+        final String responseModelName = stripPath(
+                convertType( //TODO potentially move convertType out of java helper
+                        ds3ResponseType.getType(),
+                        ds3ResponseType.getComponentType()));
+
+        if (responseModelName.equalsIgnoreCase("null")) {
+            return new EmptyParseResponse(responseName);
+        }
+        System.out.println("TEST: " + responseModelName);
+        System.out.printf("TEST: " + responseModelName.equalsIgnoreCase("string"));
+        if (responseModelName.equalsIgnoreCase("string")) {
+            return new StringParseResponse(responseName);
+        }
+        return new BaseParseResponse(responseName, responseModelName);
     }
 
     /**

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responseparser/ResponseParserGeneratorUtil.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responseparser/ResponseParserGeneratorUtil.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3Request;
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3ResponseCode;
+import com.spectralogic.ds3autogen.java.models.ResponseCode;
 
 /**
  * Interface for utility functions used in response parser generators
@@ -43,7 +44,9 @@ public interface ResponseParserGeneratorUtil {
                                       final ImmutableList<Ds3ResponseCode> responseCodes);
 
     /**
-     * Gets the response codes required to generate this response
+     * Converts a list of non-error Ds3ResponseCodes into a list of ResponseCode models
+     * that are used to generate the response parsing code
      */
-    ImmutableList<Ds3ResponseCode> toResponseCodes(final Ds3Request request);
+    ImmutableList<ResponseCode> toResponseCodeList(final ImmutableList<Ds3ResponseCode> ds3ResponseCodes,
+                                                   final String responseName);
 }

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/helpers/JavaHelper.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/helpers/JavaHelper.java
@@ -349,6 +349,7 @@ public final class JavaHelper {
         return isSpectraDs3(packageName) || packageName.contains(Constants.NOTIFICATION_PACKAGE);
     }
 
+    //TODO delete once decoupled from response templates
     /**
      * Creates the Java code associated with processing a given response code
      * @param responseCode A Ds3ResponseCode
@@ -379,6 +380,7 @@ public final class JavaHelper {
         return builder.toString();
     }
 
+    //TODO delete once moved to special cased response parser generator
     /**
      * Creates the Java code associated with processing response codes for
      * requests that have pagination headers. If the specified response code
@@ -474,6 +476,7 @@ public final class JavaHelper {
         return builder.build();
     }
 
+    //TODO move into base response generator when refactor of response handlers to simple POJOs occurs
     /**
      * Creates the parameter name associated with a response type. Component types contain
      * name spacing of "List", and all type names end with "Result"

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/ResponseCode.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/ResponseCode.java
@@ -13,13 +13,25 @@
  * ****************************************************************************
  */
 
-package com.spectralogic.ds3autogen.java.models.withconstructor;
+package com.spectralogic.ds3autogen.java.models;
 
-/**
- * Interface for request handler with-constructor model that can
- * generate the java code from the model data.
- */
-@FunctionalInterface
-public interface WithConstructor {
-    String toJavaCode();
+public class ResponseCode {
+
+    private final int code;
+
+    /** Contains the java code for processing the response with the specified code */
+    private final String processingCode;
+
+    public ResponseCode(final int code, final String processingCode) {
+        this.code = code;
+        this.processingCode = processingCode;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public String getProcessingCode() {
+        return processingCode;
+    }
 }

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/ResponseParser.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/ResponseParser.java
@@ -15,6 +15,7 @@
 
 package com.spectralogic.ds3autogen.java.models;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
 public class ResponseParser {
@@ -23,19 +24,28 @@ public class ResponseParser {
     private final String responseName;
     private final String packageName;
     private final String parentClass;
+
+    /** contains a comma-separated list of all expected status codes */
+    private final String expectedStatusCodes;
+
     private final ImmutableSet<String> imports;
+    private final ImmutableList<ResponseCode> responseCodes;
 
     public ResponseParser(
             final String name,
             final String responseName,
             final String packageName,
             final String parentClass,
-            final ImmutableSet<String> imports) {
+            final String expectedStatusCodes,
+            final ImmutableSet<String> imports,
+            final ImmutableList<ResponseCode> responseCodes) {
         this.name = name;
         this.responseName = responseName;
         this.packageName = packageName;
         this.parentClass = parentClass;
+        this.expectedStatusCodes = expectedStatusCodes;
         this.imports = imports;
+        this.responseCodes = responseCodes;
     }
 
     public String getName() {
@@ -56,5 +66,13 @@ public class ResponseParser {
 
     public String getResponseName() {
         return responseName;
+    }
+
+    public ImmutableList<ResponseCode> getResponseCodes() {
+        return responseCodes;
+    }
+
+    public String getExpectedStatusCodes() {
+        return expectedStatusCodes;
     }
 }

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/parseresponse/BaseParseResponse.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/parseresponse/BaseParseResponse.java
@@ -1,0 +1,42 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.java.models.parseresponse;
+
+import static com.spectralogic.ds3autogen.utils.Helper.indent;
+
+/**
+ * Creates the java code for parsing an xml response
+ */
+public class BaseParseResponse implements ParseResponse {
+
+    private final static int INDENT = 4;
+
+    private final String responseName;
+    private final String responseModelName;
+
+    public BaseParseResponse(final String responseName, final String responseModelName) {
+        this.responseName = responseName;
+        this.responseModelName = responseModelName;
+    }
+
+    @Override
+    public String toJavaCode() {
+        return "try (final InputStream inputStream = new ReadableByteChannelInputStream(blockingByteChannel)) {\n"
+                + indent(INDENT + 1) + "final " + responseModelName + " result = XmlOutput.fromXml(inputStream, " + responseModelName + ".class);\n"
+                + indent(INDENT + 1) + "return new " + responseName + "(result);\n"
+                + indent(INDENT) + "}\n";
+    }
+}

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/parseresponse/EmptyParseResponse.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/parseresponse/EmptyParseResponse.java
@@ -13,13 +13,26 @@
  * ****************************************************************************
  */
 
-package com.spectralogic.ds3autogen.java.models.withconstructor;
+package com.spectralogic.ds3autogen.java.models.parseresponse;
+
+import static com.spectralogic.ds3autogen.utils.Helper.indent;
 
 /**
- * Interface for request handler with-constructor model that can
- * generate the java code from the model data.
+ * Generates the java code for when there is no payload
  */
-@FunctionalInterface
-public interface WithConstructor {
-    String toJavaCode();
+public class EmptyParseResponse implements ParseResponse {
+
+    private final static int INDENT = 4;
+
+    private final String responseName;
+
+    public EmptyParseResponse(final String responseName) {
+        this.responseName = responseName;
+    }
+
+    @Override
+    public String toJavaCode() {
+        return "//There is no payload, return an empty response handler\n"
+                + indent(INDENT) + "return new " + responseName + "();\n";
+    }
 }

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/parseresponse/ParseResponse.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/parseresponse/ParseResponse.java
@@ -13,13 +13,13 @@
  * ****************************************************************************
  */
 
-package com.spectralogic.ds3autogen.java.models.withconstructor;
+package com.spectralogic.ds3autogen.java.models.parseresponse;
 
 /**
- * Interface for request handler with-constructor model that can
- * generate the java code from the model data.
+ * Interface for converting a response code into the java code
+ * required to parse the response. Used in response parser generation.
  */
 @FunctionalInterface
-public interface WithConstructor {
+public interface ParseResponse {
     String toJavaCode();
 }

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/parseresponse/StringParseResponse.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/parseresponse/StringParseResponse.java
@@ -1,0 +1,40 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.java.models.parseresponse;
+
+import static com.spectralogic.ds3autogen.utils.Helper.indent;
+
+/**
+ * Creates the java code for parsing a String response payload
+ */
+public class StringParseResponse implements ParseResponse {
+
+    private final static int INDENT = 4;
+
+    private final String responseName;
+
+    public StringParseResponse(final String responseName) {
+        this.responseName = responseName;
+    }
+
+    @Override
+    public String toJavaCode() {
+        return "try (final InputStream inputStream = new ReadableByteChannelInputStream(blockingByteChannel)) {\n"
+                + indent(INDENT + 1) + "final String result = IOUtils.toString(inputStream, StandardCharsets.UTF_8);\n"
+                + indent(INDENT + 1) + "return new " + responseName + "(result);\n"
+                + indent(INDENT) + "}\n";
+    }
+}

--- a/ds3-autogen-java/src/main/resources/tmpls/responseparser/response_parser_template.ftl
+++ b/ds3-autogen-java/src/main/resources/tmpls/responseparser/response_parser_template.ftl
@@ -5,5 +5,22 @@ package ${packageName};
 <#include "../imports.ftl"/>
 
 public class ${name} extends ${parentClass}<${responseName}> {
-    //TODO implement
+    private final int[] expectedStatusCodes = new int[]{${expectedStatusCodes}};
+
+    @Override
+    public ${responseName} parseXmlResponse(final WebResponse response, final ReadableByteChannel blockingByteChannel) throws IOException {
+        final int statusCode = response.statusCode();
+        if (ResponseParserUtils.validateStatusCode(statusCode, expectedStatusCodes)) {
+            switch (statusCode) {
+            <#list responseCodes as responseCode>
+            case ${responseCode.code}:
+                ${responseCode.processingCode}
+            </#list>
+            default:
+                assert false: "validateStatusCode should have made it impossible to reach this line";
+            }
+        }
+
+        throw ResponseParserUtils.createFailedRequest(response, blockingByteChannel, expectedStatusCodes);
+    }
 }

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaFunctionalTests.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaFunctionalTests.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *
@@ -22,6 +22,7 @@ import com.spectralogic.ds3autogen.api.models.Arguments;
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3ApiSpec;
 import com.spectralogic.ds3autogen.api.models.enums.Operation;
 import com.spectralogic.ds3autogen.docspec.Ds3DocSpecEmptyImpl;
+import com.spectralogic.ds3autogen.java.models.parseresponse.BaseParseResponse;
 import com.spectralogic.ds3autogen.java.utils.TestGeneratedCode;
 import com.spectralogic.ds3autogen.java.utils.TestGeneratedComponentResponseCode;
 import com.spectralogic.ds3autogen.testutil.logging.FileTypeToLog;
@@ -47,7 +48,7 @@ import static org.mockito.Mockito.mock;
 public class JavaFunctionalTests {
 
     private static final Logger LOG = LoggerFactory.getLogger(JavaFunctionalTests.class);
-    private final static GeneratedCodeLogger CODE_LOGGER = new GeneratedCodeLogger(FileTypeToLog.RESPONSE, LOG);
+    private final static GeneratedCodeLogger CODE_LOGGER = new GeneratedCodeLogger(FileTypeToLog.PARSER, LOG);
 
     @Rule
     public TemporaryFolder tempFolder = new TemporaryFolder();
@@ -1900,7 +1901,10 @@ public class JavaFunctionalTests {
         assertTrue(hasImport("java.io.InputStream", responseParserCode));
         assertTrue(hasImport("java.nio.channels.ReadableByteChannel", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.commands.GetServiceResponse", responseParserCode));
-        //TODO test
+
+        final BaseParseResponse expectedParsing = new BaseParseResponse(responseName, "ListAllMyBucketsResult");
+        assertTrue(responseParserCode.contains(expectedParsing.toJavaCode()));
+        assertTrue(responseParserCode.contains("private final int[] expectedStatusCodes = new int[]{200};"));
     }
 
     @Test

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/models/parseresponse/ParseResponse_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/models/parseresponse/ParseResponse_Test.java
@@ -1,0 +1,52 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.java.models.parseresponse;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class ParseResponse_Test {
+
+    @Test
+    public void emptyParserResponse_Test() {
+        final String expected = "//There is no payload, return an empty response handler\n" +
+                "                return new TestResponse();\n";
+        final EmptyParseResponse result = new EmptyParseResponse("TestResponse");
+        assertThat(result.toJavaCode(), is(expected));
+    }
+
+    @Test
+    public void stringParseResponse_Test() {
+        final String expected = "try (final InputStream inputStream = new ReadableByteChannelInputStream(blockingByteChannel)) {\n" +
+                "                    final String result = IOUtils.toString(inputStream, StandardCharsets.UTF_8);\n" +
+                "                    return new TestResponse(result);\n" +
+                "                }\n";
+        final StringParseResponse result = new StringParseResponse("TestResponse");
+        assertThat(result.toJavaCode(), is(expected));
+    }
+
+    @Test
+    public void baseParseResponse_Test() {
+        final String expected = "try (final InputStream inputStream = new ReadableByteChannelInputStream(blockingByteChannel)) {\n" +
+                "                    final TestType result = XmlOutput.fromXml(inputStream, TestType.class);\n" +
+                "                    return new TestResponse(result);\n" +
+                "                }\n";
+        final BaseParseResponse result = new BaseParseResponse("TestResponse", "TestType");
+        assertThat(result.toJavaCode(), is(expected));
+    }
+}

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/utils/ResponseParserGeneratorTestUtil.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/utils/ResponseParserGeneratorTestUtil.java
@@ -1,0 +1,38 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.java.utils;
+
+import com.google.common.collect.ImmutableList;
+import com.spectralogic.ds3autogen.api.models.apispec.Ds3ResponseCode;
+import com.spectralogic.ds3autogen.api.models.apispec.Ds3ResponseType;
+
+/**
+ * Contains Ds3ResponseCode fixtures designed to test response parser generation
+ */
+public final class ResponseParserGeneratorTestUtil {
+
+    public static Ds3ResponseCode getNullResponseCode() {
+        return new Ds3ResponseCode(200, ImmutableList.of(new Ds3ResponseType("null", null)));
+    }
+
+    public static Ds3ResponseCode getStringResponseCode() {
+        return new Ds3ResponseCode(201, ImmutableList.of(new Ds3ResponseType("java.lang.String", null)));
+    }
+
+    public static Ds3ResponseCode getBaseResponseCode() {
+        return new Ds3ResponseCode(202, ImmutableList.of(new Ds3ResponseType("com.test.Type", null)));
+    }
+}


### PR DESCRIPTION
**Changes**

- Copied parsing logic from response generator to response parser generator
- Refactored parsing logic to use new ResponseCode model instead of contract Ds3ResponseCode within template
- Refactored parsing logic from java helper to utility files and ResponeParserGenerator to clean up template files

**Future Changes**
- Special case response parsers
- Update response handlers to simple POJOs