### PR TITLE
Special cased Allocate Job Chunk response handler in java module

### DIFF
--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/JavaCodeGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/JavaCodeGenerator.java
@@ -29,6 +29,7 @@ import com.spectralogic.ds3autogen.java.generators.responsemodels.BaseResponseGe
 import com.spectralogic.ds3autogen.java.generators.responsemodels.BulkResponseGenerator;
 import com.spectralogic.ds3autogen.java.generators.responsemodels.CodesResponseGenerator;
 import com.spectralogic.ds3autogen.java.generators.responsemodels.ResponseModelGenerator;
+import com.spectralogic.ds3autogen.java.generators.responseparser.AllocateJobChunkParserGenerator;
 import com.spectralogic.ds3autogen.java.generators.responseparser.BaseResponseParserGenerator;
 import com.spectralogic.ds3autogen.java.generators.responseparser.HeadBucketParserGenerator;
 import com.spectralogic.ds3autogen.java.generators.responseparser.ResponseParserGenerator;
@@ -294,6 +295,9 @@ public class JavaCodeGenerator implements CodeGenerator {
         if (isBulkRequest(ds3Request)) {
             return config.getTemplate("responseparser/bulk_response_parser.ftl");
         }
+        if (isAllocateJobChunkRequest(ds3Request)) {
+            return config.getTemplate("responseparser/allocate_job_chunk_response_parser.ftl");
+        }
         return config.getTemplate("responseparser/response_parser_template.ftl");
     }
 
@@ -312,6 +316,9 @@ public class JavaCodeGenerator implements CodeGenerator {
         //TODO special case as necessary
         if (isHeadBucketRequest(ds3Request)) {
             return new HeadBucketParserGenerator();
+        }
+        if (isAllocateJobChunkRequest(ds3Request)) {
+            return new AllocateJobChunkParserGenerator();
         }
         return new BaseResponseParserGenerator();
     }

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responseparser/AllocateJobChunkParserGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responseparser/AllocateJobChunkParserGenerator.java
@@ -1,0 +1,96 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.java.generators.responseparser;
+
+import com.google.common.collect.ImmutableList;
+import com.spectralogic.ds3autogen.api.models.apispec.Ds3ResponseCode;
+import com.spectralogic.ds3autogen.java.models.ResponseCode;
+
+import java.util.NoSuchElementException;
+
+import static com.spectralogic.ds3autogen.java.utils.ResponseAndParserUtils.getResponseCodes;
+import static com.spectralogic.ds3autogen.utils.ConverterUtil.isEmpty;
+import static com.spectralogic.ds3autogen.utils.Helper.indent;
+
+/**
+ * Response parser generator for Allocate Job Chunk SpectraS3 command
+ */
+public class AllocateJobChunkParserGenerator extends BaseResponseParserGenerator {
+
+    protected static final ImmutableList<Integer> EXPECTED_RESPONSE_CODES = ImmutableList.of(200);
+
+    /**
+     * Gets the non-error response codes required to generate this response
+     */
+    @Override
+    public ImmutableList<ResponseCode> toResponseCodeList(
+            final ImmutableList<Ds3ResponseCode> ds3ResponseCodes,
+            final String responseName) {
+        //Verify that the expected status codes are present
+        final ImmutableList<Integer> codes = getResponseCodes(ds3ResponseCodes);
+        if (!codes.containsAll(EXPECTED_RESPONSE_CODES)) {
+            throw new IllegalArgumentException("Does not contain expected response codes: " + EXPECTED_RESPONSE_CODES.toString());
+        }
+
+        final ResponseCode code200 = new ResponseCode(
+                200,
+                toParsePayloadCode(getDs3ResponseCode(ds3ResponseCodes, 200), responseName));
+
+        // The switch case for 307 should fall through to the 503 handling
+        final ResponseCode code307 = new ResponseCode(307, "");
+
+        final ResponseCode code503 = new ResponseCode(503, toRetryLaterCode(responseName));
+
+        return ImmutableList.of(code200, code307, code503);
+    }
+
+    /**
+     * Creates the java code for parsing the response payload
+     */
+    protected static String toParsePayloadCode(
+            final Ds3ResponseCode ds3ResponseCode,
+            final String responseName) {
+        final String responseModelName = getResponseModelName(ds3ResponseCode.getDs3ResponseTypes().get(0));
+
+        return "try (final InputStream inputStream = new ReadableByteChannelInputStream(blockingByteChannel)) {\n"
+                + indent(5) + "final " + responseModelName + " result = XmlOutput.fromXml(inputStream, " + responseModelName + ".class);\n"
+                + indent(5) + "return new " + responseName + "(result, 0, Status.ALLOCATED);\n"
+                + indent(4) + "}\n";
+    }
+
+    /**
+     * Creates the java code for retry-later response
+     */
+    protected static String toRetryLaterCode(final String responseName) {
+        return "return new " + responseName + "(null, parseRetryAfter(response), Status.RETRYLATER);";
+    }
+
+    /**
+     * Retrieves the fist instance of Ds3ResponseCode with the specified code
+     * @throws NoSuchElementException
+     */
+    protected static Ds3ResponseCode getDs3ResponseCode(
+            final ImmutableList<Ds3ResponseCode> ds3ResponseCodes,
+            final int code) {
+        if (isEmpty(ds3ResponseCodes)) {
+            throw new NoSuchElementException("Ds3ResponseCode list is empty");
+        }
+        return ds3ResponseCodes.stream()
+                .filter(i -> i.getCode() == code)
+                .findFirst()
+                .get();
+    }
+}

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responseparser/BaseResponseParserGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responseparser/BaseResponseParserGenerator.java
@@ -118,10 +118,7 @@ public class BaseResponseParserGenerator implements ResponseParserGenerator<Resp
             throw new IllegalArgumentException("Response code does not contain any response types: " + ds3ResponseCode.getCode());
         }
         final Ds3ResponseType ds3ResponseType = ds3ResponseCode.getDs3ResponseTypes().get(0);
-        final String responseModelName = stripPath(
-                convertType( //TODO potentially move convertType out of java helper
-                        ds3ResponseType.getType(),
-                        ds3ResponseType.getComponentType()));
+        final String responseModelName = getResponseModelName(ds3ResponseType);
 
         if (responseModelName.equalsIgnoreCase("null")) {
             return new EmptyParseResponse(responseName);
@@ -130,6 +127,16 @@ public class BaseResponseParserGenerator implements ResponseParserGenerator<Resp
             return new StringParseResponse(responseName);
         }
         return new BaseParseResponse(responseName, responseModelName);
+    }
+
+    /**
+     * Retrieves the response model name within a Ds3ResponseType
+     */
+    protected static String getResponseModelName(final Ds3ResponseType ds3ResponseType) {
+        return stripPath(
+                convertType( //TODO potentially move convertType out of java helper
+                        ds3ResponseType.getType(),
+                        ds3ResponseType.getComponentType()));
     }
 
     /**

--- a/ds3-autogen-java/src/main/resources/tmpls/responseparser/allocate_job_chunk_response_parser.ftl
+++ b/ds3-autogen-java/src/main/resources/tmpls/responseparser/allocate_job_chunk_response_parser.ftl
@@ -1,0 +1,34 @@
+<#include "../copyright.ftl"/>
+
+package ${packageName};
+
+<#include "../imports.ftl"/>
+
+public class ${name} extends ${parentClass}<${responseName}> {
+    private final int[] expectedStatusCodes = new int[]{${expectedStatusCodes}};
+
+    @Override
+    public ${responseName} parseXmlResponse(final WebResponse response, final ReadableByteChannel blockingByteChannel) throws IOException {
+        final int statusCode = response.statusCode();
+        if (ResponseParserUtils.validateStatusCode(statusCode, expectedStatusCodes)) {
+            switch (statusCode) {
+            <#list responseCodes as responseCode>
+            case ${responseCode.code}:
+                ${responseCode.processingCode}
+            </#list>
+            default:
+                assert false: "validateStatusCode should have made it impossible to reach this line";
+            }
+        }
+
+        throw ResponseParserUtils.createFailedRequest(response, blockingByteChannel, expectedStatusCodes);
+    }
+
+    private static int parseRetryAfter(final WebResponse webResponse) {
+        final String retryAfter = webResponse.getHeaders().get("Retry-After").get(0);
+        if (retryAfter == null) {
+            throw new RetryAfterExpectedException();
+        }
+        return Integer.parseInt(retryAfter);
+    }
+}

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaCodeGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaCodeGenerator_Test.java
@@ -16,6 +16,7 @@
 package com.spectralogic.ds3autogen.java;
 
 import com.spectralogic.ds3autogen.java.generators.requestmodels.*;
+import com.spectralogic.ds3autogen.java.generators.responseparser.AllocateJobChunkParserGenerator;
 import com.spectralogic.ds3autogen.java.generators.responseparser.BaseResponseParserGenerator;
 import com.spectralogic.ds3autogen.java.generators.responseparser.HeadBucketParserGenerator;
 import org.junit.Test;
@@ -32,6 +33,7 @@ public class JavaCodeGenerator_Test {
     public void getResponseParserGenerator_Test() {
         assertThat(getResponseParserGenerator(createBucketRequest()), instanceOf(BaseResponseParserGenerator.class));
         assertThat(getResponseParserGenerator(getHeadBucketRequest()), instanceOf(HeadBucketParserGenerator.class));
+        assertThat(getResponseParserGenerator(getAllocateJobChunkRequest()), instanceOf(AllocateJobChunkParserGenerator.class));
     }
 
     @Test

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaFunctionalTests.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaFunctionalTests.java
@@ -1613,7 +1613,24 @@ public class JavaFunctionalTests {
         //Test the response parser
         final String responseParserCode = testGeneratedCode.getResponseParserGeneratedCode();
         CODE_LOGGER.logFile(responseParserCode, FileTypeToLog.PARSER);
-        //TODO test
+
+        assertTrue(isOfPackage("com.spectralogic.ds3client.commands.parsers", responseParserCode));
+
+        assertTrue(hasImport("com.spectralogic.ds3client.commands.parsers.interfaces.AbstractResponseParser", responseParserCode));
+        assertTrue(hasImport("com.spectralogic.ds3client.networking.WebResponse", responseParserCode));
+        assertTrue(hasImport("java.io.IOException", responseParserCode));
+        assertTrue(hasImport("java.nio.channels.ReadableByteChannel", responseParserCode));
+        assertTrue(hasImport("com.spectralogic.ds3client.commands.spectrads3." + responseName, responseParserCode));
+        assertTrue(hasImport("com.spectralogic.ds3client.commands.parsers.utils.ResponseParserUtils", responseParserCode));
+
+        assertTrue(hasImport("com.spectralogic.ds3client.models.Objects", responseParserCode));
+        assertTrue(hasImport("com.spectralogic.ds3client.serializer.XmlOutput", responseParserCode));
+        assertTrue(hasImport("com.spectralogic.ds3client.utils.ReadableByteChannelInputStream", responseParserCode));
+        assertTrue(hasImport("java.io.InputStream", responseParserCode));
+
+        assertTrue(responseParserCode.contains("return new AllocateJobChunkSpectraS3Response(result, 0, Status.ALLOCATED);"));
+        assertTrue(responseParserCode.contains("return new AllocateJobChunkSpectraS3Response(null, parseRetryAfter(response), Status.RETRYLATER);"));
+        assertTrue(responseParserCode.contains("private final int[] expectedStatusCodes = new int[]{200, 307, 503};"));
     }
 
     @Test

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responseparser/AllocateJobChunkParserGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responseparser/AllocateJobChunkParserGenerator_Test.java
@@ -1,0 +1,98 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.java.generators.responseparser;
+
+import com.google.common.collect.ImmutableList;
+import com.spectralogic.ds3autogen.api.models.apispec.Ds3ResponseCode;
+import com.spectralogic.ds3autogen.api.models.apispec.Ds3ResponseType;
+import com.spectralogic.ds3autogen.java.models.ResponseCode;
+import org.junit.Test;
+
+import java.util.NoSuchElementException;
+
+import static com.spectralogic.ds3autogen.java.generators.responseparser.AllocateJobChunkParserGenerator.getDs3ResponseCode;
+import static com.spectralogic.ds3autogen.java.generators.responseparser.AllocateJobChunkParserGenerator.toParsePayloadCode;
+import static com.spectralogic.ds3autogen.java.generators.responseparser.AllocateJobChunkParserGenerator.toRetryLaterCode;
+import static com.spectralogic.ds3autogen.java.test.helpers.Ds3ResponseCodeFixtureTestHelper.getTestResponseCodes;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class AllocateJobChunkParserGenerator_Test {
+
+    private final static AllocateJobChunkParserGenerator generator = new AllocateJobChunkParserGenerator();
+
+    @Test (expected = NoSuchElementException.class)
+    public void getDs3ResponseCode_NullList_Test() {
+        getDs3ResponseCode(null, 200);
+    }
+
+    @Test (expected = NoSuchElementException.class)
+    public void getDs3ResponseCode_EmptyList_Test() {
+        getDs3ResponseCode(ImmutableList.of(), 200);
+    }
+
+    @Test (expected = NoSuchElementException.class)
+    public void getDs3ResponseCode_NotInList_Test() {
+        getDs3ResponseCode(getTestResponseCodes(), 100);
+    }
+
+    @Test
+    public void getDs3ResponseCode_Test() {
+        final Ds3ResponseCode result = getDs3ResponseCode(getTestResponseCodes(), 200);
+        assertThat(result.getCode(), is(200));
+    }
+
+    @Test
+    public void toRetryLaterCode_Test() {
+        final String expected = "return new MyResponse(null, parseRetryAfter(response), Status.RETRYLATER);";
+        assertThat(toRetryLaterCode("MyResponse"), is(expected));
+    }
+
+    @Test
+    public void toParsePayloadCode_Test() {
+        final String expected = "try (final InputStream inputStream = new ReadableByteChannelInputStream(blockingByteChannel)) {\n" +
+                "                    final JobChunkApiBean result = XmlOutput.fromXml(inputStream, JobChunkApiBean.class);\n" +
+                "                    return new MyResponse(result, 0, Status.ALLOCATED);\n" +
+                "                }\n";
+
+        final Ds3ResponseCode ds3ResponseCode = new Ds3ResponseCode(
+                200,
+                ImmutableList.of(new Ds3ResponseType("com.spectralogic.s3.server.domain.JobChunkApiBean", null)));
+
+        final String result = toParsePayloadCode(ds3ResponseCode, "MyResponse");
+        assertThat(result, is(expected));
+    }
+
+    @Test (expected = IllegalArgumentException.class)
+    public void toResponseCodeList_Error_Test() {
+        generator.toResponseCodeList(ImmutableList.of(), "TestResponse");
+    }
+
+    @Test
+    public void toResponseCodeList_Test() {
+        final ImmutableList responseCodes = ImmutableList.of(
+                new Ds3ResponseCode(
+                        200,
+                        ImmutableList.of(
+                                new Ds3ResponseType("com.spectralogic.s3.server.domain.JobChunkApiBean", null))));
+
+        final ImmutableList<ResponseCode> result = generator.toResponseCodeList(responseCodes, "TestResponse");
+        assertThat(result.size(), is(3));
+        assertThat(result.get(0).getCode(), is(200));
+        assertThat(result.get(1).getCode(), is(307));
+        assertThat(result.get(2).getCode(), is(503));
+    }
+}

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responseparser/BaseResponseParserGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responseparser/BaseResponseParserGenerator_Test.java
@@ -246,4 +246,16 @@ public class BaseResponseParserGenerator_Test {
         final String result = toStatusCodeList(responseCodes);
         assertThat(result, is("201, 202, 203"));
     }
+
+    @Test
+    public void getResponseModelName_SimpleType_Test() {
+        final Ds3ResponseType responseType = new Ds3ResponseType("com.test.MyType", null);
+        assertThat(getResponseModelName(responseType), is("MyType"));
+    }
+
+    @Test
+    public void getResponseModelName_ComponentType_Test() {
+        final Ds3ResponseType responseType = new Ds3ResponseType("array", "com.test.ComponentType");
+        assertThat(getResponseModelName(responseType), is("List<ComponentType>"));
+    }
 }


### PR DESCRIPTION
**Goal**
Separate Response Handlers into Response Handlers (simple POJOs) and Response Parsers in java module

**Changes**
- Special cased Allocate Job Chunks response parser
- Created function getResponseModelName in BaseResponseParserGenerator to reuse code

**Future Changes**
- Special case remaining response parsers
- Change response handlers to simple POJOs
- special case Allocate Job Chunk response handler
  - Add enum status
  - Add parameters: objectsResult, retryAfterSeconds, and status

--
Generated Code
--
```
/*
 * ******************************************************************************
 *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
 *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 *   this file except in compliance with the License. A copy of the License is located at
 *
 *   http://www.apache.org/licenses/LICENSE-2.0
 *
 *   or in the "license" file accompanying this file.
 *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
 *   specific language governing permissions and limitations under the License.
 * ****************************************************************************
 */

// This code is auto-generated, do not modify
package com.spectralogic.ds3client.commands.parsers;

import com.spectralogic.ds3client.commands.parsers.interfaces.AbstractResponseParser;
import com.spectralogic.ds3client.commands.parsers.utils.ResponseParserUtils;
import com.spectralogic.ds3client.commands.spectrads3.AllocateJobChunkSpectraS3Response;
import com.spectralogic.ds3client.models.Objects;
import com.spectralogic.ds3client.networking.WebResponse;
import com.spectralogic.ds3client.serializer.XmlOutput;
import com.spectralogic.ds3client.utils.ReadableByteChannelInputStream;
import java.io.IOException;
import java.io.InputStream;
import java.nio.channels.ReadableByteChannel;

public class AllocateJobChunkSpectraS3ResponseParser extends AbstractResponseParser<AllocateJobChunkSpectraS3Response> {
    private final int[] expectedStatusCodes = new int[]{200, 307, 503};

    @Override
    public AllocateJobChunkSpectraS3Response parseXmlResponse(final WebResponse response, final ReadableByteChannel blockingByteChannel) throws IOException {
        final int statusCode = response.statusCode();
        if (ResponseParserUtils.validateStatusCode(statusCode, expectedStatusCodes)) {
            switch (statusCode) {
            case 200:
                try (final InputStream inputStream = new ReadableByteChannelInputStream(blockingByteChannel)) {
                    final Objects result = XmlOutput.fromXml(inputStream, Objects.class);
                    return new AllocateJobChunkSpectraS3Response(result, 0, Status.ALLOCATED);
                }

            case 307:
                
            case 503:
                return new AllocateJobChunkSpectraS3Response(null, parseRetryAfter(response), Status.RETRYLATER);
            default:
                assert false: "validateStatusCode should have made it impossible to reach this line";
            }
        }

        throw ResponseParserUtils.createFailedRequest(response, blockingByteChannel, expectedStatusCodes);
    }

    private static int parseRetryAfter(final WebResponse webResponse) {
        final String retryAfter = webResponse.getHeaders().get("Retry-After").get(0);
        if (retryAfter == null) {
            throw new RetryAfterExpectedException();
        }
        return Integer.parseInt(retryAfter);
    }
}
```