### PR TITLE
Special cased head object response handler in java module

### DIFF
--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/JavaCodeGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/JavaCodeGenerator.java
@@ -26,6 +26,7 @@ import com.spectralogic.ds3autogen.api.models.docspec.Ds3DocSpec;
 import com.spectralogic.ds3autogen.java.converters.ClientConverter;
 import com.spectralogic.ds3autogen.java.generators.requestmodels.*;
 import com.spectralogic.ds3autogen.java.generators.responsemodels.BaseResponseGenerator;
+import com.spectralogic.ds3autogen.java.generators.responsemodels.HeadObjectResponseGenerator;
 import com.spectralogic.ds3autogen.java.generators.responsemodels.ResponseModelGenerator;
 import com.spectralogic.ds3autogen.java.generators.responseparser.*;
 import com.spectralogic.ds3autogen.java.generators.typemodels.*;
@@ -407,11 +408,13 @@ public class JavaCodeGenerator implements CodeGenerator {
         return modelGenerator.generate(ds3Request, getCommandPackage(ds3Request));
     }
 
-    //TODO add test once request generation refactor is completed
     /**
      * Retrieves the associated response generator for the specified Ds3Request
      */
     protected static ResponseModelGenerator<?> getResponseTemplateModelGenerator(final Ds3Request ds3Request) {
+        if (isHeadObjectRequest(ds3Request)) {
+            return new HeadObjectResponseGenerator();
+        }
         return new BaseResponseGenerator();
     }
 
@@ -423,6 +426,9 @@ public class JavaCodeGenerator implements CodeGenerator {
      * @throws IOException
      */
     private Template getResponseTemplate(final Ds3Request ds3Request) throws IOException {
+        if (isHeadObjectRequest(ds3Request)) {
+            return config.getTemplate("response/head_object_response.ftl");
+        }
         return config.getTemplate("response/response_template.ftl");
     }
 

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responsemodels/BaseResponseGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responsemodels/BaseResponseGenerator.java
@@ -132,7 +132,7 @@ public class BaseResponseGenerator implements ResponseModelGenerator<Response>, 
     @Override
     public ImmutableSet<String> getAllImports(final Ds3Request ds3Request) {
         if (isEmpty(ds3Request.getDs3ResponseCodes())) {
-            return ImmutableSet.of();
+            return ImmutableSet.of(getParentImport(ds3Request));
         }
         final ImmutableList<Ds3ResponseCode> responseCodes = ds3Request.getDs3ResponseCodes().stream()
                 .filter(i -> i.getCode() < 300)

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responsemodels/HeadObjectResponseGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responsemodels/HeadObjectResponseGenerator.java
@@ -1,0 +1,59 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.java.generators.responsemodels;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.spectralogic.ds3autogen.api.models.Arguments;
+import com.spectralogic.ds3autogen.api.models.apispec.Ds3Request;
+import com.spectralogic.ds3autogen.api.models.apispec.Ds3ResponseCode;
+import com.spectralogic.ds3autogen.utils.collections.GuavaCollectors;
+import com.spectralogic.ds3autogen.utils.comparators.CustomArgumentComparator;
+
+/**
+ * Response handler generator for AmazonS3 Head Object command
+ */
+public class HeadObjectResponseGenerator extends BaseResponseGenerator {
+
+    /**
+     * Retrieves the list of parameters needed to create the response POJO
+     * for head object
+     */
+    @Override
+    public ImmutableList<Arguments> toParamList(final ImmutableList<Ds3ResponseCode> ds3ResponseCodes) {
+        final ImmutableList<Arguments> params = ImmutableList.of(
+                new Arguments("Metadata", "Metadata"),
+                new Arguments("long", "ObjectSize"),
+                new Arguments("Status", "Status"));
+
+        return params.stream()
+                .sorted(new CustomArgumentComparator())
+                .collect(GuavaCollectors.immutableList());
+    }
+
+    /**
+     * Retrieves the parent and metadata import
+     */
+    @Override
+    public ImmutableSet<String> getAllImports(final Ds3Request ds3Request) {
+
+        final ImmutableSet.Builder<String> builder = ImmutableSet.builder();
+        builder.add(getParentImport(ds3Request));
+        return ImmutableSet.of(
+                getParentImport(ds3Request),
+                "com.spectralogic.ds3client.networking.Metadata");
+    }
+}

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responsemodels/HeadObjectResponseGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responsemodels/HeadObjectResponseGenerator.java
@@ -49,9 +49,6 @@ public class HeadObjectResponseGenerator extends BaseResponseGenerator {
      */
     @Override
     public ImmutableSet<String> getAllImports(final Ds3Request ds3Request) {
-
-        final ImmutableSet.Builder<String> builder = ImmutableSet.builder();
-        builder.add(getParentImport(ds3Request));
         return ImmutableSet.of(
                 getParentImport(ds3Request),
                 "com.spectralogic.ds3client.networking.Metadata");

--- a/ds3-autogen-java/src/main/resources/tmpls/response/head_object_response.ftl
+++ b/ds3-autogen-java/src/main/resources/tmpls/response/head_object_response.ftl
@@ -1,0 +1,26 @@
+<#include "../copyright.ftl"/>
+
+package ${packageName};
+
+<#include "../imports.ftl"/>
+
+public class ${name} extends ${parentClass} {
+
+    public enum Status { EXISTS, DOESNTEXIST, UNKNOWN }
+
+    <#list params as param>
+    private final ${param.type} ${param.name?uncap_first};
+    </#list>
+
+    public ${name}(${constructorParams}) {
+        <#list params as param>
+        this.${param.name?uncap_first} = this.${param.name?uncap_first};
+        </#list>
+    }
+
+    <#list params as param>
+    public ${param.type} get${param.name?cap_first}() {
+        return this.${param.name?uncap_first};
+    }
+    </#list>
+}

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaCodeGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaCodeGenerator_Test.java
@@ -16,16 +16,25 @@
 package com.spectralogic.ds3autogen.java;
 
 import com.spectralogic.ds3autogen.java.generators.requestmodels.*;
+import com.spectralogic.ds3autogen.java.generators.responsemodels.BaseResponseGenerator;
+import com.spectralogic.ds3autogen.java.generators.responsemodels.HeadObjectResponseGenerator;
 import com.spectralogic.ds3autogen.java.generators.responseparser.*;
 import org.junit.Test;
 
 import static com.spectralogic.ds3autogen.java.JavaCodeGenerator.getResponseParserGenerator;
+import static com.spectralogic.ds3autogen.java.JavaCodeGenerator.getResponseTemplateModelGenerator;
 import static com.spectralogic.ds3autogen.java.JavaCodeGenerator.getTemplateModelGenerator;
 import static com.spectralogic.ds3autogen.testutil.Ds3ModelFixtures.*;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertThat;
 
 public class JavaCodeGenerator_Test {
+
+    @Test
+    public void getResponseTemplateModelGenerator_Test() {
+        assertThat(getResponseTemplateModelGenerator(createBucketRequest()), instanceOf(BaseResponseGenerator.class));
+        assertThat(getResponseTemplateModelGenerator(getHeadObjectRequest()), instanceOf(HeadObjectResponseGenerator.class));
+    }
 
     @Test
     public void getResponseParserGenerator_Test() {

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaFunctionalTests.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaFunctionalTests.java
@@ -53,7 +53,7 @@ import static org.mockito.Mockito.mock;
 public class JavaFunctionalTests {
 
     private static final Logger LOG = LoggerFactory.getLogger(JavaFunctionalTests.class);
-    private final static GeneratedCodeLogger CODE_LOGGER = new GeneratedCodeLogger(FileTypeToLog.PARSER, LOG);
+    private final static GeneratedCodeLogger CODE_LOGGER = new GeneratedCodeLogger(FileTypeToLog.RESPONSE, LOG);
 
     @Rule
     public TemporaryFolder tempFolder = new TemporaryFolder();
@@ -2032,11 +2032,14 @@ public class JavaFunctionalTests {
         assertTrue(extendsClass(responseName, "AbstractResponse", responseGeneratedCode));
         assertTrue(isOfPackage("com.spectralogic.ds3client.commands", responseGeneratedCode));
 
-        assertFalse(hasImport("com.spectralogic.ds3client.commands.AbstractResponse", responseGeneratedCode));
+        assertTrue(hasImport("com.spectralogic.ds3client.commands.interfaces.AbstractResponse", responseGeneratedCode));
+        assertTrue(hasImport("com.spectralogic.ds3client.networking.Metadata", responseGeneratedCode));
 
-        //TODO special case enum
-        //assertTrue(responseGeneratedCode.contains("public enum Status"));
-        //assertTrue(responseGeneratedCode.contains("EXISTS, DOESNTEXIST, UNKNOWN"));
+        assertTrue(isReqParamOfType("metadata", "Metadata", responseName, responseGeneratedCode, false));
+        assertTrue(isReqParamOfType("objectSize", "long", responseName, responseGeneratedCode, false));
+        assertTrue(isReqParamOfType("status", "Status", responseName, responseGeneratedCode, false));
+
+        assertTrue(responseGeneratedCode.contains("public enum Status { EXISTS, DOESNTEXIST, UNKNOWN }"));
 
         //Test the Ds3Client
         final String ds3ClientGeneratedCode = testGeneratedCode.getDs3ClientGeneratedCode();

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responsemodels/BaseResponseGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responsemodels/BaseResponseGenerator_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *
@@ -44,14 +44,16 @@ public class BaseResponseGenerator_Test {
     @Test
     public void getAllImports_NullList_Test() {
         final ImmutableSet<String> result = generator.getAllImports(createEmptyDs3Request());
-        assertThat(result.size(), is(0));
+        assertThat(result.size(), is(1));
+        assertThat(result, hasItem("com.spectralogic.ds3client.commands.interfaces.AbstractResponse"));
     }
 
     @Test
     public void getAllImports_EmptyList_Test() {
         final ImmutableSet<String> result = generator.getAllImports(
                 createDs3RequestTestData(false, ImmutableList.of(), null, null));
-        assertThat(result.size(), is(0));
+        assertThat(result.size(), is(1));
+        assertThat(result, hasItem("com.spectralogic.ds3client.commands.interfaces.AbstractResponse"));
     }
 
     @Test

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responsemodels/HeadObjectResponseGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responsemodels/HeadObjectResponseGenerator_Test.java
@@ -1,0 +1,50 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.java.generators.responsemodels;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.spectralogic.ds3autogen.api.models.Arguments;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class HeadObjectResponseGenerator_Test {
+
+    private static final HeadObjectResponseGenerator generator = new HeadObjectResponseGenerator();
+
+    @Test
+    public void getAllImports_Test() {
+        final ImmutableSet<String> result = generator.getAllImports(null);
+        assertThat(result.size(), is(2));
+        assertThat(result, hasItem("com.spectralogic.ds3client.networking.Metadata"));
+        assertThat(result, hasItem("com.spectralogic.ds3client.commands.interfaces.AbstractResponse"));
+    }
+
+    @Test
+    public void toParamList_Test() {
+        final ImmutableList<Arguments> result = generator.toParamList(null);
+        assertThat(result.size(), is(3));
+        assertThat(result.get(0).getName(), is("Metadata"));
+        assertThat(result.get(0).getType(), is("Metadata"));
+        assertThat(result.get(1).getName(), is("ObjectSize"));
+        assertThat(result.get(1).getType(), is("long"));
+        assertThat(result.get(2).getName(), is("Status"));
+        assertThat(result.get(2).getType(), is("Status"));
+    }
+}


### PR DESCRIPTION
**Changes**
- Special cased Head Object response handler
- Fixed bug in base response generator where parent import was not included if Ds3ResponseCodes was empty/null

**Future Changes**
- Special case additional response handlers as needed
- Code cleanup

--
Generated Code: HeadObjectResponse.java
--
```
/*
 * ******************************************************************************
 *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
 *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 *   this file except in compliance with the License. A copy of the License is located at
 *
 *   http://www.apache.org/licenses/LICENSE-2.0
 *
 *   or in the "license" file accompanying this file.
 *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
 *   specific language governing permissions and limitations under the License.
 * ****************************************************************************
 */

// This code is auto-generated, do not modify
package com.spectralogic.ds3client.commands;

import com.spectralogic.ds3client.commands.interfaces.AbstractResponse;
import com.spectralogic.ds3client.networking.Metadata;

public class HeadObjectResponse extends AbstractResponse {

    public enum Status { EXISTS, DOESNTEXIST, UNKNOWN }

    private final Metadata metadata;
    private final long objectSize;
    private final Status status;

    public HeadObjectResponse(final Metadata metadata, final long objectSize, final Status status) {
        this.metadata = this.metadata;
        this.objectSize = this.objectSize;
        this.status = this.status;
    }

    public Metadata getMetadata() {
        return this.metadata;
    }
    public long getObjectSize() {
        return this.objectSize;
    }
    public Status getStatus() {
        return this.status;
    }
}
```