### PR TITLE
Special cased Head Object response parser in java module

### DIFF
--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/JavaCodeGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/JavaCodeGenerator.java
@@ -31,6 +31,7 @@ import com.spectralogic.ds3autogen.java.generators.responsemodels.CodesResponseG
 import com.spectralogic.ds3autogen.java.generators.responsemodels.ResponseModelGenerator;
 import com.spectralogic.ds3autogen.java.generators.responseparser.BaseResponseParserGenerator;
 import com.spectralogic.ds3autogen.java.generators.responseparser.HeadBucketParserGenerator;
+import com.spectralogic.ds3autogen.java.generators.responseparser.HeadObjectParserGenerator;
 import com.spectralogic.ds3autogen.java.generators.responseparser.ResponseParserGenerator;
 import com.spectralogic.ds3autogen.java.generators.typemodels.*;
 import com.spectralogic.ds3autogen.java.helpers.JavaHelper;
@@ -294,6 +295,9 @@ public class JavaCodeGenerator implements CodeGenerator {
         if (isBulkRequest(ds3Request)) {
             return config.getTemplate("responseparser/bulk_response_parser.ftl");
         }
+        if (isHeadObjectRequest(ds3Request)) {
+            return config.getTemplate("responseparser/head_object_response_parser.ftl");
+        }
         return config.getTemplate("responseparser/response_parser_template.ftl");
     }
 
@@ -312,6 +316,9 @@ public class JavaCodeGenerator implements CodeGenerator {
         //TODO special case as necessary
         if (isHeadBucketRequest(ds3Request)) {
             return new HeadBucketParserGenerator();
+        }
+        if (isHeadObjectRequest(ds3Request)) {
+            return new HeadObjectParserGenerator();
         }
         return new BaseResponseParserGenerator();
     }

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responseparser/HeadObjectParserGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responseparser/HeadObjectParserGenerator.java
@@ -1,0 +1,57 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.java.generators.responseparser;
+
+import com.google.common.collect.ImmutableList;
+import com.spectralogic.ds3autogen.api.models.apispec.Ds3ResponseCode;
+import com.spectralogic.ds3autogen.java.models.ResponseCode;
+
+import static com.spectralogic.ds3autogen.java.utils.ResponseAndParserUtils.getResponseCodes;
+
+/**
+ * Response parser generator for Head Object command
+ */
+public class HeadObjectParserGenerator extends BaseResponseParserGenerator {
+
+    protected static final ImmutableList<Integer> EXPECTED_RESPONSE_CODES = ImmutableList.of(200, 404);
+
+    /**
+     * Gets the non-error response codes required to generate this response
+     */
+    @Override
+    public ImmutableList<ResponseCode> toResponseCodeList(
+            final ImmutableList<Ds3ResponseCode> ds3ResponseCodes,
+            final String responseName) {
+        //Verify that the expected status codes are present
+        final ImmutableList<Integer> codes = getResponseCodes(ds3ResponseCodes);
+        if (!codes.containsAll(EXPECTED_RESPONSE_CODES)) {
+            throw new IllegalArgumentException("Does not contain expected response codes: " + EXPECTED_RESPONSE_CODES.toString());
+        }
+
+        final ResponseCode code200 = new ResponseCode(200, toReturnCode(responseName, "EXISTS"));
+        final ResponseCode code404 = new ResponseCode(404, toReturnCode(responseName, "DOESNTEXIST"));
+
+        return ImmutableList.of(code200, code404);
+    }
+
+    /**
+     * Gets the java code for returning the response handler with the specified status,
+     * metadata, and object size
+     */
+    protected static String toReturnCode(final String responseName, final String status) {
+        return "return new " + responseName + "(metadata, objectSize, Status." + status + ");\n";
+    }
+}

--- a/ds3-autogen-java/src/main/resources/tmpls/responseparser/head_object_response_parser.ftl
+++ b/ds3-autogen-java/src/main/resources/tmpls/responseparser/head_object_response_parser.ftl
@@ -1,0 +1,29 @@
+<#include "../copyright.ftl"/>
+
+package ${packageName};
+
+import com.spectralogic.ds3client.commands.interfaces.MetadataImpl;
+<#include "../imports.ftl"/>
+
+public class ${name} extends ${parentClass}<${responseName}> {
+    private final int[] expectedStatusCodes = new int[]{${expectedStatusCodes}};
+
+    @Override
+    public ${responseName} parseXmlResponse(final WebResponse response, final ReadableByteChannel blockingByteChannel) throws IOException {
+        final int statusCode = response.statusCode();
+        if (ResponseParserUtils.validateStatusCode(statusCode, expectedStatusCodes)) {
+            final Metadata metadata = new MetadataImpl(response.getHeaders());
+            final long objectSize = getSizeFromHeaders(response.getHeaders());
+            switch (statusCode) {
+            <#list responseCodes as responseCode>
+            case ${responseCode.code}:
+                ${responseCode.processingCode}
+            </#list>
+            default:
+                assert false: "validateStatusCode should have made it impossible to reach this line";
+            }
+        }
+
+        throw ResponseParserUtils.createFailedRequest(response, blockingByteChannel, expectedStatusCodes);
+    }
+}

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaFunctionalTests.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaFunctionalTests.java
@@ -1822,7 +1822,20 @@ public class JavaFunctionalTests {
         //Test the response parser
         final String responseParserCode = testGeneratedCode.getResponseParserGeneratedCode();
         CODE_LOGGER.logFile(responseParserCode, FileTypeToLog.PARSER);
-        //TODO test
+
+        assertTrue(isOfPackage("com.spectralogic.ds3client.commands.parsers", responseParserCode));
+
+        assertTrue(hasImport("com.spectralogic.ds3client.commands.parsers.interfaces.AbstractResponseParser", responseParserCode));
+        assertTrue(hasImport("com.spectralogic.ds3client.networking.WebResponse", responseParserCode));
+        assertTrue(hasImport("java.io.IOException", responseParserCode));
+        assertTrue(hasImport("java.nio.channels.ReadableByteChannel", responseParserCode));
+        assertTrue(hasImport("com.spectralogic.ds3client.commands." + responseName, responseParserCode));
+        assertTrue(hasImport("com.spectralogic.ds3client.commands.parsers.utils.ResponseParserUtils", responseParserCode));
+        assertTrue(hasImport("com.spectralogic.ds3client.commands.interfaces.MetadataImpl", responseGeneratedCode));
+
+        assertTrue(responseParserCode.contains("return new HeadObjectResponse(metadata, objectSize, Status.EXISTS);"));
+        assertTrue(responseParserCode.contains("return new HeadObjectResponse(metadata, objectSize, Status.DOESNTEXIST);"));
+        assertTrue(responseParserCode.contains("private final int[] expectedStatusCodes = new int[]{200, 404};"));
     }
 
     @Test

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responseparser/HeadObjectParserGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responseparser/HeadObjectParserGenerator_Test.java
@@ -1,0 +1,59 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.java.generators.responseparser;
+
+import com.google.common.collect.ImmutableList;
+import com.spectralogic.ds3autogen.java.models.ResponseCode;
+import org.junit.Test;
+
+import static com.spectralogic.ds3autogen.java.generators.responseparser.HeadObjectParserGenerator.toReturnCode;
+import static com.spectralogic.ds3autogen.testutil.Ds3ModelFixtures.getHeadBucketRequest;
+import static com.spectralogic.ds3autogen.testutil.Ds3ModelFixtures.getRequestDeleteNotification;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class HeadObjectParserGenerator_Test {
+
+    private final HeadObjectParserGenerator generator = new HeadObjectParserGenerator();
+
+    @Test
+    public void toReturnCode_Test() {
+        final String expected = "return new MyResponse(metadata, objectSize, Status.MyStatus);\n";
+        assertThat(toReturnCode("MyResponse", "MyStatus"), is(expected));
+    }
+
+    @Test (expected = IllegalArgumentException.class)
+    public void toResponseCodeList_Error_Test() {
+        generator.toResponseCodeList(getRequestDeleteNotification().getDs3ResponseCodes(), "TestResponse");
+    }
+
+    @Test
+    public void toResponseCodeList_Test() {
+        final ImmutableList<ResponseCode> result = generator.toResponseCodeList(
+                getHeadBucketRequest().getDs3ResponseCodes(),
+                "TestResponse");
+
+        assertThat(result.size(), is(2));
+
+        assertThat(result.get(0).getCode(), is(200));
+        assertThat(result.get(0).getProcessingCode(),
+                is("return new TestResponse(metadata, objectSize, Status.EXISTS);\n"));
+
+        assertThat(result.get(1).getCode(), is(404));
+        assertThat(result.get(1).getProcessingCode(),
+                is("return new TestResponse(metadata, objectSize, Status.DOESNTEXIST);\n"));
+    }
+}


### PR DESCRIPTION
**Goal**
Separate Response Handlers into Response Handlers (simple POJOs) and Response Parsers in java module

**Changes**
Special cased Head Object response parser

**Future Changes**
- Special case remaining response parsers
- Change response handlers to simple POJOs
- Special case Head Object response handler
  - Add enum Status
  - Add parameters: status, metadata, and objectSize

--
Generated Code
--
```
/*
 * ******************************************************************************
 *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
 *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 *   this file except in compliance with the License. A copy of the License is located at
 *
 *   http://www.apache.org/licenses/LICENSE-2.0
 *
 *   or in the "license" file accompanying this file.
 *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
 *   specific language governing permissions and limitations under the License.
 * ****************************************************************************
 */

// This code is auto-generated, do not modify
package com.spectralogic.ds3client.commands.parsers;

import com.spectralogic.ds3client.commands.interfaces.MetadataImpl;
import com.spectralogic.ds3client.commands.HeadObjectResponse;
import com.spectralogic.ds3client.commands.parsers.interfaces.AbstractResponseParser;
import com.spectralogic.ds3client.commands.parsers.utils.ResponseParserUtils;
import com.spectralogic.ds3client.networking.WebResponse;
import java.io.IOException;
import java.nio.channels.ReadableByteChannel;

public class HeadObjectResponseParser extends AbstractResponseParser<HeadObjectResponse> {
    private final int[] expectedStatusCodes = new int[]{200, 404};

    @Override
    public HeadObjectResponse parseXmlResponse(final WebResponse response, final ReadableByteChannel blockingByteChannel) throws IOException {
        final int statusCode = response.statusCode();
        if (ResponseParserUtils.validateStatusCode(statusCode, expectedStatusCodes)) {
            final Metadata metadata = new MetadataImpl(response.getHeaders());
            final long objectSize = getSizeFromHeaders(response.getHeaders());
            switch (statusCode) {
            case 200:
                return new HeadObjectResponse(metadata, objectSize, Status.EXISTS);

            case 404:
                return new HeadObjectResponse(metadata, objectSize, Status.DOESNTEXIST);

            default:
                assert false: "validateStatusCode should have made it impossible to reach this line";
            }
        }

        throw ResponseParserUtils.createFailedRequest(response, blockingByteChannel, expectedStatusCodes);
    }
}
```