### PR TITLE
Special cased Get Object response handler generation in java module

### DIFF
--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/JavaCodeGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/JavaCodeGenerator.java
@@ -423,6 +423,9 @@ public class JavaCodeGenerator implements CodeGenerator {
         if (isBulkRequest(ds3Request)) {
             return new BulkResponseGenerator();
         }
+        if (isGetObjectAmazonS3Request(ds3Request)) {
+            return new GetObjectResponseGenerator();
+        }
         return new BaseResponseGenerator();
     }
 
@@ -448,6 +451,9 @@ public class JavaCodeGenerator implements CodeGenerator {
         }
         if (isBulkRequest(ds3Request)) {
             return config.getTemplate("response/bulk_response.ftl");
+        }
+        if (isGetObjectAmazonS3Request(ds3Request)) {
+            return config.getTemplate("response/get_object_response.ftl");
         }
         return config.getTemplate("response/response_template.ftl");
     }

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responsemodels/BaseResponseGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responsemodels/BaseResponseGenerator.java
@@ -66,7 +66,8 @@ public class BaseResponseGenerator implements ResponseModelGenerator<Response>, 
     /**
      * Converts a list of Arguments into a comma-separated list of parameters
      */
-    protected static String toConstructorParams(final ImmutableList<Arguments> params) {
+    @Override
+    public String toConstructorParams(final ImmutableList<Arguments> params) {
         if (isEmpty(params)) {
             return "";
         }

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responsemodels/GetObjectResponseGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responsemodels/GetObjectResponseGenerator.java
@@ -1,0 +1,73 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.java.generators.responsemodels;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.spectralogic.ds3autogen.api.models.Arguments;
+import com.spectralogic.ds3autogen.api.models.apispec.Ds3Request;
+import com.spectralogic.ds3autogen.api.models.apispec.Ds3ResponseCode;
+import com.spectralogic.ds3autogen.utils.comparators.CustomArgumentComparator;
+
+import java.util.stream.Collectors;
+
+import static com.spectralogic.ds3autogen.utils.ConverterUtil.hasContent;
+import static com.spectralogic.ds3autogen.utils.Helper.uncapFirst;
+
+/**
+ * Response handler generator for AmazonS3 Get Object command
+ */
+public class GetObjectResponseGenerator extends BaseResponseGenerator {
+
+    /**
+     * Retrieves the list of parameters that are not inherited from the parent class
+     */
+    @Override
+    public ImmutableList<Arguments> toParamList(final ImmutableList<Ds3ResponseCode> ds3ResponseCodes) {
+        return ImmutableList.of(
+                new Arguments("Metadata", "Metadata"),
+                new Arguments("long", "ObjectSize"));
+    }
+
+    /**
+     * Converts a list of Arguments into a comma-separated list of parameters
+     */
+    @Override
+    public String toConstructorParams(final ImmutableList<Arguments> params) {
+        final ImmutableList.Builder<Arguments> builder = ImmutableList.builder();
+        if (hasContent(params)) {
+            builder.addAll(params);
+        }
+        builder.add(new Arguments("String", "Checksum"));
+        builder.add(new Arguments("ChecksumType.Type", "ChecksumType"));
+
+        return builder.build().stream()
+                .sorted(new CustomArgumentComparator())
+                .map(i -> "final " + i.getType() + " " + uncapFirst(i.getName()))
+                .collect(Collectors.joining(", "));
+    }
+
+    /**
+     * Gets the imports for: parent class, checksum type, and metadata
+     */
+    @Override
+    public ImmutableSet<String> getAllImports(final Ds3Request ds3Request) {
+        return ImmutableSet.of(
+                getParentImport(),
+                "com.spectralogic.ds3client.models.ChecksumType",
+                "com.spectralogic.ds3client.networking.Metadata");
+    }
+}

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responsemodels/ResponseGeneratorUtil.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responsemodels/ResponseGeneratorUtil.java
@@ -43,4 +43,9 @@ public interface ResponseGeneratorUtil {
      * Retrieves the list of parameters needed to create the response POJO
      */
     ImmutableList<Arguments> toParamList(final ImmutableList<Ds3ResponseCode> ds3ResponseCodes);
+
+    /**
+     * Converts a list of Arguments into a comma-separated list of parameters for the constructor
+     */
+    String toConstructorParams(final ImmutableList<Arguments> params);
 }

--- a/ds3-autogen-java/src/main/resources/tmpls/response/get_object_response.ftl
+++ b/ds3-autogen-java/src/main/resources/tmpls/response/get_object_response.ftl
@@ -1,0 +1,26 @@
+<#include "../copyright.ftl"/>
+
+package ${packageName};
+
+<#include "../imports.ftl"/>
+
+public class ${name} extends ${parentClass} {
+
+    <#list params as param>
+    private final ${param.type} ${param.name?uncap_first};
+    </#list>
+
+    public ${name}(${constructorParams}) {
+        super(checksum, checksumType);
+        <#list params as param>
+        this.${param.name?uncap_first} = this.${param.name?uncap_first};
+        </#list>
+    }
+
+    <#list params as param>
+    public ${param.type} get${param.name?cap_first}() {
+        return this.${param.name?uncap_first};
+    }
+
+    </#list>
+}

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaCodeGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaCodeGenerator_Test.java
@@ -38,6 +38,7 @@ public class JavaCodeGenerator_Test {
         assertThat(getResponseGenerator(getJobChunksReadyForClientProcessingRequest()), instanceOf(RetryAfterResponseGenerator.class));
         assertThat(getResponseGenerator(getRequestBulkGet()), instanceOf(BulkResponseGenerator.class));
         assertThat(getResponseGenerator(getRequestBulkPut()), instanceOf(BulkResponseGenerator.class));
+        assertThat(getResponseGenerator(getRequestAmazonS3GetObject()), instanceOf(GetObjectResponseGenerator.class));
     }
 
     @Test

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaFunctionalTests.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaFunctionalTests.java
@@ -1226,8 +1226,14 @@ public class JavaFunctionalTests {
         assertTrue(extendsClass(responseName, "AbstractResponse", responseGeneratedCode));
         assertTrue(isOfPackage("com.spectralogic.ds3client.commands", responseGeneratedCode));
 
-        //TODO special case response handler
         assertTrue(hasImport("com.spectralogic.ds3client.commands.interfaces.AbstractResponse", responseGeneratedCode));
+        assertTrue(hasImport("com.spectralogic.ds3client.models.ChecksumType", responseGeneratedCode));
+        assertTrue(hasImport("com.spectralogic.ds3client.networking.Metadata", responseGeneratedCode));
+
+        assertTrue(isReqParamOfType("checksum", "String", responseName, responseGeneratedCode, true));
+        assertTrue(isReqParamOfType("checksumType", "ChecksumType.Type", responseName, responseGeneratedCode, true));
+        assertTrue(isReqParamOfType("metadata", "Metadata", responseName, responseGeneratedCode, false));
+        assertTrue(isReqParamOfType("objectSize", "long", responseName, responseGeneratedCode, false));
 
         //Test the Ds3Client
         final String ds3ClientGeneratedCode = testGeneratedCode.getDs3ClientGeneratedCode();

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responsemodels/BaseResponseGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responsemodels/BaseResponseGenerator_Test.java
@@ -25,7 +25,6 @@ import org.junit.Test;
 import java.util.Optional;
 
 import static com.spectralogic.ds3autogen.java.generators.responsemodels.BaseResponseGenerator.createDs3ResponseTypeParamName;
-import static com.spectralogic.ds3autogen.java.generators.responsemodels.BaseResponseGenerator.toConstructorParams;
 import static com.spectralogic.ds3autogen.java.generators.responsemodels.BaseResponseGenerator.toParam;
 import static com.spectralogic.ds3autogen.java.test.helpers.Ds3ResponseCodeFixtureTestHelper.createPopulatedErrorResponseCode;
 import static com.spectralogic.ds3autogen.java.test.helpers.Ds3ResponseCodeFixtureTestHelper.createPopulatedResponseCode;
@@ -33,9 +32,7 @@ import static com.spectralogic.ds3autogen.testutil.Ds3ModelPartialDataFixture.cr
 import static com.spectralogic.ds3autogen.testutil.Ds3ModelPartialDataFixture.createEmptyDs3Request;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class BaseResponseGenerator_Test {
 
@@ -173,13 +170,13 @@ public class BaseResponseGenerator_Test {
 
     @Test
     public void toConstructorParams_NullList_Test() {
-        final String result = toConstructorParams(null);
+        final String result = generator.toConstructorParams(null);
         assertThat(result, is(""));
     }
 
     @Test
     public void toConstructorParams_EmptyList_Test() {
-        final String result = toConstructorParams(ImmutableList.of());
+        final String result = generator.toConstructorParams(ImmutableList.of());
         assertThat(result, is(""));
     }
 
@@ -192,7 +189,7 @@ public class BaseResponseGenerator_Test {
                 new Arguments("TypeTwo", "ArgTwo"),
                 new Arguments("TypeThree", "ArgThree"));
 
-        final String result = toConstructorParams(args);
+        final String result = generator.toConstructorParams(args);
         assertThat(result, is(expected));
     }
 }

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responsemodels/GetObjectResponseGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responsemodels/GetObjectResponseGenerator_Test.java
@@ -1,0 +1,71 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.java.generators.responsemodels;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.spectralogic.ds3autogen.api.models.Arguments;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class GetObjectResponseGenerator_Test {
+
+    private static final GetObjectResponseGenerator generator = new GetObjectResponseGenerator();
+
+    @Test
+    public void getAllImports_Test() {
+        final ImmutableSet<String> result = generator.getAllImports(null);
+        assertThat(result.size(), is(3));
+        assertThat(result, hasItem("com.spectralogic.ds3client.commands.interfaces.AbstractResponse"));
+        assertThat(result, hasItem("com.spectralogic.ds3client.models.ChecksumType"));
+        assertThat(result, hasItem("com.spectralogic.ds3client.networking.Metadata"));
+    }
+
+    @Test
+    public void toConstructorParams_NullList_Test() {
+        final String expected = "final String checksum, final ChecksumType.Type checksumType";
+        assertThat(generator.toConstructorParams(null), is(expected));
+    }
+
+    @Test
+    public void toConstructorParams_EmptyList_Test() {
+        final String expected = "final String checksum, final ChecksumType.Type checksumType";
+        assertThat(generator.toConstructorParams(ImmutableList.of()), is(expected));
+    }
+
+    @Test
+    public void toConstructorParams_FullList_Test() {
+        final String expected = "final String checksum, final ChecksumType.Type checksumType, final Metadata metadata, final long objectSize";
+        final ImmutableList<Arguments> args = ImmutableList.of(
+                new Arguments("Metadata", "Metadata"),
+                new Arguments("long", "ObjectSize"));
+
+        assertThat(generator.toConstructorParams(args), is(expected));
+    }
+
+    @Test
+    public void toParamList_Test() {
+        final ImmutableList<Arguments> result = generator.toParamList(null);
+        assertThat(result.size(), is(2));
+        assertThat(result.get(0).getName(), is("Metadata"));
+        assertThat(result.get(0).getType(), is("Metadata"));
+        assertThat(result.get(1).getName(), is("ObjectSize"));
+        assertThat(result.get(1).getType(), is("long"));
+    }
+}


### PR DESCRIPTION
**Changes**
- Special cased Get Object response handler
- Defined `toConstructorParams` in `ResponseGeneratorUtil` interface so it can be overloaded within response generators

**Future Changes**
- Update ClientImpl generation
- Code cleanup

--
Generated Code: GetObjectResponse.java
--
```
/*
 * ******************************************************************************
 *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
 *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 *   this file except in compliance with the License. A copy of the License is located at
 *
 *   http://www.apache.org/licenses/LICENSE-2.0
 *
 *   or in the "license" file accompanying this file.
 *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
 *   specific language governing permissions and limitations under the License.
 * ****************************************************************************
 */

// This code is auto-generated, do not modify
package com.spectralogic.ds3client.commands;

import com.spectralogic.ds3client.commands.interfaces.AbstractResponse;
import com.spectralogic.ds3client.models.ChecksumType;
import com.spectralogic.ds3client.networking.Metadata;

public class GetObjectResponse extends AbstractResponse {

    private final Metadata metadata;
    private final long objectSize;

    public GetObjectResponse(final String checksum, final ChecksumType.Type checksumType, final Metadata metadata, final long objectSize) {
        super(checksum, checksumType);
        this.metadata = this.metadata;
        this.objectSize = this.objectSize;
    }

    public Metadata getMetadata() {
        return this.metadata;
    }

    public long getObjectSize() {
        return this.objectSize;
    }

}
```