### PR TITLE
Cleaned up java module code

### DIFF
--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responsemodels/BaseResponseGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responsemodels/BaseResponseGenerator.java
@@ -148,7 +148,6 @@ public class BaseResponseGenerator implements ResponseModelGenerator<Response>, 
         return builder.build();
     }
 
-    //TODO make protected once decoupled from JavaHelper.processResponseCodeLines
     /**
      * Creates the parameter name associated with a response type. Component types contain
      * name spacing of "List", and all type names end with "Result"
@@ -157,7 +156,7 @@ public class BaseResponseGenerator implements ResponseModelGenerator<Response>, 
      *   No Component Type:  MyType -> myTypeResult
      *   With Component Type:  MyComponentType -> myComponentTypeListResult
      */
-    public static String createDs3ResponseTypeParamName(final Ds3ResponseType responseType) {
+    protected static String createDs3ResponseTypeParamName(final Ds3ResponseType responseType) {
         if (stripPath(responseType.getType()).equalsIgnoreCase("null")) {
             return "";
         }

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/utils/ResponseAndParserUtils.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/utils/ResponseAndParserUtils.java
@@ -20,10 +20,10 @@ import com.google.common.collect.ImmutableSet;
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3ResponseCode;
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3ResponseType;
 import com.spectralogic.ds3autogen.java.converters.ConvertType;
+import com.spectralogic.ds3autogen.java.models.Element;
 import com.spectralogic.ds3autogen.utils.ConverterUtil;
 import com.spectralogic.ds3autogen.utils.collections.GuavaCollectors;
 
-import static com.spectralogic.ds3autogen.java.helpers.JavaHelper.convertType;
 import java.util.NoSuchElementException;
 
 import static com.spectralogic.ds3autogen.utils.ConverterUtil.hasContent;
@@ -109,7 +109,7 @@ public final class ResponseAndParserUtils {
      */
     public static String getResponseModelName(final Ds3ResponseType ds3ResponseType) {
         return stripPath(
-                convertType( //TODO potentially move convertType out of java helper
+                convertType(
                         ds3ResponseType.getType(),
                         ds3ResponseType.getComponentType()));
     }
@@ -128,5 +128,32 @@ public final class ResponseAndParserUtils {
                 .filter(i -> i.getCode() == code)
                 .findFirst()
                 .get();
+    }
+
+    /**
+     * Creates the Java type from elements, converting component types into a List.
+     */
+    public static String convertType(final Element element) throws IllegalArgumentException {
+        return convertType(element.getType(), element.getComponentType());
+    }
+
+    /**
+     * Creates the Java type from elements, converting component types into a List,
+     * and ChecksumType into ChecksumType.Type
+     */
+    public static String convertType(final String type, final String componentType) throws IllegalArgumentException {
+        if (isEmpty(componentType)) {
+            final String typeNoPath = stripPath(type);
+            switch (typeNoPath.toLowerCase()) {
+                case "checksumtype":
+                    return "ChecksumType.Type";
+                default:
+                    return typeNoPath;
+            }
+        }
+        if (type.equalsIgnoreCase("array")) {
+            return "List<" + stripPath(componentType) + ">";
+        }
+        throw new IllegalArgumentException("Unknown element type: " + type);
     }
 }

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/helpers/JavaHelper_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/helpers/JavaHelper_Test.java
@@ -17,8 +17,6 @@ package com.spectralogic.ds3autogen.java.helpers;
 
 import com.google.common.collect.ImmutableList;
 import com.spectralogic.ds3autogen.api.models.Arguments;
-import com.spectralogic.ds3autogen.api.models.apispec.Ds3ResponseCode;
-import com.spectralogic.ds3autogen.api.models.apispec.Ds3ResponseType;
 import com.spectralogic.ds3autogen.api.models.enums.Operation;
 import com.spectralogic.ds3autogen.java.models.AnnotationInfo;
 import com.spectralogic.ds3autogen.java.models.Element;
@@ -26,60 +24,12 @@ import com.spectralogic.ds3autogen.java.models.EnumConstant;
 import com.spectralogic.ds3autogen.java.models.Variable;
 import org.junit.Test;
 
-import java.util.Arrays;
-import java.util.List;
-
 import static com.spectralogic.ds3autogen.java.helpers.JavaHelper.*;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 public class JavaHelper_Test {
-
-    @Test
-    public void argTypeList_NullList_Test() {
-        final String result = argTypeList(null);
-        assertThat(result, is(""));
-    }
-
-    @Test
-    public void argTypeList_EmptyList_Test() {
-        final String result = argTypeList(ImmutableList.of());
-        assertThat(result, is(""));
-    }
-
-    @Test
-    public void argTypeList_FullList_Test() {
-        final String expectedResult = "Type1, Type2, Type3";
-        final ImmutableList<Arguments> arguments = ImmutableList.of(
-                new Arguments("Type2", "arg2"),
-                new Arguments("Type1", "arg1"),
-                new Arguments("Type3", "arg3"));
-        final String result = argTypeList(arguments);
-        assertThat(result, is(expectedResult));
-    }
-
-    @Test
-    public void argsToList_NullList_Test() {
-        final String result = argsToList(null);
-        assertThat(result, is(""));
-    }
-
-    @Test
-    public void argsToList_EmptyList_Test() {
-        final String result = argsToList(ImmutableList.of());
-        assertThat(result, is(""));
-    }
-
-    @Test
-    public void argsToList_FullList_Test() {
-        final String expectedResult = "arg1, arg2, arg3";
-        final List<Arguments> arguments = Arrays.asList(
-                new Arguments("type1", "Arg1"),
-                new Arguments("type1", "Arg2"),
-                new Arguments("type1", "Arg3"));
-        final String result = argsToList(arguments);
-        assertThat(result, is(expectedResult));
-    }
 
     @Test
     public void getType_Argument_Test() {
@@ -149,29 +99,6 @@ public class JavaHelper_Test {
                 + "    }\n";
 
         final String result = createGetter("BucketName", "String");
-        assertThat(result, is(expectedResult));
-    }
-
-    @Test
-    public void modifiedArgNameList_NullList_Test() {
-        final String result = modifiedArgNameList(null, "Arg1", "Integer.toString(arg1)");
-        assertThat(result, is(""));
-    }
-
-    @Test
-    public void modifiedArgNameList_EmptyList_Test() {
-        final String result = modifiedArgNameList(ImmutableList.of(), "Arg1", "Integer.toString(arg1)");
-        assertThat(result, is(""));
-    }
-
-    @Test
-    public void modifiedArgNameList_FullList_Test() {
-        final String expectedResult = "Integer.toString(arg1), arg2, arg3";
-        final ImmutableList<Arguments> arguments = ImmutableList.of(
-                new Arguments("Type1", "Arg1"),
-                new Arguments("Type2", "Arg2"),
-                new Arguments("Type3", "Arg3"));
-        final String result = modifiedArgNameList(arguments, "Arg1", "Integer.toString(arg1)");
         assertThat(result, is(expectedResult));
     }
 
@@ -333,29 +260,6 @@ public class JavaHelper_Test {
     }
 
     @Test
-    public void convertType_String_Test() {
-        assertThat(convertType("long", null), is("long"));
-        assertThat(convertType("long", ""), is("long"));
-        assertThat(convertType("array", "com.spectralogic.s3.common.dao.domain.tape.Tape"), is("List<Tape>"));
-        assertThat(convertType("com.spectralogic.util.security.ChecksumType", null), is("ChecksumType.Type"));
-    }
-
-    @Test
-    public void convertType_Element_Test() {
-        final Element element = new Element("Length", "long", "");
-        assertThat(convertType(element), is("long"));
-
-        final Element compositeElement = new Element("Tapes", "array", "com.spectralogic.s3.common.dao.domain.tape.Tape");
-        assertThat(convertType(compositeElement), is("List<Tape>"));
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void convertType_Exception_Test() {
-        final Element compositeElement = new Element("Tapes", "map", "com.spectralogic.s3.common.dao.domain.tape.Tape");
-        convertType(compositeElement);
-    }
-
-    @Test
     public void getEnumValues_NullList_Test() {
         final String result = getEnumValues(null, 1);
         assertThat(result, is(""));
@@ -386,103 +290,6 @@ public class JavaHelper_Test {
 
         assertThat(getEnumValues(ImmutableList.of(), 1), is(""));
         assertThat(getEnumValues(null, 1), is(""));
-    }
-
-    @Test
-    public void addEnum_NullList_Test() {
-        final ImmutableList<EnumConstant> result = addEnum(null, "ONE");
-        assertThat(result.size(), is(1));
-        assertThat(result.get(0).getName(), is("ONE"));
-    }
-
-    @Test
-    public void addEnum_EmptyList_Test() {
-        final ImmutableList<EnumConstant> result = addEnum(ImmutableList.of(), "ONE");
-        assertThat(result.size(), is(1));
-        assertThat(result.get(0).getName(), is("ONE"));
-    }
-
-    @Test
-    public void addEnum_FullList_Test() {
-        final ImmutableList<EnumConstant> enumConstants = ImmutableList.of(
-                new EnumConstant("ONE"),
-                new EnumConstant("TWO"),
-                new EnumConstant("THREE"));
-        final ImmutableList<EnumConstant> result = addEnum(enumConstants, "FOUR");
-        assertThat(result.size(), is(4));
-        assertThat(result.get(3).getName(), is("FOUR"));
-    }
-
-    @Test
-    public void isSpectraDs3OrNotification_Test() {
-        assertTrue(isSpectraDs3OrNotification("com.spectralogic.ds3client.commands.spectrads3"));
-        assertFalse(isSpectraDs3OrNotification("com.spectralogic.ds3client.commands"));
-
-        assertTrue(isSpectraDs3OrNotification("com.spectralogic.ds3client.commands.spectrads3.notifications"));
-        assertTrue(isSpectraDs3OrNotification("com.spectralogic.ds3client.commands.notifications"));
-    }
-
-    @Test
-    public void createBulkVariable_Test() {
-        final String baseClassExpected = "";
-        final Arguments baseClassArg = new Arguments("BlobStoreTaskPriority", "Priority");
-        assertThat(createBulkVariable(baseClassArg, true), is(baseClassExpected));
-
-        final String optionalExpected = "private ArgType argName;";
-        final Arguments arg = new Arguments("ArgType", "ArgName");
-        assertThat(createBulkVariable(arg, false), is(optionalExpected));
-
-        final String requiredExpected = "private final ArgType argName;";
-        assertThat(createBulkVariable(arg, true), is(requiredExpected));
-    }
-
-    @Test
-    public void processResponseCodeLines_NullType_Test() {
-        final String expectedResult =
-                "//Do nothing, payload is null\n" +
-                "break;";
-
-        final Ds3ResponseCode responseCode = new Ds3ResponseCode(
-                200,
-                ImmutableList.of(
-                        new Ds3ResponseType("null", null)));
-
-        final String result = processResponseCodeLines(responseCode, 0);
-        assertThat(result, is(expectedResult));
-    }
-
-    @Test
-    public void processResponseCodeLines_StringType_Test() {
-        final String expectedResult =
-                "try (final InputStream content = getResponse().getResponseStream()) {\n" +
-                "    this.stringResult = IOUtils.toString(content, StandardCharsets.UTF_8);\n" +
-                "}\n" +
-                "break;";
-
-        final Ds3ResponseCode responseCode = new Ds3ResponseCode(
-                200,
-                ImmutableList.of(
-                        new Ds3ResponseType("java.lang.String", null)));
-
-        final String result = processResponseCodeLines(responseCode, 0);
-        assertThat(result, is(expectedResult));
-    }
-
-    @Test
-    public void processResponseCodeLines_Test() {
-        final String expectedResult =
-                "try (final InputStream content = getResponse().getResponseStream()) {\n" +
-                "    this.completeMultipartUploadResultApiBeanResult = XmlOutput.fromXml(content, CompleteMultipartUploadResultApiBean.class);\n" +
-                "}\n" +
-                "break;";
-
-        final Ds3ResponseCode responseCode = new Ds3ResponseCode(
-                200,
-                ImmutableList.of(
-                        new Ds3ResponseType("com.spectralogic.s3.server.domain.CompleteMultipartUploadResultApiBean", null)));
-
-        final String result = processResponseCodeLines(responseCode, 0);
-        assertThat(result, is(expectedResult));
     }
 
     @Test
@@ -554,41 +361,5 @@ public class JavaHelper_Test {
     public void createAnnotation_Test() {
         final String expected = "@Annotation(\"Value\")";
         assertThat(createAnnotation("Annotation", "Value"), is(expected));
-    }
-
-    @Test
-    public void processPaginationResponseCodeLines_Test() {
-        final String expectedResult =
-                "this.pagingTruncated = parseIntHeader(\"page-truncated\");\n" +
-                "this.pagingTotalResultCount = parseIntHeader(\"total-result-count\");\n" +
-                "try (final InputStream content = getResponse().getResponseStream()) {\n" +
-                "    this.completeMultipartUploadResultApiBeanResult = XmlOutput.fromXml(content, CompleteMultipartUploadResultApiBean.class);\n" +
-                "}\n" +
-                "break;";
-
-        final Ds3ResponseCode responseCode = new Ds3ResponseCode(
-                200,
-                ImmutableList.of(
-                        new Ds3ResponseType("com.spectralogic.s3.server.domain.CompleteMultipartUploadResultApiBean", null)));
-
-        final String result = processPaginationResponseCodeLines(responseCode, 0);
-        assertThat(result, is(expectedResult));
-    }
-
-    @Test
-    public void processPaginationResponseCodeLines_ErrorCode_Test() {
-        final String expectedResult =
-                "try (final InputStream content = getResponse().getResponseStream()) {\n" +
-                "    this.completeMultipartUploadResultApiBeanResult = XmlOutput.fromXml(content, CompleteMultipartUploadResultApiBean.class);\n" +
-                "}\n" +
-                "break;";
-
-        final Ds3ResponseCode responseCode = new Ds3ResponseCode(
-                300,
-                ImmutableList.of(
-                        new Ds3ResponseType("com.spectralogic.s3.server.domain.CompleteMultipartUploadResultApiBean", null)));
-
-        final String result = processPaginationResponseCodeLines(responseCode, 0);
-        assertThat(result, is(expectedResult));
     }
 }

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/utils/ResponseAndParserUtil_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/utils/ResponseAndParserUtil_Test.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3ResponseCode;
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3ResponseType;
+import com.spectralogic.ds3autogen.java.models.Element;
 import org.junit.Test;
 
 import java.util.NoSuchElementException;
@@ -171,5 +172,28 @@ public class ResponseAndParserUtil_Test {
     public void getDs3ResponseCode_Test() {
         final Ds3ResponseCode result = getDs3ResponseCode(getTestResponseCodes(), 200);
         assertThat(result.getCode(), is(200));
+    }
+
+    @Test
+    public void convertType_String_Test() {
+        assertThat(convertType("long", null), is("long"));
+        assertThat(convertType("long", ""), is("long"));
+        assertThat(convertType("array", "com.spectralogic.s3.common.dao.domain.tape.Tape"), is("List<Tape>"));
+        assertThat(convertType("com.spectralogic.util.security.ChecksumType", null), is("ChecksumType.Type"));
+    }
+
+    @Test
+    public void convertType_Element_Test() {
+        final Element element = new Element("Length", "long", "");
+        assertThat(convertType(element), is("long"));
+
+        final Element compositeElement = new Element("Tapes", "array", "com.spectralogic.s3.common.dao.domain.tape.Tape");
+        assertThat(convertType(compositeElement), is("List<Tape>"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void convertType_Exception_Test() {
+        final Element compositeElement = new Element("Tapes", "map", "com.spectralogic.s3.common.dao.domain.tape.Tape");
+        convertType(compositeElement);
     }
 }


### PR DESCRIPTION
**Changes**
- Deleted all unused `JavaHelper` methods and associated tests
- Moved `convertType` method implementation to `ResponseAndParserUtils` and created wrapper for it in `JavaHelper` to reduce coupling since it is used in both templates and within code generators
