### PR TITLE
Minor bug fixes in java generated code

### DIFF
--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responseparser/AllocateJobChunkParserGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responseparser/AllocateJobChunkParserGenerator.java
@@ -64,7 +64,7 @@ public class AllocateJobChunkParserGenerator extends BaseResponseParserGenerator
 
         return "try (final InputStream inputStream = new ReadableByteChannelInputStream(blockingByteChannel)) {\n"
                 + indent(5) + "final " + responseModelName + " result = XmlOutput.fromXml(inputStream, " + responseModelName + ".class);\n"
-                + indent(5) + "return new " + responseName + "(result, 0, Status.ALLOCATED);\n"
+                + indent(5) + "return new " + responseName + "(result, 0, " + responseName + ".Status.ALLOCATED);\n"
                 + indent(4) + "}\n";
     }
 
@@ -72,6 +72,6 @@ public class AllocateJobChunkParserGenerator extends BaseResponseParserGenerator
      * Creates the java code for retry-later response
      */
     protected static String toRetryLaterCode(final String responseName) {
-        return "return new " + responseName + "(null, parseRetryAfter(response), Status.RETRYLATER);";
+        return "return new " + responseName + "(null, parseRetryAfter(response), " + responseName + ".Status.RETRYLATER);";
     }
 }

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responseparser/GetJobChunksReadyParserGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responseparser/GetJobChunksReadyParserGenerator.java
@@ -61,10 +61,10 @@ public class GetJobChunksReadyParserGenerator extends BaseResponseParserGenerato
         return "try (final InputStream inputStream = new ReadableByteChannelInputStream(blockingByteChannel)) {\n" +
                 indent(5) + "final " + responseModelName + " result = XmlOutput.fromXml(inputStream, " + responseModelName + ".class);\n" +
                 indent(5) + "if (isNullOrEmpty(result.getObjects())) {\n" +
-                indent(6) + "return new " + responseName + "(result, parseRetryAfter(response), Status.RETRYLATER);\n" +
+                indent(6) + "return new " + responseName + "(result, parseRetryAfter(response), " + responseName +".Status.RETRYLATER);\n" +
                 indent(5) + "}\n" +
 
-                indent(5) + "return new " + responseName + "(result, 0, Status.AVAILABLE);\n" +
+                indent(5) + "return new " + responseName + "(result, 0, " + responseName +".Status.AVAILABLE);\n" +
                 indent(4) + "}\n";
     }
 }

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responseparser/HeadBucketParserGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responseparser/HeadBucketParserGenerator.java
@@ -52,6 +52,6 @@ public class HeadBucketParserGenerator extends BaseResponseParserGenerator {
      * Gets the java code for returning the response handler with the specified status
      */
     protected static String toReturnCode(final String responseName, final String status) {
-        return "return new " + responseName + "(Status." + status + ");\n";
+        return "return new " + responseName + "(" + responseName + ".Status." + status + ");\n";
     }
 }

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responseparser/HeadObjectParserGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responseparser/HeadObjectParserGenerator.java
@@ -52,6 +52,6 @@ public class HeadObjectParserGenerator extends BaseResponseParserGenerator {
      * metadata, and object size
      */
     protected static String toReturnCode(final String responseName, final String status) {
-        return "return new " + responseName + "(metadata, objectSize, Status." + status + ");\n";
+        return "return new " + responseName + "(metadata, objectSize, " + responseName + ".Status." + status + ");\n";
     }
 }

--- a/ds3-autogen-java/src/main/resources/tmpls/client/ds3client_impl_template.ftl
+++ b/ds3-autogen-java/src/main/resources/tmpls/client/ds3client_impl_template.ftl
@@ -4,6 +4,7 @@ package ${packageName};
 
 import java.io.IOException;
 import com.spectralogic.ds3client.commands.*;
+import com.spectralogic.ds3client.commands.parsers.*;
 import com.spectralogic.ds3client.commands.spectrads3.*;
 import com.spectralogic.ds3client.commands.spectrads3.notifications.*;
 import com.spectralogic.ds3client.models.JobNode;

--- a/ds3-autogen-java/src/main/resources/tmpls/response/common/constructor_and_params.ftl
+++ b/ds3-autogen-java/src/main/resources/tmpls/response/common/constructor_and_params.ftl
@@ -4,7 +4,7 @@
 
     public ${name}(${constructorParams}) {
         <#list params as param>
-        this.${param.name?uncap_first} = this.${param.name?uncap_first};
+        this.${param.name?uncap_first} = ${param.name?uncap_first};
         </#list>
     }
 

--- a/ds3-autogen-java/src/main/resources/tmpls/response/get_object_response.ftl
+++ b/ds3-autogen-java/src/main/resources/tmpls/response/get_object_response.ftl
@@ -13,7 +13,7 @@ public class ${name} extends ${parentClass} {
     public ${name}(${constructorParams}) {
         super(checksum, checksumType);
         <#list params as param>
-        this.${param.name?uncap_first} = this.${param.name?uncap_first};
+        this.${param.name?uncap_first} = ${param.name?uncap_first};
         </#list>
     }
 

--- a/ds3-autogen-java/src/main/resources/tmpls/responseparser/allocate_job_chunk_parser.ftl
+++ b/ds3-autogen-java/src/main/resources/tmpls/responseparser/allocate_job_chunk_parser.ftl
@@ -9,7 +9,7 @@ public class ${name} extends ${parentClass}<${responseName}> {
 
     @Override
     public ${responseName} parseXmlResponse(final WebResponse response, final ReadableByteChannel blockingByteChannel) throws IOException {
-        final int statusCode = response.statusCode();
+        final int statusCode = response.getStatusCode();
         if (ResponseParserUtils.validateStatusCode(statusCode, expectedStatusCodes)) {
             switch (statusCode) {
             <#list responseCodes as responseCode>

--- a/ds3-autogen-java/src/main/resources/tmpls/responseparser/allocate_job_chunk_parser.ftl
+++ b/ds3-autogen-java/src/main/resources/tmpls/responseparser/allocate_job_chunk_parser.ftl
@@ -2,6 +2,7 @@
 
 package ${packageName};
 
+import com.spectralogic.ds3client.exceptions.RetryAfterExpectedException;
 <#include "../imports.ftl"/>
 
 public class ${name} extends ${parentClass}<${responseName}> {

--- a/ds3-autogen-java/src/main/resources/tmpls/responseparser/bulk_response_parser.ftl
+++ b/ds3-autogen-java/src/main/resources/tmpls/responseparser/bulk_response_parser.ftl
@@ -9,12 +9,12 @@ public class ${name} extends ${parentClass}<${responseName}> {
 
     @Override
     public ${responseName} parseXmlResponse(final WebResponse response, final ReadableByteChannel blockingByteChannel) throws IOException {
-        final int statusCode = response.statusCode();
+        final int statusCode = response.getStatusCode();
         if (ResponseParserUtils.validateStatusCode(statusCode, expectedStatusCodes)) {
             switch (statusCode) {
             <#list responseCodes as responseCode>
             case ${responseCode.code}:
-                if (ResponseParserUtils.getSizeFromHeaders(response.headers()) == 0) {
+                if (ResponseParserUtils.getSizeFromHeaders(response.getHeaders()) == 0) {
                     return new ${responseName}(null);
                 }
                 ${responseCode.processingCode}

--- a/ds3-autogen-java/src/main/resources/tmpls/responseparser/get_job_chunks_ready_parser.ftl
+++ b/ds3-autogen-java/src/main/resources/tmpls/responseparser/get_job_chunks_ready_parser.ftl
@@ -12,7 +12,7 @@ public class ${name} extends ${parentClass}<${responseName}> {
 
     @Override
     public ${responseName} parseXmlResponse(final WebResponse response, final ReadableByteChannel blockingByteChannel) throws IOException {
-        final int statusCode = response.statusCode();
+        final int statusCode = response.getStatusCode();
         if (ResponseParserUtils.validateStatusCode(statusCode, expectedStatusCodes)) {
             switch (statusCode) {
             <#list responseCodes as responseCode>

--- a/ds3-autogen-java/src/main/resources/tmpls/responseparser/head_object_parser.ftl
+++ b/ds3-autogen-java/src/main/resources/tmpls/responseparser/head_object_parser.ftl
@@ -3,14 +3,17 @@
 package ${packageName};
 
 import com.spectralogic.ds3client.commands.interfaces.MetadataImpl;
+import com.spectralogic.ds3client.networking.Metadata;
 <#include "../imports.ftl"/>
+
+import static com.spectralogic.ds3client.commands.parsers.utils.ResponseParserUtils.getSizeFromHeaders;
 
 public class ${name} extends ${parentClass}<${responseName}> {
     private final int[] expectedStatusCodes = new int[]{${expectedStatusCodes}};
 
     @Override
     public ${responseName} parseXmlResponse(final WebResponse response, final ReadableByteChannel blockingByteChannel) throws IOException {
-        final int statusCode = response.statusCode();
+        final int statusCode = response.getStatusCode();
         if (ResponseParserUtils.validateStatusCode(statusCode, expectedStatusCodes)) {
             final Metadata metadata = new MetadataImpl(response.getHeaders());
             final long objectSize = getSizeFromHeaders(response.getHeaders());

--- a/ds3-autogen-java/src/main/resources/tmpls/responseparser/response_parser_template.ftl
+++ b/ds3-autogen-java/src/main/resources/tmpls/responseparser/response_parser_template.ftl
@@ -9,7 +9,7 @@ public class ${name} extends ${parentClass}<${responseName}> {
 
     @Override
     public ${responseName} parseXmlResponse(final WebResponse response, final ReadableByteChannel blockingByteChannel) throws IOException {
-        final int statusCode = response.statusCode();
+        final int statusCode = response.getStatusCode();
         if (ResponseParserUtils.validateStatusCode(statusCode, expectedStatusCodes)) {
             switch (statusCode) {
             <#list responseCodes as responseCode>

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaFunctionalTests.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaFunctionalTests.java
@@ -53,7 +53,7 @@ import static org.mockito.Mockito.mock;
 public class JavaFunctionalTests {
 
     private static final Logger LOG = LoggerFactory.getLogger(JavaFunctionalTests.class);
-    private final static GeneratedCodeLogger CODE_LOGGER = new GeneratedCodeLogger(FileTypeToLog.CLIENT, LOG);
+    private final static GeneratedCodeLogger CODE_LOGGER = new GeneratedCodeLogger(FileTypeToLog.RESPONSE, LOG);
 
     @Rule
     public TemporaryFolder tempFolder = new TemporaryFolder();
@@ -1925,8 +1925,8 @@ public class JavaFunctionalTests {
         assertTrue(hasImport("java.io.InputStream", responseParserCode));
         assertTrue(responseParserCode.contains("import static com.spectralogic.ds3client.utils.Guard.isNullOrEmpty"));
 
-        assertTrue(responseParserCode.contains("return new GetJobChunksReadyForClientProcessingSpectraS3Response(result, parseRetryAfter(response), Status.RETRYLATER);"));
-        assertTrue(responseParserCode.contains("return new GetJobChunksReadyForClientProcessingSpectraS3Response(result, 0, Status.AVAILABLE);"));
+        assertTrue(responseParserCode.contains("return new GetJobChunksReadyForClientProcessingSpectraS3Response(result, parseRetryAfter(response), GetJobChunksReadyForClientProcessingSpectraS3Response.Status.RETRYLATER);"));
+        assertTrue(responseParserCode.contains("return new GetJobChunksReadyForClientProcessingSpectraS3Response(result, 0, GetJobChunksReadyForClientProcessingSpectraS3Response.Status.AVAILABLE);"));
 
         assertTrue(responseParserCode.contains("private final int[] expectedStatusCodes = new int[]{200};"));
     }
@@ -1997,9 +1997,9 @@ public class JavaFunctionalTests {
         assertTrue(hasImport("com.spectralogic.ds3client.commands." + responseName, responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.commands.parsers.utils.ResponseParserUtils", responseParserCode));
 
-        assertTrue(responseParserCode.contains("return new HeadBucketResponse(Status.EXISTS);"));
-        assertTrue(responseParserCode.contains("return new HeadBucketResponse(Status.NOTAUTHORIZED);"));
-        assertTrue(responseParserCode.contains("return new HeadBucketResponse(Status.DOESNTEXIST);"));
+        assertTrue(responseParserCode.contains("return new HeadBucketResponse(HeadBucketResponse.Status.EXISTS);"));
+        assertTrue(responseParserCode.contains("return new HeadBucketResponse(HeadBucketResponse.Status.NOTAUTHORIZED);"));
+        assertTrue(responseParserCode.contains("return new HeadBucketResponse(HeadBucketResponse.Status.DOESNTEXIST);"));
         assertTrue(responseParserCode.contains("private final int[] expectedStatusCodes = new int[]{200, 403, 404};"));
     }
 
@@ -2074,9 +2074,11 @@ public class JavaFunctionalTests {
         assertTrue(hasImport("com.spectralogic.ds3client.commands." + responseName, responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.commands.parsers.utils.ResponseParserUtils", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.commands.interfaces.MetadataImpl", responseParserCode));
+        assertTrue(hasImport("com.spectralogic.ds3client.networking.Metadata", responseParserCode));
+        assertTrue(responseParserCode.contains("import static com.spectralogic.ds3client.commands.parsers.utils.ResponseParserUtils.getSizeFromHeaders;"));
 
-        assertTrue(responseParserCode.contains("return new HeadObjectResponse(metadata, objectSize, Status.EXISTS);"));
-        assertTrue(responseParserCode.contains("return new HeadObjectResponse(metadata, objectSize, Status.DOESNTEXIST);"));
+        assertTrue(responseParserCode.contains("return new HeadObjectResponse(metadata, objectSize, HeadObjectResponse.Status.EXISTS);"));
+        assertTrue(responseParserCode.contains("return new HeadObjectResponse(metadata, objectSize, HeadObjectResponse.Status.DOESNTEXIST);"));
         assertTrue(responseParserCode.contains("private final int[] expectedStatusCodes = new int[]{200, 404};"));
     }
 

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaFunctionalTests.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaFunctionalTests.java
@@ -1838,9 +1838,10 @@ public class JavaFunctionalTests {
         assertTrue(hasImport("com.spectralogic.ds3client.serializer.XmlOutput", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.utils.ReadableByteChannelInputStream", responseParserCode));
         assertTrue(hasImport("java.io.InputStream", responseParserCode));
+        assertTrue(hasImport("com.spectralogic.ds3client.exceptions.RetryAfterExpectedException", responseParserCode));
 
-        assertTrue(responseParserCode.contains("return new AllocateJobChunkSpectraS3Response(result, 0, Status.ALLOCATED);"));
-        assertTrue(responseParserCode.contains("return new AllocateJobChunkSpectraS3Response(null, parseRetryAfter(response), Status.RETRYLATER);"));
+        assertTrue(responseParserCode.contains("return new AllocateJobChunkSpectraS3Response(result, 0, AllocateJobChunkSpectraS3Response.Status.ALLOCATED);"));
+        assertTrue(responseParserCode.contains("return new AllocateJobChunkSpectraS3Response(null, parseRetryAfter(response), AllocateJobChunkSpectraS3Response.Status.RETRYLATER);"));
         assertTrue(responseParserCode.contains("private final int[] expectedStatusCodes = new int[]{200, 307, 503};"));
     }
 

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responseparser/AllocateJobChunkParserGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responseparser/AllocateJobChunkParserGenerator_Test.java
@@ -32,7 +32,7 @@ public class AllocateJobChunkParserGenerator_Test {
 
     @Test
     public void toRetryLaterCode_Test() {
-        final String expected = "return new MyResponse(null, parseRetryAfter(response), Status.RETRYLATER);";
+        final String expected = "return new MyResponse(null, parseRetryAfter(response), MyResponse.Status.RETRYLATER);";
         assertThat(toRetryLaterCode("MyResponse"), is(expected));
     }
 
@@ -40,7 +40,7 @@ public class AllocateJobChunkParserGenerator_Test {
     public void toParsePayloadCode_Test() {
         final String expected = "try (final InputStream inputStream = new ReadableByteChannelInputStream(blockingByteChannel)) {\n" +
                 "                    final JobChunkApiBean result = XmlOutput.fromXml(inputStream, JobChunkApiBean.class);\n" +
-                "                    return new MyResponse(result, 0, Status.ALLOCATED);\n" +
+                "                    return new MyResponse(result, 0, MyResponse.Status.ALLOCATED);\n" +
                 "                }\n";
 
         final Ds3ResponseCode ds3ResponseCode = new Ds3ResponseCode(

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responseparser/GetJobChunksReadyParserGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responseparser/GetJobChunksReadyParserGenerator_Test.java
@@ -36,9 +36,9 @@ public class GetJobChunksReadyParserGenerator_Test {
         final String expected = "try (final InputStream inputStream = new ReadableByteChannelInputStream(blockingByteChannel)) {\n" +
                 "                    final JobWithChunksApiBean result = XmlOutput.fromXml(inputStream, JobWithChunksApiBean.class);\n" +
                 "                    if (isNullOrEmpty(result.getObjects())) {\n" +
-                "                        return new TestResponse(result, parseRetryAfter(response), Status.RETRYLATER);\n" +
+                "                        return new TestResponse(result, parseRetryAfter(response), TestResponse.Status.RETRYLATER);\n" +
                 "                    }\n" +
-                "                    return new TestResponse(result, 0, Status.AVAILABLE);\n" +
+                "                    return new TestResponse(result, 0, TestResponse.Status.AVAILABLE);\n" +
                 "                }\n";
 
         final Ds3ResponseCode ds3ResponseCode = new Ds3ResponseCode(

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responseparser/HeadBucketParserGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responseparser/HeadBucketParserGenerator_Test.java
@@ -31,7 +31,7 @@ public class HeadBucketParserGenerator_Test {
 
     @Test
     public void toReturnCode_Test() {
-        final String expected = "return new MyResponse(Status.MyStatus);\n";
+        final String expected = "return new MyResponse(MyResponse.Status.MyStatus);\n";
         assertThat(toReturnCode("MyResponse", "MyStatus"), is(expected));
     }
 
@@ -50,14 +50,14 @@ public class HeadBucketParserGenerator_Test {
 
         assertThat(result.get(0).getCode(), is(200));
         assertThat(result.get(0).getProcessingCode(),
-                is("return new TestResponse(Status.EXISTS);\n"));
+                is("return new TestResponse(TestResponse.Status.EXISTS);\n"));
 
         assertThat(result.get(1).getCode(), is(403));
         assertThat(result.get(1).getProcessingCode(),
-                is("return new TestResponse(Status.NOTAUTHORIZED);\n"));
+                is("return new TestResponse(TestResponse.Status.NOTAUTHORIZED);\n"));
 
         assertThat(result.get(2).getCode(), is(404));
         assertThat(result.get(2).getProcessingCode(),
-                is("return new TestResponse(Status.DOESNTEXIST);\n"));
+                is("return new TestResponse(TestResponse.Status.DOESNTEXIST);\n"));
     }
 }

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responseparser/HeadObjectParserGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responseparser/HeadObjectParserGenerator_Test.java
@@ -31,7 +31,7 @@ public class HeadObjectParserGenerator_Test {
 
     @Test
     public void toReturnCode_Test() {
-        final String expected = "return new MyResponse(metadata, objectSize, Status.MyStatus);\n";
+        final String expected = "return new MyResponse(metadata, objectSize, MyResponse.Status.MyStatus);\n";
         assertThat(toReturnCode("MyResponse", "MyStatus"), is(expected));
     }
 
@@ -50,10 +50,10 @@ public class HeadObjectParserGenerator_Test {
 
         assertThat(result.get(0).getCode(), is(200));
         assertThat(result.get(0).getProcessingCode(),
-                is("return new TestResponse(metadata, objectSize, Status.EXISTS);\n"));
+                is("return new TestResponse(metadata, objectSize, TestResponse.Status.EXISTS);\n"));
 
         assertThat(result.get(1).getCode(), is(404));
         assertThat(result.get(1).getProcessingCode(),
-                is("return new TestResponse(metadata, objectSize, Status.DOESNTEXIST);\n"));
+                is("return new TestResponse(metadata, objectSize, TestResponse.Status.DOESNTEXIST);\n"));
     }
 }

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/utils/TestHelper.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/utils/TestHelper.java
@@ -289,7 +289,7 @@ public final class TestHelper {
         assertTrue(hasImport("com.spectralogic.ds3client.commands.parsers.utils.ResponseParserUtils", code));
 
         final BaseParseResponse expectedParsing = new BaseParseResponse(responseName, "MasterObjectList");
-        final String expectedParsingCode = "if (ResponseParserUtils.getSizeFromHeaders(response.headers()) == 0) {\n" +
+        final String expectedParsingCode = "if (ResponseParserUtils.getSizeFromHeaders(response.getHeaders()) == 0) {\n" +
                 "                    return new " + responseName + "(null);\n" +
                 "                }\n" +
                 "                " + expectedParsing.toJavaCode();


### PR DESCRIPTION
**Changes**
- Specified response handler in response parsers when referencing a Status enum defined in the response handler: 
  - was `Status.ENUM_STATUS`, now `ResponseHandler.Status.ENUM_STATUS`
- Added import of parsers package in Ds3ClientImpl
- Removed erroneous `this` reference in constructor assignments
- Fixed getter function names from parent class
  - headers -> getHeaders
  - statusCode -> getStatusCode