### PR TITLE
Special cased head bucket response parser in java module

### DIFF
--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/JavaCodeGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/JavaCodeGenerator.java
@@ -30,6 +30,7 @@ import com.spectralogic.ds3autogen.java.generators.responsemodels.BulkResponseGe
 import com.spectralogic.ds3autogen.java.generators.responsemodels.CodesResponseGenerator;
 import com.spectralogic.ds3autogen.java.generators.responsemodels.ResponseModelGenerator;
 import com.spectralogic.ds3autogen.java.generators.responseparser.BaseResponseParserGenerator;
+import com.spectralogic.ds3autogen.java.generators.responseparser.HeadBucketParserGenerator;
 import com.spectralogic.ds3autogen.java.generators.responseparser.ResponseParserGenerator;
 import com.spectralogic.ds3autogen.java.generators.typemodels.*;
 import com.spectralogic.ds3autogen.java.helpers.JavaHelper;
@@ -309,6 +310,9 @@ public class JavaCodeGenerator implements CodeGenerator {
      */
     protected static ResponseParserGenerator<?> getResponseParserGenerator(final Ds3Request ds3Request) {
         //TODO special case as necessary
+        if (isHeadBucketRequest(ds3Request)) {
+            return new HeadBucketParserGenerator();
+        }
         return new BaseResponseParserGenerator();
     }
 

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responsemodels/CodesResponseGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responsemodels/CodesResponseGenerator.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableList;
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3Request;
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3ResponseCode;
 
+import static com.spectralogic.ds3autogen.java.utils.ResponseAndParserUtils.getResponseCodes;
 import static com.spectralogic.ds3autogen.java.utils.ResponseAndParserUtils.removeErrorResponseCodes;
 import static com.spectralogic.ds3autogen.utils.ConverterUtil.isEmpty;
 import static com.spectralogic.ds3autogen.utils.Ds3RequestClassificationUtil.isAllocateJobChunkRequest;
@@ -90,19 +91,5 @@ public class CodesResponseGenerator extends BaseResponseGenerator {
             }
         }
         return true;
-    }
-
-    /**
-     * Gets a list of response codes from within a list of Ds3ResponseCodes
-     */
-    protected static ImmutableList<Integer> getResponseCodes(final ImmutableList<Ds3ResponseCode> responseCodes) {
-        if (isEmpty(responseCodes)) {
-            return ImmutableList.of();
-        }
-        final ImmutableList.Builder<Integer> builder = ImmutableList.builder();
-        for (final Ds3ResponseCode responseCode : responseCodes) {
-            builder.add(responseCode.getCode());
-        }
-        return builder.build();
     }
 }

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responseparser/HeadBucketParserGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responseparser/HeadBucketParserGenerator.java
@@ -1,0 +1,57 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.java.generators.responseparser;
+
+import com.google.common.collect.ImmutableList;
+import com.spectralogic.ds3autogen.api.models.apispec.Ds3ResponseCode;
+import com.spectralogic.ds3autogen.java.models.ResponseCode;
+
+import static com.spectralogic.ds3autogen.java.utils.ResponseAndParserUtils.getResponseCodes;
+
+/**
+ * Response parser generator for Head Bucket command
+ */
+public class HeadBucketParserGenerator extends BaseResponseParserGenerator {
+
+    protected static final ImmutableList<Integer> EXPECTED_RESPONSE_CODES = ImmutableList.of(200, 403, 404);
+
+    /**
+     * Gets the non-error response codes required to generate this response
+     */
+    @Override
+    public ImmutableList<ResponseCode> toResponseCodeList(
+            final ImmutableList<Ds3ResponseCode> ds3ResponseCodes,
+            final String responseName) {
+        //Verify that the expected status codes are present
+        final ImmutableList<Integer> codes = getResponseCodes(ds3ResponseCodes);
+        if (!codes.containsAll(EXPECTED_RESPONSE_CODES)) {
+            throw new IllegalArgumentException("Does not contain expected response codes: " + EXPECTED_RESPONSE_CODES.toString());
+        }
+
+        final ResponseCode code200 = new ResponseCode(200, toReturnCode(responseName, "EXISTS"));
+        final ResponseCode code403 = new ResponseCode(403, toReturnCode(responseName, "NOTAUTHORIZED"));
+        final ResponseCode code404 = new ResponseCode(404, toReturnCode(responseName, "DOESNTEXIST"));
+
+        return ImmutableList.of(code200, code403, code404);
+    }
+
+    /**
+     * Gets the java code for returning the response handler with the specified status
+     */
+    protected static String toReturnCode(final String responseName, final String status) {
+        return "return new " + responseName + "(Status." + status + ");\n";
+    }
+}

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/utils/ResponseAndParserUtils.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/utils/ResponseAndParserUtils.java
@@ -87,4 +87,16 @@ public final class ResponseAndParserUtils {
                 .filter(rc -> rc.getCode() < 400)
                 .collect(GuavaCollectors.immutableList());
     }
+
+    /**
+     * Gets the list of response codes from within a list of Ds3ResponseCodes
+     */
+    public static ImmutableList<Integer> getResponseCodes(final ImmutableList<Ds3ResponseCode> responseCodes) {
+        if (isEmpty(responseCodes)) {
+            return ImmutableList.of();
+        }
+        return responseCodes.stream()
+                .map(Ds3ResponseCode::getCode)
+                .collect(GuavaCollectors.immutableList());
+    }
 }

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaCodeGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaCodeGenerator_Test.java
@@ -17,6 +17,7 @@ package com.spectralogic.ds3autogen.java;
 
 import com.spectralogic.ds3autogen.java.generators.requestmodels.*;
 import com.spectralogic.ds3autogen.java.generators.responseparser.BaseResponseParserGenerator;
+import com.spectralogic.ds3autogen.java.generators.responseparser.HeadBucketParserGenerator;
 import org.junit.Test;
 
 import static com.spectralogic.ds3autogen.java.JavaCodeGenerator.getResponseParserGenerator;
@@ -30,6 +31,7 @@ public class JavaCodeGenerator_Test {
     @Test
     public void getResponseParserGenerator_Test() {
         assertThat(getResponseParserGenerator(createBucketRequest()), instanceOf(BaseResponseParserGenerator.class));
+        assertThat(getResponseParserGenerator(getHeadBucketRequest()), instanceOf(HeadBucketParserGenerator.class));
     }
 
     @Test

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaFunctionalTests.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaFunctionalTests.java
@@ -1744,7 +1744,20 @@ public class JavaFunctionalTests {
         //Test the response parser
         final String responseParserCode = testGeneratedCode.getResponseParserGeneratedCode();
         CODE_LOGGER.logFile(responseParserCode, FileTypeToLog.PARSER);
-        //TODO test
+
+        assertTrue(isOfPackage("com.spectralogic.ds3client.commands.parsers", responseParserCode));
+
+        assertTrue(hasImport("com.spectralogic.ds3client.commands.parsers.interfaces.AbstractResponseParser", responseParserCode));
+        assertTrue(hasImport("com.spectralogic.ds3client.networking.WebResponse", responseParserCode));
+        assertTrue(hasImport("java.io.IOException", responseParserCode));
+        assertTrue(hasImport("java.nio.channels.ReadableByteChannel", responseParserCode));
+        assertTrue(hasImport("com.spectralogic.ds3client.commands." + responseName, responseParserCode));
+        assertTrue(hasImport("com.spectralogic.ds3client.commands.parsers.utils.ResponseParserUtils", responseParserCode));
+
+        assertTrue(responseParserCode.contains("return new HeadBucketResponse(Status.EXISTS);"));
+        assertTrue(responseParserCode.contains("return new HeadBucketResponse(Status.NOTAUTHORIZED);"));
+        assertTrue(responseParserCode.contains("return new HeadBucketResponse(Status.DOESNTEXIST);"));
+        assertTrue(responseParserCode.contains("private final int[] expectedStatusCodes = new int[]{200, 403, 404};"));
     }
 
     @Test

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responsemodels/CodesResponseGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responsemodels/CodesResponseGenerator_Test.java
@@ -21,8 +21,8 @@ import com.spectralogic.ds3autogen.api.models.apispec.Ds3ResponseCode;
 import com.spectralogic.ds3autogen.api.models.enums.*;
 import org.junit.Test;
 
-import static com.spectralogic.ds3autogen.java.generators.responsemodels.CodesResponseGenerator.getResponseCodes;
 import static com.spectralogic.ds3autogen.java.generators.responsemodels.CodesResponseGenerator.hasExpectedResponseCodes;
+import static com.spectralogic.ds3autogen.java.test.helpers.Ds3ResponseCodeFixtureTestHelper.getTestResponseCodes;
 import static com.spectralogic.ds3autogen.testutil.Ds3ModelFixtures.getRequestMultiFileDelete;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertFalse;
@@ -32,40 +32,6 @@ import static org.junit.Assert.assertTrue;
 public class CodesResponseGenerator_Test {
 
     private final static CodesResponseGenerator generator = new CodesResponseGenerator();
-
-    private static ImmutableList<Ds3ResponseCode> getTestResponseCodes() {
-        return ImmutableList.of(
-                new Ds3ResponseCode(200, null),
-                new Ds3ResponseCode(206, null),
-                new Ds3ResponseCode(307, null),
-                new Ds3ResponseCode(400, null),
-                new Ds3ResponseCode(404, null));
-    }
-
-    @Test
-    public void getResponseCodes_NullList_Test() {
-        final ImmutableList<Integer> result = getResponseCodes(null);
-        assertThat(result.size(), is(0));
-    }
-
-    @Test
-    public void getResponseCodes_EmptyList_Test() {
-        final ImmutableList<Integer> result = getResponseCodes(ImmutableList.of());
-        assertThat(result.size(), is(0));
-    }
-
-    @Test
-    public void getResponseCodes_FullList_Test() {
-        final ImmutableList<Ds3ResponseCode> responseCodes = getTestResponseCodes();
-
-        final ImmutableList<Integer> result = getResponseCodes(responseCodes);
-        assertThat(result.size(), is(5));
-        assertTrue(result.contains(200));
-        assertTrue(result.contains(206));
-        assertTrue(result.contains(307));
-        assertTrue(result.contains(400));
-        assertTrue(result.contains(404));
-    }
 
     @Test
     public void hasExpectedResponseCodes_NullList_Test() {

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responseparser/HeadBucketParserGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responseparser/HeadBucketParserGenerator_Test.java
@@ -1,0 +1,63 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.java.generators.responseparser;
+
+import com.google.common.collect.ImmutableList;
+import com.spectralogic.ds3autogen.java.models.ResponseCode;
+import org.junit.Test;
+
+import static com.spectralogic.ds3autogen.java.generators.responseparser.HeadBucketParserGenerator.toReturnCode;
+import static com.spectralogic.ds3autogen.testutil.Ds3ModelFixtures.getHeadBucketRequest;
+import static com.spectralogic.ds3autogen.testutil.Ds3ModelFixtures.getRequestDeleteNotification;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class HeadBucketParserGenerator_Test {
+
+    final HeadBucketParserGenerator generator = new HeadBucketParserGenerator();
+
+    @Test
+    public void toReturnCode_Test() {
+        final String expected = "return new MyResponse(Status.MyStatus);\n";
+        assertThat(toReturnCode("MyResponse", "MyStatus"), is(expected));
+    }
+
+    @Test (expected = IllegalArgumentException.class)
+    public void toResponseCodeList_Error_Test() {
+        generator.toResponseCodeList(getRequestDeleteNotification().getDs3ResponseCodes(), "TestResponse");
+    }
+
+    @Test
+    public void toResponseCodeList_Test() {
+        final ImmutableList<ResponseCode> result = generator.toResponseCodeList(
+                getHeadBucketRequest().getDs3ResponseCodes(),
+                "TestResponse");
+
+        assertThat(result.size(), is(3));
+
+        assertThat(result.get(0).getCode(), is(200));
+        assertThat(result.get(0).getProcessingCode(),
+                is("return new TestResponse(Status.EXISTS);\n"));
+
+        assertThat(result.get(1).getCode(), is(403));
+        assertThat(result.get(1).getProcessingCode(),
+                is("return new TestResponse(Status.NOTAUTHORIZED);\n"));
+
+        assertThat(result.get(2).getCode(), is(404));
+        assertThat(result.get(2).getProcessingCode(),
+                is("return new TestResponse(Status.DOESNTEXIST);\n"));
+    }
+}

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/test/helpers/Ds3ResponseCodeFixtureTestHelper.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/test/helpers/Ds3ResponseCodeFixtureTestHelper.java
@@ -53,4 +53,13 @@ public final class Ds3ResponseCodeFixtureTestHelper {
                 ImmutableList.of(
                         new Ds3ResponseType("com.spectralogic.Test.Type" + variation, null)));
     }
+
+    public static ImmutableList<Ds3ResponseCode> getTestResponseCodes() {
+        return ImmutableList.of(
+                new Ds3ResponseCode(200, null),
+                new Ds3ResponseCode(206, null),
+                new Ds3ResponseCode(307, null),
+                new Ds3ResponseCode(400, null),
+                new Ds3ResponseCode(404, null));
+    }
 }

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/utils/ResponseAndParserUtil_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/utils/ResponseAndParserUtil_Test.java
@@ -112,4 +112,29 @@ public class ResponseAndParserUtil_Test {
         assertThat(result.get(1).getCode(), is(206));
         assertThat(result.get(2).getCode(), is(307));
     }
+
+    @Test
+    public void getResponseCodes_NullList_Test() {
+        final ImmutableList<Integer> result = getResponseCodes(null);
+        assertThat(result.size(), is(0));
+    }
+
+    @Test
+    public void getResponseCodes_EmptyList_Test() {
+        final ImmutableList<Integer> result = getResponseCodes(ImmutableList.of());
+        assertThat(result.size(), is(0));
+    }
+
+    @Test
+    public void getResponseCodes_FullList_Test() {
+        final ImmutableList<Ds3ResponseCode> responseCodes = getTestResponseCodes();
+
+        final ImmutableList<Integer> result = getResponseCodes(responseCodes);
+        assertThat(result.size(), is(5));
+        assertTrue(result.contains(200));
+        assertTrue(result.contains(206));
+        assertTrue(result.contains(307));
+        assertTrue(result.contains(400));
+        assertTrue(result.contains(404));
+    }
 }


### PR DESCRIPTION
**Goal**
Separate Response Handlers into Response Handlers (simple POJOs) and Response Parsers in java module

**Changes**
- Special cased Head Bucket response parser
- Moved getResponseCodes from Response Generator into utility
  - Moved associated tests

**Future Changes**
- Special case remaining response parsers
- Change response handlers to simple POJOs
- Special case Head Bucket response handler
  - Add enum Status
  - Add Status parameter

--
**Generated Code**
--

```
/*
 * ******************************************************************************
 *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
 *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 *   this file except in compliance with the License. A copy of the License is located at
 *
 *   http://www.apache.org/licenses/LICENSE-2.0
 *
 *   or in the "license" file accompanying this file.
 *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
 *   specific language governing permissions and limitations under the License.
 * ****************************************************************************
 */

// This code is auto-generated, do not modify
package com.spectralogic.ds3client.commands.parsers;

import com.spectralogic.ds3client.commands.HeadBucketResponse;
import com.spectralogic.ds3client.commands.parsers.interfaces.AbstractResponseParser;
import com.spectralogic.ds3client.commands.parsers.utils.ResponseParserUtils;
import com.spectralogic.ds3client.networking.WebResponse;
import java.io.IOException;
import java.nio.channels.ReadableByteChannel;

public class HeadBucketResponseParser extends AbstractResponseParser<HeadBucketResponse> {
    private final int[] expectedStatusCodes = new int[]{200, 403, 404};

    @Override
    public HeadBucketResponse parseXmlResponse(final WebResponse response, final ReadableByteChannel blockingByteChannel) throws IOException {
        final int statusCode = response.statusCode();
        if (ResponseParserUtils.validateStatusCode(statusCode, expectedStatusCodes)) {
            switch (statusCode) {
            case 200:
                return new HeadBucketResponse(Status.EXISTS);

            case 403:
                return new HeadBucketResponse(Status.NOTAUTHORIZED);

            case 404:
                return new HeadBucketResponse(Status.DOESNTEXIST);

            default:
                assert false: "validateStatusCode should have made it impossible to reach this line";
            }
        }

        throw ResponseParserUtils.createFailedRequest(response, blockingByteChannel, expectedStatusCodes);
    }
}
```