### PR TITLE
Special cased bulk response handler generation in java module

### DIFF
--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/JavaCodeGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/JavaCodeGenerator.java
@@ -402,14 +402,14 @@ public class JavaCodeGenerator implements CodeGenerator {
      * @return A Response
      */
     private static Response toResponse(final Ds3Request ds3Request) {
-        final ResponseModelGenerator<?> modelGenerator = getResponseTemplateModelGenerator(ds3Request);
+        final ResponseModelGenerator<?> modelGenerator = getResponseGenerator(ds3Request);
         return modelGenerator.generate(ds3Request, getCommandPackage(ds3Request));
     }
 
     /**
      * Retrieves the associated response generator for the specified Ds3Request
      */
-    protected static ResponseModelGenerator<?> getResponseTemplateModelGenerator(final Ds3Request ds3Request) {
+    protected static ResponseModelGenerator<?> getResponseGenerator(final Ds3Request ds3Request) {
         if (isHeadObjectRequest(ds3Request)) {
             return new HeadObjectResponseGenerator();
         }
@@ -419,6 +419,9 @@ public class JavaCodeGenerator implements CodeGenerator {
         if (isAllocateJobChunkRequest(ds3Request)
                 || isGetJobChunksReadyForClientProcessingRequest(ds3Request)) {
             return new RetryAfterResponseGenerator();
+        }
+        if (isBulkRequest(ds3Request)) {
+            return new BulkResponseGenerator();
         }
         return new BaseResponseGenerator();
     }
@@ -442,6 +445,9 @@ public class JavaCodeGenerator implements CodeGenerator {
         }
         if (isGetJobChunksReadyForClientProcessingRequest(ds3Request)) {
             return config.getTemplate("response/chunks_ready_response.ftl");
+        }
+        if (isBulkRequest(ds3Request)) {
+            return config.getTemplate("response/bulk_response.ftl");
         }
         return config.getTemplate("response/response_template.ftl");
     }
@@ -483,14 +489,14 @@ public class JavaCodeGenerator implements CodeGenerator {
      * @return A Request model
      */
     private Request toRequest(final Ds3Request ds3Request, final Ds3DocSpec docSpec) {
-        final RequestModelGenerator<?> modelGenerator = getTemplateModelGenerator(ds3Request);
+        final RequestModelGenerator<?> modelGenerator = getRequestGenerator(ds3Request);
         return modelGenerator.generate(ds3Request, getCommandPackage(ds3Request), docSpec);
     }
 
     /**
      * Retrieves the associated request generator for the specified Ds3Request
      */
-    protected static RequestModelGenerator<?> getTemplateModelGenerator(final Ds3Request ds3Request) {
+    protected static RequestModelGenerator<?> getRequestGenerator(final Ds3Request ds3Request) {
         if (hasStringRequestPayload(ds3Request)) {
             return new StringRequestPayloadGenerator();
         }

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responsemodels/BaseResponseGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responsemodels/BaseResponseGenerator.java
@@ -47,7 +47,7 @@ public class BaseResponseGenerator implements ResponseModelGenerator<Response>, 
     @Override
     public Response generate(final Ds3Request ds3Request, final String packageName) {
         final String responseName = NormalizingContractNamesUtil.toResponseName(ds3Request.getName());
-        final String parentClass = getParentClass(ds3Request);
+        final String parentClass = getParentClass();
 
         final ImmutableList<Arguments> params = toParamList(ds3Request.getDs3ResponseCodes());
         final ImmutableSet<String> imports = getAllImports(ds3Request);
@@ -116,7 +116,7 @@ public class BaseResponseGenerator implements ResponseModelGenerator<Response>, 
      * is AbstractResponse
      */
     @Override
-    public String getParentImport(final Ds3Request ds3Request) {
+    public String getParentImport() {
         return ABSTRACT_RESPONSE_IMPORT;
     }
 
@@ -124,8 +124,8 @@ public class BaseResponseGenerator implements ResponseModelGenerator<Response>, 
      * Returns the parent class that the response extends
      */
     @Override
-    public String getParentClass(final Ds3Request ds3Request) {
-        return removePath(getParentImport(ds3Request));
+    public String getParentClass() {
+        return removePath(getParentImport());
     }
 
     /**
@@ -135,7 +135,7 @@ public class BaseResponseGenerator implements ResponseModelGenerator<Response>, 
     @Override
     public ImmutableSet<String> getAllImports(final Ds3Request ds3Request) {
         if (isEmpty(ds3Request.getDs3ResponseCodes())) {
-            return ImmutableSet.of(getParentImport(ds3Request));
+            return ImmutableSet.of(getParentImport());
         }
         final ImmutableList<Ds3ResponseCode> responseCodes = ds3Request.getDs3ResponseCodes().stream()
                 .filter(i -> i.getCode() < ERROR_CODE_THRESHOLD)
@@ -143,7 +143,7 @@ public class BaseResponseGenerator implements ResponseModelGenerator<Response>, 
 
         final ImmutableSet.Builder<String> builder = ImmutableSet.builder();
         builder.addAll(getImportListFromResponseCodes(responseCodes));
-        builder.add(getParentImport(ds3Request));
+        builder.add(getParentImport());
         return builder.build();
     }
 

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responsemodels/BulkResponseGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responsemodels/BulkResponseGenerator.java
@@ -1,0 +1,32 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.java.generators.responsemodels;
+
+/**
+ * Response handler generator for SpectraS3 bulk commands
+ */
+public class BulkResponseGenerator extends BaseResponseGenerator {
+
+    private final static String BULK_RESPONSE_IMPORT = "com.spectralogic.ds3client.commands.interfaces.BulkResponse";
+
+    /**
+     * Returns the import for the parent class: Bulk Response
+     */
+    @Override
+    public String getParentImport() {
+        return BULK_RESPONSE_IMPORT;
+    }
+}

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responsemodels/HeadObjectResponseGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responsemodels/HeadObjectResponseGenerator.java
@@ -50,7 +50,7 @@ public class HeadObjectResponseGenerator extends BaseResponseGenerator {
     @Override
     public ImmutableSet<String> getAllImports(final Ds3Request ds3Request) {
         return ImmutableSet.of(
-                getParentImport(ds3Request),
+                getParentImport(),
                 "com.spectralogic.ds3client.networking.Metadata");
     }
 }

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responsemodels/ResponseGeneratorUtil.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responsemodels/ResponseGeneratorUtil.java
@@ -26,12 +26,12 @@ public interface ResponseGeneratorUtil {
     /**
      * Returns the import for the parent class for this response
      */
-    String getParentImport(final Ds3Request ds3Request);
+    String getParentImport();
 
     /**
      * Returns the parent class that the response extends
      */
-    String getParentClass(final Ds3Request ds3Request);
+    String getParentClass();
 
     /**
      * Gets all the imports associated with response types that the response will

--- a/ds3-autogen-java/src/main/resources/tmpls/response/bulk_response.ftl
+++ b/ds3-autogen-java/src/main/resources/tmpls/response/bulk_response.ftl
@@ -1,0 +1,11 @@
+<#include "../copyright.ftl"/>
+
+package ${packageName};
+
+<#include "../imports.ftl"/>
+
+public class ${name} extends ${parentClass} {
+    public ${name}(${constructorParams}) {
+        super(masterObjectListResult);
+    }
+}

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaCodeGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaCodeGenerator_Test.java
@@ -16,16 +16,13 @@
 package com.spectralogic.ds3autogen.java;
 
 import com.spectralogic.ds3autogen.java.generators.requestmodels.*;
-import com.spectralogic.ds3autogen.java.generators.responsemodels.RetryAfterResponseGenerator;
-import com.spectralogic.ds3autogen.java.generators.responsemodels.BaseResponseGenerator;
-import com.spectralogic.ds3autogen.java.generators.responsemodels.HeadBucketResponseGenerator;
-import com.spectralogic.ds3autogen.java.generators.responsemodels.HeadObjectResponseGenerator;
+import com.spectralogic.ds3autogen.java.generators.responsemodels.*;
 import com.spectralogic.ds3autogen.java.generators.responseparser.*;
 import org.junit.Test;
 
 import static com.spectralogic.ds3autogen.java.JavaCodeGenerator.getResponseParserGenerator;
-import static com.spectralogic.ds3autogen.java.JavaCodeGenerator.getResponseTemplateModelGenerator;
-import static com.spectralogic.ds3autogen.java.JavaCodeGenerator.getTemplateModelGenerator;
+import static com.spectralogic.ds3autogen.java.JavaCodeGenerator.getResponseGenerator;
+import static com.spectralogic.ds3autogen.java.JavaCodeGenerator.getRequestGenerator;
 import static com.spectralogic.ds3autogen.testutil.Ds3ModelFixtures.*;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertThat;
@@ -33,11 +30,14 @@ import static org.junit.Assert.assertThat;
 public class JavaCodeGenerator_Test {
 
     @Test
-    public void getResponseTemplateModelGenerator_Test() {
-        assertThat(getResponseTemplateModelGenerator(createBucketRequest()), instanceOf(BaseResponseGenerator.class));
-        assertThat(getResponseTemplateModelGenerator(getHeadObjectRequest()), instanceOf(HeadObjectResponseGenerator.class));
-        assertThat(getResponseTemplateModelGenerator(getHeadBucketRequest()), instanceOf(HeadBucketResponseGenerator.class));
-        assertThat(getResponseTemplateModelGenerator(getAllocateJobChunkRequest()), instanceOf(RetryAfterResponseGenerator.class));
+    public void getResponseGenerator_Test() {
+        assertThat(getResponseGenerator(createBucketRequest()), instanceOf(BaseResponseGenerator.class));
+        assertThat(getResponseGenerator(getHeadObjectRequest()), instanceOf(HeadObjectResponseGenerator.class));
+        assertThat(getResponseGenerator(getHeadBucketRequest()), instanceOf(HeadBucketResponseGenerator.class));
+        assertThat(getResponseGenerator(getAllocateJobChunkRequest()), instanceOf(RetryAfterResponseGenerator.class));
+        assertThat(getResponseGenerator(getJobChunksReadyForClientProcessingRequest()), instanceOf(RetryAfterResponseGenerator.class));
+        assertThat(getResponseGenerator(getRequestBulkGet()), instanceOf(BulkResponseGenerator.class));
+        assertThat(getResponseGenerator(getRequestBulkPut()), instanceOf(BulkResponseGenerator.class));
     }
 
     @Test
@@ -51,20 +51,20 @@ public class JavaCodeGenerator_Test {
     }
 
     @Test
-    public void getTemplateModelGenerator_Test() {
-        assertThat(getTemplateModelGenerator(getGetBlobPersistence()), instanceOf(StringRequestPayloadGenerator.class));
-        assertThat(getTemplateModelGenerator(getRequestBulkPut()), instanceOf(BulkRequestGenerator.class));
-        assertThat(getTemplateModelGenerator(getRequestBulkGet()), instanceOf(BulkRequestGenerator.class));
-        assertThat(getTemplateModelGenerator(getEjectStorageDomainRequest()), instanceOf(ObjectsRequestPayloadGenerator.class));
-        assertThat(getTemplateModelGenerator(getRequestVerifyPhysicalPlacement()), instanceOf(ObjectsRequestPayloadGenerator.class));
-        assertThat(getTemplateModelGenerator(getRequestCreateObject()), instanceOf(CreateObjectRequestGenerator.class));
-        assertThat(getTemplateModelGenerator(getRequestCreateNotification()), instanceOf(CreateNotificationRequestGenerator.class));
-        assertThat(getTemplateModelGenerator(getRequestGetNotification()), instanceOf(NotificationRequestGenerator.class));
-        assertThat(getTemplateModelGenerator(getRequestDeleteNotification()), instanceOf(NotificationRequestGenerator.class));
-        assertThat(getTemplateModelGenerator(getRequestAmazonS3GetObject()), instanceOf(GetObjectRequestGenerator.class));
-        assertThat(getTemplateModelGenerator(getRequestMultiFileDelete()), instanceOf(MultiFileDeleteRequestGenerator.class));
-        assertThat(getTemplateModelGenerator(getCreateMultiPartUploadPart()), instanceOf(StreamRequestPayloadGenerator.class));
-        assertThat(getTemplateModelGenerator(getCompleteMultipartUploadRequest()), instanceOf(CompleteMultipartUploadRequestGenerator.class));
-        assertThat(getTemplateModelGenerator(getBucketRequest()), instanceOf(BaseRequestGenerator.class));
+    public void getRequestGenerator_Test() {
+        assertThat(getRequestGenerator(getGetBlobPersistence()), instanceOf(StringRequestPayloadGenerator.class));
+        assertThat(getRequestGenerator(getRequestBulkPut()), instanceOf(BulkRequestGenerator.class));
+        assertThat(getRequestGenerator(getRequestBulkGet()), instanceOf(BulkRequestGenerator.class));
+        assertThat(getRequestGenerator(getEjectStorageDomainRequest()), instanceOf(ObjectsRequestPayloadGenerator.class));
+        assertThat(getRequestGenerator(getRequestVerifyPhysicalPlacement()), instanceOf(ObjectsRequestPayloadGenerator.class));
+        assertThat(getRequestGenerator(getRequestCreateObject()), instanceOf(CreateObjectRequestGenerator.class));
+        assertThat(getRequestGenerator(getRequestCreateNotification()), instanceOf(CreateNotificationRequestGenerator.class));
+        assertThat(getRequestGenerator(getRequestGetNotification()), instanceOf(NotificationRequestGenerator.class));
+        assertThat(getRequestGenerator(getRequestDeleteNotification()), instanceOf(NotificationRequestGenerator.class));
+        assertThat(getRequestGenerator(getRequestAmazonS3GetObject()), instanceOf(GetObjectRequestGenerator.class));
+        assertThat(getRequestGenerator(getRequestMultiFileDelete()), instanceOf(MultiFileDeleteRequestGenerator.class));
+        assertThat(getRequestGenerator(getCreateMultiPartUploadPart()), instanceOf(StreamRequestPayloadGenerator.class));
+        assertThat(getRequestGenerator(getCompleteMultipartUploadRequest()), instanceOf(CompleteMultipartUploadRequestGenerator.class));
+        assertThat(getRequestGenerator(getBucketRequest()), instanceOf(BaseRequestGenerator.class));
     }
 }

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaFunctionalTests.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaFunctionalTests.java
@@ -455,19 +455,20 @@ public class JavaFunctionalTests {
         final String responseGeneratedCode = testGeneratedCode.getResponseGeneratedCode();
         CODE_LOGGER.logFile(responseGeneratedCode, FileTypeToLog.RESPONSE);
         final String responseName = requestName.replace("Request", "Response");
-        assertTrue(extendsClass(responseName, "AbstractResponse", responseGeneratedCode));
+        assertTrue(extendsClass(responseName, "BulkResponse", responseGeneratedCode));
         assertTrue(isOfPackage("com.spectralogic.ds3client.commands.spectrads3", responseGeneratedCode));
 
-        assertTrue(hasImport("com.spectralogic.ds3client.commands.interfaces.AbstractResponse", responseGeneratedCode));
-        assertTrue(hasImport("com.spectralogic.ds3client.models.JobWithChunksContainerApiBean", responseGeneratedCode));
+        assertTrue(hasImport("com.spectralogic.ds3client.commands.interfaces.BulkResponse", responseGeneratedCode));
 
-        assertTrue(isReqParamOfType("jobWithChunksContainerApiBeanResult", "JobWithChunksContainerApiBean", responseName, responseGeneratedCode, false));
+        final ImmutableList<Arguments> responseConstructorArg = ImmutableList.of(
+                new Arguments("MasterObjectList", "masterObjectListResult"));
+        assertTrue(hasConstructor(responseName, responseConstructorArg, responseGeneratedCode));
 
         //Test the Ds3Client
         final String ds3ClientGeneratedCode = testGeneratedCode.getDs3ClientGeneratedCode();
         CODE_LOGGER.logFile(ds3ClientGeneratedCode, FileTypeToLog.CLIENT);
         testDs3Client(requestName, ds3ClientGeneratedCode);
-        assertTrue(ds3ClientGeneratedCode.contains("@ResponsePayloadModel(\"JobWithChunksContainerApiBean\")"));
+        assertTrue(ds3ClientGeneratedCode.contains("@ResponsePayloadModel(\"MasterObjectList\")"));
         assertTrue(ds3ClientGeneratedCode.contains("@Action(\"MODIFY\")"));
         assertTrue(ds3ClientGeneratedCode.contains("@Resource(\"BUCKET\")"));
 
@@ -529,19 +530,21 @@ public class JavaFunctionalTests {
         final String responseGeneratedCode = testGeneratedCode.getResponseGeneratedCode();
         CODE_LOGGER.logFile(responseGeneratedCode, FileTypeToLog.RESPONSE);
         final String responseName = requestName.replace("Request", "Response");
-        assertTrue(extendsClass(responseName, "AbstractResponse", responseGeneratedCode));
+        assertTrue(extendsClass(responseName, "BulkResponse", responseGeneratedCode));
         assertTrue(isOfPackage("com.spectralogic.ds3client.commands.spectrads3", responseGeneratedCode));
 
-        assertTrue(hasImport("com.spectralogic.ds3client.models.JobWithChunksContainerApiBean", responseGeneratedCode));
-        assertTrue(hasImport("com.spectralogic.ds3client.commands.interfaces.AbstractResponse", responseGeneratedCode));
+        assertTrue(hasImport("com.spectralogic.ds3client.models.MasterObjectList", responseGeneratedCode));
+        assertTrue(hasImport("com.spectralogic.ds3client.commands.interfaces.BulkResponse", responseGeneratedCode));
 
-        assertTrue(isReqParamOfType("jobWithChunksContainerApiBeanResult", "JobWithChunksContainerApiBean", responseName, responseGeneratedCode, false));
+        final ImmutableList<Arguments> responseConstructorArg = ImmutableList.of(
+                new Arguments("MasterObjectList", "masterObjectListResult"));
+        assertTrue(hasConstructor(responseName, responseConstructorArg, responseGeneratedCode));
 
         //Test the Ds3Client
         final String ds3ClientGeneratedCode = testGeneratedCode.getDs3ClientGeneratedCode();
         CODE_LOGGER.logFile(ds3ClientGeneratedCode, FileTypeToLog.CLIENT);
         testDs3Client(requestName, ds3ClientGeneratedCode);
-        assertTrue(ds3ClientGeneratedCode.contains("@ResponsePayloadModel(\"JobWithChunksContainerApiBean\")"));
+        assertTrue(ds3ClientGeneratedCode.contains("@ResponsePayloadModel(\"MasterObjectList\")"));
         assertTrue(ds3ClientGeneratedCode.contains("@Action(\"MODIFY\")"));
         assertTrue(ds3ClientGeneratedCode.contains("@Resource(\"BUCKET\")"));
 

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responsemodels/BaseResponseGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responsemodels/BaseResponseGenerator_Test.java
@@ -74,12 +74,12 @@ public class BaseResponseGenerator_Test {
     @Test
     public void getParentImport_Test() {
         final String expected = "com.spectralogic.ds3client.commands.interfaces.AbstractResponse";
-        assertThat(generator.getParentImport(createEmptyDs3Request()), is(expected));
+        assertThat(generator.getParentImport(), is(expected));
     }
 
     @Test
     public void getParentClass_Test() {
-        assertThat(generator.getParentClass(createEmptyDs3Request()), is("AbstractResponse"));
+        assertThat(generator.getParentClass(), is("AbstractResponse"));
     }
 
     @Test

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responsemodels/BulkResponseGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responsemodels/BulkResponseGenerator_Test.java
@@ -1,0 +1,32 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.java.generators.responsemodels;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class BulkResponseGenerator_Test {
+
+    private static final BulkResponseGenerator generator = new BulkResponseGenerator();
+
+    @Test
+    public void getParentImport_Test() {
+        assertThat(generator.getParentImport(),
+                is("com.spectralogic.ds3client.commands.interfaces.BulkResponse"));
+    }
+}

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/utils/TestHelper.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/utils/TestHelper.java
@@ -288,7 +288,7 @@ public final class TestHelper {
         assertTrue(hasImport("com.spectralogic.ds3client.commands.spectrads3." + responseName, code));
         assertTrue(hasImport("com.spectralogic.ds3client.commands.parsers.utils.ResponseParserUtils", code));
 
-        final BaseParseResponse expectedParsing = new BaseParseResponse(responseName, "JobWithChunksContainerApiBean");
+        final BaseParseResponse expectedParsing = new BaseParseResponse(responseName, "MasterObjectList");
         final String expectedParsingCode = "if (ResponseParserUtils.getSizeFromHeaders(response.headers()) == 0) {\n" +
                 "                    return new " + responseName + "(null);\n" +
                 "                }\n" +

--- a/ds3-autogen-java/src/test/resources/input/createGetJobRequestHandler.xml
+++ b/ds3-autogen-java/src/test/resources/input/createGetJobRequestHandler.xml
@@ -4,6 +4,7 @@
             <RequestHandler Classification="spectrads3" Name="com.spectralogic.s3.server.handler.reqhandler.spectrads3.job.CreateGetJobRequestHandler">
                 <Request Action="MODIFY" HttpVerb="PUT" IncludeIdInPath="true" Operation="START_BULK_GET" Resource="BUCKET" ResourceType="NON_SINGLETON">
                     <OptionalQueryParams>
+                        <Param Name="Aggregating" Type="boolean"/>
                         <Param Name="ChunkClientProcessingOrderGuarantee" Type="com.spectralogic.s3.common.dao.domain.ds3.JobChunkClientProcessingOrderGuarantee"/>
                         <Param Name="Name" Type="java.lang.String"/>
                         <Param Name="Priority" Type="com.spectralogic.s3.common.dao.domain.ds3.BlobStoreTaskPriority"/>
@@ -16,7 +17,7 @@
                     <ResponseCode>
                         <Code>200</Code>
                         <ResponseTypes>
-                            <ResponseType Type="com.spectralogic.s3.server.domain.JobWithChunksContainerApiBean"/>
+                            <ResponseType Type="com.spectralogic.s3.server.domain.JobWithChunksApiBean"/>
                         </ResponseTypes>
                     </ResponseCode>
                     <ResponseCode>
@@ -37,8 +38,14 @@
                             <ResponseType Type="com.spectralogic.s3.server.domain.HttpErrorResultApiBean"/>
                         </ResponseTypes>
                     </ResponseCode>
+                    <ResponseCode>
+                        <Code>500</Code>
+                        <ResponseTypes>
+                            <ResponseType Type="com.spectralogic.s3.server.domain.HttpErrorResultApiBean"/>
+                        </ResponseTypes>
+                    </ResponseCode>
                 </ResponseCodes>
-                <Version>12.F5D855B92D35D52FD4C2EDADAA0FD689</Version>
+                <Version>12.16C01F7FD7B2B3EABC9D36FDAFF5E278</Version>
             </RequestHandler>
         </RequestHandlers>
     </Contract>

--- a/ds3-autogen-java/src/test/resources/input/createPutJobRequestHandler.xml
+++ b/ds3-autogen-java/src/test/resources/input/createPutJobRequestHandler.xml
@@ -4,8 +4,11 @@
             <RequestHandler Classification="spectrads3" Name="com.spectralogic.s3.server.handler.reqhandler.spectrads3.job.CreatePutJobRequestHandler">
                 <Request Action="MODIFY" HttpVerb="PUT" IncludeIdInPath="true" Operation="START_BULK_PUT" Resource="BUCKET" ResourceType="NON_SINGLETON">
                     <OptionalQueryParams>
+                        <Param Name="Aggregating" Type="boolean"/>
+                        <Param Name="Force" Type="void"/>
                         <Param Name="IgnoreNamingConflicts" Type="void"/>
                         <Param Name="MaxUploadSize" Type="long"/>
+                        <Param Name="MinimizeSpanningAcrossMedia" Type="boolean"/>
                         <Param Name="Name" Type="java.lang.String"/>
                         <Param Name="Priority" Type="com.spectralogic.s3.common.dao.domain.ds3.BlobStoreTaskPriority"/>
                     </OptionalQueryParams>
@@ -17,7 +20,7 @@
                     <ResponseCode>
                         <Code>200</Code>
                         <ResponseTypes>
-                            <ResponseType Type="com.spectralogic.s3.server.domain.JobWithChunksContainerApiBean"/>
+                            <ResponseType Type="com.spectralogic.s3.server.domain.JobWithChunksApiBean"/>
                         </ResponseTypes>
                     </ResponseCode>
                     <ResponseCode>
@@ -33,7 +36,7 @@
                         </ResponseTypes>
                     </ResponseCode>
                 </ResponseCodes>
-                <Version>12.6994530E2B4F2E6BD1E68AC5405518C8</Version>
+                <Version>13.D2E87353A1F72FE15767983C5C20B969</Version>
             </RequestHandler>
         </RequestHandlers>
     </Contract>


### PR DESCRIPTION
**Changes**
- Special cased bulk response handler generation
- Updated test input files to BP 3.2.2 for Bulk Put and Bulk Get commands
- Renamed JavaCodeGenerator functions for clarity
  - getResponseTemplateModelGenerator -> getResponseGenerator
  - getTemplateModelGenerator -> getRequestGenerator
- Removed unused parameters in response generator methods
  - getParentClass
  - getParentImport

**Future Changes**
- Special case Get Object response handler generation
- Update ClientImpl generation
- Code cleanup

--
Generated Code: Bulk Get Response handler
--
```
/*
 * ******************************************************************************
 *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
 *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 *   this file except in compliance with the License. A copy of the License is located at
 *
 *   http://www.apache.org/licenses/LICENSE-2.0
 *
 *   or in the "license" file accompanying this file.
 *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
 *   specific language governing permissions and limitations under the License.
 * ****************************************************************************
 */

// This code is auto-generated, do not modify
package com.spectralogic.ds3client.commands.spectrads3;

import com.spectralogic.ds3client.models.MasterObjectList;
import com.spectralogic.ds3client.commands.interfaces.BulkResponse;

public class GetBulkJobSpectraS3Response extends BulkResponse {
    public GetBulkJobSpectraS3Response(final MasterObjectList masterObjectListResult) {
        super(masterObjectListResult);
    }
}
```