### PR TITLE
Special cased Head Bucket response handler in java module

### DIFF
--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/JavaCodeGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/JavaCodeGenerator.java
@@ -26,6 +26,7 @@ import com.spectralogic.ds3autogen.api.models.docspec.Ds3DocSpec;
 import com.spectralogic.ds3autogen.java.converters.ClientConverter;
 import com.spectralogic.ds3autogen.java.generators.requestmodels.*;
 import com.spectralogic.ds3autogen.java.generators.responsemodels.BaseResponseGenerator;
+import com.spectralogic.ds3autogen.java.generators.responsemodels.HeadBucketResponseGenerator;
 import com.spectralogic.ds3autogen.java.generators.responsemodels.HeadObjectResponseGenerator;
 import com.spectralogic.ds3autogen.java.generators.responsemodels.ResponseModelGenerator;
 import com.spectralogic.ds3autogen.java.generators.responseparser.*;
@@ -415,6 +416,9 @@ public class JavaCodeGenerator implements CodeGenerator {
         if (isHeadObjectRequest(ds3Request)) {
             return new HeadObjectResponseGenerator();
         }
+        if (isHeadBucketRequest(ds3Request)) {
+            return new HeadBucketResponseGenerator();
+        }
         return new BaseResponseGenerator();
     }
 
@@ -428,6 +432,9 @@ public class JavaCodeGenerator implements CodeGenerator {
     private Template getResponseTemplate(final Ds3Request ds3Request) throws IOException {
         if (isHeadObjectRequest(ds3Request)) {
             return config.getTemplate("response/head_object_response.ftl");
+        }
+        if (isHeadBucketRequest(ds3Request)) {
+            return config.getTemplate("response/head_bucket_response.ftl");
         }
         return config.getTemplate("response/response_template.ftl");
     }

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responsemodels/HeadBucketResponseGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responsemodels/HeadBucketResponseGenerator.java
@@ -1,0 +1,35 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.java.generators.responsemodels;
+
+import com.google.common.collect.ImmutableList;
+import com.spectralogic.ds3autogen.api.models.Arguments;
+import com.spectralogic.ds3autogen.api.models.apispec.Ds3ResponseCode;
+
+/**
+ * Response handler generator for AmazonS3 Head Bucket command
+ */
+public class HeadBucketResponseGenerator extends BaseResponseGenerator {
+
+    /**
+     * Retrieves the Status parameter used in the head bucket response handler
+     */
+    @Override
+    public ImmutableList<Arguments> toParamList(final ImmutableList<Ds3ResponseCode> ds3ResponseCodes) {
+        return ImmutableList.of(
+                new Arguments("Status", "Status"));
+    }
+}

--- a/ds3-autogen-java/src/main/resources/tmpls/response/common/constructor_and_params.ftl
+++ b/ds3-autogen-java/src/main/resources/tmpls/response/common/constructor_and_params.ftl
@@ -1,0 +1,16 @@
+    <#list params as param>
+    private final ${param.type} ${param.name?uncap_first};
+    </#list>
+
+    public ${name}(${constructorParams}) {
+        <#list params as param>
+        this.${param.name?uncap_first} = this.${param.name?uncap_first};
+        </#list>
+    }
+
+    <#list params as param>
+    public ${param.type} get${param.name?cap_first}() {
+        return this.${param.name?uncap_first};
+    }
+
+    </#list>

--- a/ds3-autogen-java/src/main/resources/tmpls/response/head_bucket_response.ftl
+++ b/ds3-autogen-java/src/main/resources/tmpls/response/head_bucket_response.ftl
@@ -5,5 +5,7 @@ package ${packageName};
 <#include "../imports.ftl"/>
 
 public class ${name} extends ${parentClass} {
+
+    public enum Status { EXISTS, DOESNTEXIST, NOTAUTHORIZED, UNKNOWN }
 <#include "common/constructor_and_params.ftl"/>
 }

--- a/ds3-autogen-java/src/main/resources/tmpls/response/head_object_response.ftl
+++ b/ds3-autogen-java/src/main/resources/tmpls/response/head_object_response.ftl
@@ -7,20 +7,5 @@ package ${packageName};
 public class ${name} extends ${parentClass} {
 
     public enum Status { EXISTS, DOESNTEXIST, UNKNOWN }
-
-    <#list params as param>
-    private final ${param.type} ${param.name?uncap_first};
-    </#list>
-
-    public ${name}(${constructorParams}) {
-        <#list params as param>
-        this.${param.name?uncap_first} = this.${param.name?uncap_first};
-        </#list>
-    }
-
-    <#list params as param>
-    public ${param.type} get${param.name?cap_first}() {
-        return this.${param.name?uncap_first};
-    }
-    </#list>
+<#include "common/constructor_and_params.ftl"/>
 }

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaCodeGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaCodeGenerator_Test.java
@@ -17,6 +17,7 @@ package com.spectralogic.ds3autogen.java;
 
 import com.spectralogic.ds3autogen.java.generators.requestmodels.*;
 import com.spectralogic.ds3autogen.java.generators.responsemodels.BaseResponseGenerator;
+import com.spectralogic.ds3autogen.java.generators.responsemodels.HeadBucketResponseGenerator;
 import com.spectralogic.ds3autogen.java.generators.responsemodels.HeadObjectResponseGenerator;
 import com.spectralogic.ds3autogen.java.generators.responseparser.*;
 import org.junit.Test;
@@ -34,6 +35,7 @@ public class JavaCodeGenerator_Test {
     public void getResponseTemplateModelGenerator_Test() {
         assertThat(getResponseTemplateModelGenerator(createBucketRequest()), instanceOf(BaseResponseGenerator.class));
         assertThat(getResponseTemplateModelGenerator(getHeadObjectRequest()), instanceOf(HeadObjectResponseGenerator.class));
+        assertThat(getResponseTemplateModelGenerator(getHeadBucketRequest()), instanceOf(HeadBucketResponseGenerator.class));
     }
 
     @Test

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaFunctionalTests.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaFunctionalTests.java
@@ -1960,9 +1960,9 @@ public class JavaFunctionalTests {
 
         assertFalse(hasImport("com.spectralogic.ds3client.commands.AbstractResponse", responseGeneratedCode));
 
-        //TODO special case enum
-        //assertTrue(responseGeneratedCode.contains("public enum Status"));
-        //assertTrue(responseGeneratedCode.contains("EXISTS, DOESNTEXIST, NOTAUTHORIZED, UNKNOWN"));
+        assertTrue(isReqParamOfType("status", "Status", responseName, responseGeneratedCode, false));
+
+        assertTrue(responseGeneratedCode.contains("public enum Status { EXISTS, DOESNTEXIST, NOTAUTHORIZED, UNKNOWN }"));
 
         //Test the Ds3Client
         final String ds3ClientGeneratedCode = testGeneratedCode.getDs3ClientGeneratedCode();

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responsemodels/HeadBucketResponseGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responsemodels/HeadBucketResponseGenerator_Test.java
@@ -1,0 +1,36 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.java.generators.responsemodels;
+
+import com.google.common.collect.ImmutableList;
+import com.spectralogic.ds3autogen.api.models.Arguments;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class HeadBucketResponseGenerator_Test {
+
+    private static final HeadBucketResponseGenerator generator = new HeadBucketResponseGenerator();
+
+    @Test
+    public void toParamList_Test() {
+        final ImmutableList<Arguments> result = generator.toParamList(null);
+        assertThat(result.size(), is(1));
+        assertThat(result.get(0).getName(), is("Status"));
+        assertThat(result.get(0).getType(), is("Status"));
+    }
+}


### PR DESCRIPTION
**Changes**
- Special cased Head Bucket response handler
- Placed common response template code into separate file for re-use

**Future Changes**
- Special case response handlers as needed
- Update client impl to match new format
- Code cleanup

--
Generated Code: HeadBucketResponse.java
--
```
/*
 * ******************************************************************************
 *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
 *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 *   this file except in compliance with the License. A copy of the License is located at
 *
 *   http://www.apache.org/licenses/LICENSE-2.0
 *
 *   or in the "license" file accompanying this file.
 *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
 *   specific language governing permissions and limitations under the License.
 * ****************************************************************************
 */

// This code is auto-generated, do not modify
package com.spectralogic.ds3client.commands;

import com.spectralogic.ds3client.commands.interfaces.AbstractResponse;

public class HeadBucketResponse extends AbstractResponse {

    public enum Status { EXISTS, DOESNTEXIST, NOTAUTHORIZED, UNKNOWN }
    
    private final Status status;

    public HeadBucketResponse(final Status status) {
        this.status = this.status;
    }

    public Status getStatus() {
        return this.status;
    }

}
```