### PR TITLE
Moved pagination headers to separate response generator

### DIFF
--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/JavaCodeGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/JavaCodeGenerator.java
@@ -426,6 +426,10 @@ public class JavaCodeGenerator implements CodeGenerator {
         if (isGetObjectAmazonS3Request(ds3Request)) {
             return new GetObjectResponseGenerator();
         }
+        //This should be the last test so that it does not overwrite any special cased generators
+        if (supportsPaginationRequest(ds3Request)) {
+            return new PaginationResponseGenerator();
+        }
         return new BaseResponseGenerator();
     }
 
@@ -454,6 +458,10 @@ public class JavaCodeGenerator implements CodeGenerator {
         }
         if (isGetObjectAmazonS3Request(ds3Request)) {
             return config.getTemplate("response/get_object_response.ftl");
+        }
+        //This should be the last test so that it does not overwrite any special cased templates
+        if (supportsPaginationRequest(ds3Request)) {
+            return config.getTemplate("response/pagination_response.ftl");
         }
         return config.getTemplate("response/response_template.ftl");
     }

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responsemodels/BaseResponseGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responsemodels/BaseResponseGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *
@@ -33,7 +33,6 @@ import static com.spectralogic.ds3autogen.java.utils.ResponseAndParserUtils.getI
 import static com.spectralogic.ds3autogen.java.utils.ResponseAndParserUtils.getResponseModelName;
 import static com.spectralogic.ds3autogen.utils.ConverterUtil.hasContent;
 import static com.spectralogic.ds3autogen.utils.ConverterUtil.isEmpty;
-import static com.spectralogic.ds3autogen.utils.Ds3RequestClassificationUtil.supportsPaginationRequest;
 import static com.spectralogic.ds3autogen.utils.Helper.stripPath;
 import static com.spectralogic.ds3autogen.utils.Helper.uncapFirst;
 import static com.spectralogic.ds3autogen.utils.NormalizingContractNamesUtil.removePath;
@@ -50,7 +49,7 @@ public class BaseResponseGenerator implements ResponseModelGenerator<Response>, 
         final String responseName = NormalizingContractNamesUtil.toResponseName(ds3Request.getName());
         final String parentClass = getParentClass();
 
-        final ImmutableList<Arguments> params = toParamListWithPagination(ds3Request);
+        final ImmutableList<Arguments> params = toParamList(ds3Request.getDs3ResponseCodes());
         final ImmutableSet<String> imports = getAllImports(ds3Request);
 
         final String constructorParams = toConstructorParams(params);
@@ -75,24 +74,6 @@ public class BaseResponseGenerator implements ResponseModelGenerator<Response>, 
         return params.stream()
                 .map(i -> "final " + i.getType() + " " + uncapFirst(i.getName()))
                 .collect(Collectors.joining(", "));
-    }
-
-    /**
-     * Retrieves the list of parameters need to create the response POJO. If the response
-     * has pagination headers, then the pagination parameters are appended to the end of
-     * the list.
-     */
-    @Override
-    public ImmutableList<Arguments> toParamListWithPagination(final Ds3Request ds3Request) {
-        if (!supportsPaginationRequest(ds3Request)) {
-            return toParamList(ds3Request.getDs3ResponseCodes());
-        }
-        final ImmutableList.Builder<Arguments> builder = ImmutableList.builder();
-        builder.addAll(toParamList(ds3Request.getDs3ResponseCodes()));
-        builder.add(new Arguments("Integer", "pagingTotalResultCount"));
-        builder.add(new Arguments("Integer", "pagingTruncated"));
-
-        return builder.build();
     }
 
     /**

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responsemodels/PaginationResponseGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responsemodels/PaginationResponseGenerator.java
@@ -1,0 +1,61 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.java.generators.responsemodels;
+
+import com.google.common.collect.ImmutableList;
+import com.spectralogic.ds3autogen.api.models.Arguments;
+
+import java.util.stream.Collectors;
+
+import static com.spectralogic.ds3autogen.utils.ConverterUtil.hasContent;
+import static com.spectralogic.ds3autogen.utils.Helper.uncapFirst;
+
+/**
+ * Response generator for response handlers that have patination headers.
+ * These handlers extend the AbstractPaginationResponse, and pass the
+ * pagination parameters to the super constructor.
+ */
+public class PaginationResponseGenerator extends BaseResponseGenerator {
+
+    private final static String PAGINATION_RESPONSE_IMPORT = "com.spectralogic.ds3client.commands.interfaces.AbstractPaginationResponse";
+
+    /**
+     * Returns the import for the parent class for standard response, which
+     * is AbstractResponse
+     */
+    @Override
+    public String getParentImport() {
+        return PAGINATION_RESPONSE_IMPORT;
+    }
+
+    /**
+     * Retrieves the list of parameters need to create the response POJO and
+     * adds the pagination parameters to the end of the list.
+     */
+    @Override
+    public String toConstructorParams(final ImmutableList<Arguments> params) {
+        final ImmutableList.Builder<Arguments> builder = ImmutableList.builder();
+        if (hasContent(params)) {
+            builder.addAll(params);
+        }
+        builder.add(new Arguments("Integer", "pagingTotalResultCount"));
+        builder.add(new Arguments("Integer", "pagingTruncated"));
+
+        return builder.build().stream()
+                .map(i -> "final " + i.getType() + " " + uncapFirst(i.getName()))
+                .collect(Collectors.joining(", "));
+    }
+}

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responsemodels/ResponseGeneratorUtil.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responsemodels/ResponseGeneratorUtil.java
@@ -48,11 +48,4 @@ public interface ResponseGeneratorUtil {
      * Converts a list of Arguments into a comma-separated list of parameters for the constructor
      */
     String toConstructorParams(final ImmutableList<Arguments> params);
-
-    /**
-     * Retrieves the list of parameters need to create the response POJO. If the response
-     * has pagination headers, then the pagination parameters are appended to the end of
-     * the list.
-     */
-    ImmutableList<Arguments> toParamListWithPagination(final Ds3Request ds3Request);
 }

--- a/ds3-autogen-java/src/main/resources/tmpls/response/pagination_response.ftl
+++ b/ds3-autogen-java/src/main/resources/tmpls/response/pagination_response.ftl
@@ -1,0 +1,26 @@
+<#include "../copyright.ftl"/>
+
+package ${packageName};
+
+<#include "../imports.ftl"/>
+
+public class ${name} extends ${parentClass} {
+
+    <#list params as param>
+    private final ${param.type} ${param.name?uncap_first};
+    </#list>
+
+    public ${name}(${constructorParams}) {
+        super(pagingTotalResultCount, pagingTruncated);
+        <#list params as param>
+        this.${param.name?uncap_first} = ${param.name?uncap_first};
+        </#list>
+    }
+
+    <#list params as param>
+    public ${param.type} get${param.name?cap_first}() {
+        return this.${param.name?uncap_first};
+    }
+
+    </#list>
+}

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaCodeGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaCodeGenerator_Test.java
@@ -39,6 +39,7 @@ public class JavaCodeGenerator_Test {
         assertThat(getResponseGenerator(getRequestBulkGet()), instanceOf(BulkResponseGenerator.class));
         assertThat(getResponseGenerator(getRequestBulkPut()), instanceOf(BulkResponseGenerator.class));
         assertThat(getResponseGenerator(getRequestAmazonS3GetObject()), instanceOf(GetObjectResponseGenerator.class));
+        assertThat(getResponseGenerator(getBucketsSpectraS3Request()), instanceOf(PaginationResponseGenerator.class));
     }
 
     @Test

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaFunctionalTests.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaFunctionalTests.java
@@ -53,7 +53,7 @@ import static org.mockito.Mockito.mock;
 public class JavaFunctionalTests {
 
     private static final Logger LOG = LoggerFactory.getLogger(JavaFunctionalTests.class);
-    private final static GeneratedCodeLogger CODE_LOGGER = new GeneratedCodeLogger(FileTypeToLog.PARSER, LOG);
+    private final static GeneratedCodeLogger CODE_LOGGER = new GeneratedCodeLogger(FileTypeToLog.RESPONSE, LOG);
 
     @Rule
     public TemporaryFolder tempFolder = new TemporaryFolder();
@@ -1552,13 +1552,15 @@ public class JavaFunctionalTests {
         CODE_LOGGER.logFile(responseGeneratedCode, FileTypeToLog.RESPONSE);
 
         final String responseName = requestName.replace("Request", "Response");
-        assertTrue(extendsClass(responseName, "AbstractResponse", responseGeneratedCode));
+        assertTrue(extendsClass(responseName, "AbstractPaginationResponse", responseGeneratedCode));
         assertTrue(isOfPackage("com.spectralogic.ds3client.commands.spectrads3.notifications", responseGeneratedCode));
 
-        assertTrue(hasImport("com.spectralogic.ds3client.commands.interfaces.AbstractResponse", responseGeneratedCode));
+        assertTrue(hasImport("com.spectralogic.ds3client.commands.interfaces.AbstractPaginationResponse", responseGeneratedCode));
         assertTrue(hasImport("com.spectralogic.ds3client.models.JobCompletedNotificationRegistrationList", responseGeneratedCode));
 
         assertTrue(isReqParamOfType("jobCompletedNotificationRegistrationListResult", "JobCompletedNotificationRegistrationList", responseName, responseGeneratedCode, false));
+        assertTrue(isReqParamOfType("pagingTotalResultCount", "Integer", responseName, responseGeneratedCode, true));
+        assertTrue(isReqParamOfType("pagingTruncated", "Integer", responseName, responseGeneratedCode, true));
 
         //Test the Ds3Client
         final String ds3ClientGeneratedCode = testGeneratedCode.getDs3ClientGeneratedCode();
@@ -2367,9 +2369,11 @@ public class JavaFunctionalTests {
         final String responseGeneratedCode = testGeneratedCode.getResponseGeneratedCode();
         CODE_LOGGER.logFile(responseGeneratedCode, FileTypeToLog.RESPONSE);
         final String responseName = requestName.replace("Request", "Response");
-        assertTrue(extendsClass(responseName, "AbstractResponse", responseGeneratedCode));
+        assertTrue(extendsClass(responseName, "AbstractPaginationResponse", responseGeneratedCode));
 
         assertTrue(isReqParamOfType("bucketListResult", "BucketList", responseName, responseGeneratedCode, false));
+        assertTrue(isReqParamOfType("pagingTotalResultCount", "Integer", responseName, responseGeneratedCode, true));
+        assertTrue(isReqParamOfType("pagingTruncated", "Integer", responseName, responseGeneratedCode, true));
 
         //Test the Ds3Client
         final String ds3ClientGeneratedCode = testGeneratedCode.getDs3ClientGeneratedCode();
@@ -2553,11 +2557,13 @@ public class JavaFunctionalTests {
         final String responseGeneratedCode = testGeneratedCode.getResponseGeneratedCode();
         CODE_LOGGER.logFile(responseGeneratedCode, FileTypeToLog.RESPONSE);
         final String responseName = requestName.replace("Request", "Response");
-        assertTrue(extendsClass(responseName, "AbstractResponse", responseGeneratedCode));
+        assertTrue(extendsClass(responseName, "AbstractPaginationResponse", responseGeneratedCode));
 
-        assertTrue(hasImport("com.spectralogic.ds3client.commands.interfaces.AbstractResponse", responseGeneratedCode));
+        assertTrue(hasImport("com.spectralogic.ds3client.commands.interfaces.AbstractPaginationResponse", responseGeneratedCode));
 
         assertTrue(isReqParamOfType("s3ObjectListResult", "S3ObjectList", responseName, responseGeneratedCode, false));
+        assertTrue(isReqParamOfType("pagingTotalResultCount", "Integer", responseName, responseGeneratedCode, true));
+        assertTrue(isReqParamOfType("pagingTruncated", "Integer", responseName, responseGeneratedCode, true));
 
         //Test the Ds3Client
         final String ds3ClientGeneratedCode = testGeneratedCode.getDs3ClientGeneratedCode();

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responsemodels/BaseResponseGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responsemodels/BaseResponseGenerator_Test.java
@@ -18,7 +18,6 @@ package com.spectralogic.ds3autogen.java.generators.responsemodels;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.spectralogic.ds3autogen.api.models.Arguments;
-import com.spectralogic.ds3autogen.api.models.apispec.Ds3Request;
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3ResponseCode;
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3ResponseType;
 import org.junit.Test;
@@ -29,11 +28,10 @@ import static com.spectralogic.ds3autogen.java.generators.responsemodels.BaseRes
 import static com.spectralogic.ds3autogen.java.generators.responsemodels.BaseResponseGenerator.toParam;
 import static com.spectralogic.ds3autogen.java.test.helpers.Ds3ResponseCodeFixtureTestHelper.createPopulatedErrorResponseCode;
 import static com.spectralogic.ds3autogen.java.test.helpers.Ds3ResponseCodeFixtureTestHelper.createPopulatedResponseCode;
-import static com.spectralogic.ds3autogen.testutil.Ds3ModelFixtures.getGetBlobPersistence;
-import static com.spectralogic.ds3autogen.testutil.Ds3ModelFixtures.getObjectsDetailsRequest;
 import static com.spectralogic.ds3autogen.testutil.Ds3ModelPartialDataFixture.createDs3RequestTestData;
 import static com.spectralogic.ds3autogen.testutil.Ds3ModelPartialDataFixture.createEmptyDs3Request;
-import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.*;
 
 public class BaseResponseGenerator_Test {
@@ -193,23 +191,5 @@ public class BaseResponseGenerator_Test {
 
         final String result = generator.toConstructorParams(args);
         assertThat(result, is(expected));
-    }
-
-    @Test
-    public void toParamListWithPagination_WithPagination_Test() {
-        final Ds3Request request = getObjectsDetailsRequest(); // Request that supports pagination
-        final ImmutableList<Arguments> result = generator.toParamListWithPagination(request);
-        assertThat(result.size(), is(3));
-        assertThat(result.get(1).getName(), is("pagingTotalResultCount"));
-        assertThat(result.get(2).getName(), is("pagingTruncated"));
-    }
-
-    @Test
-    public void toParamListWithPagination_WithNoPagination_Test() {
-        final Ds3Request request = getGetBlobPersistence(); // Request that does not supports pagination
-        final ImmutableList<Arguments> result = generator.toParamListWithPagination(request);
-        assertThat(result.size(), is(1));
-        assertThat(result.get(0).getName(), is(not("pagingTotalResultCount")));
-        assertThat(result.get(0).getName(), is(not("pagingTruncated")));
     }
 }

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responsemodels/PaginationResponseGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responsemodels/PaginationResponseGenerator_Test.java
@@ -1,0 +1,57 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.java.generators.responsemodels;
+
+import com.google.common.collect.ImmutableList;
+import com.spectralogic.ds3autogen.api.models.Arguments;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+public class PaginationResponseGenerator_Test {
+
+    private static final PaginationResponseGenerator generator = new PaginationResponseGenerator();
+
+    @Test
+    public void getParentImport_Test() {
+        assertThat(generator.getParentImport(),
+                is("com.spectralogic.ds3client.commands.interfaces.AbstractPaginationResponse"));
+    }
+
+    @Test
+    public void toConstructorParams_NullList_Test() {
+        final String expected = "final Integer pagingTotalResultCount, final Integer pagingTruncated";
+        assertThat(generator.toConstructorParams(null), is(expected));
+    }
+
+    @Test
+    public void toConstructorParams_EmptyList_Test() {
+        final String expected = "final Integer pagingTotalResultCount, final Integer pagingTruncated";
+        assertThat(generator.toConstructorParams(ImmutableList.of()), is(expected));
+    }
+
+    @Test
+    public void toConstructorParams_FullList_Test() {
+        final String expected = "final TypeOne argOne, final TypeTwo argTwo, final Integer pagingTotalResultCount, final Integer pagingTruncated";
+
+        final ImmutableList<Arguments> args = ImmutableList.of(
+                new Arguments("TypeOne", "ArgOne"),
+                new Arguments("TypeTwo", "ArgTwo"));
+
+        assertThat(generator.toConstructorParams(args), is(expected));
+    }
+}


### PR DESCRIPTION
**Changes**
- Moved pagination header logic to new Pagination Response Generator and template
- Response handlers that have pagination headers now extend AbstractPaginationResponse

--
Example Generated Code: GetBucketsSpectraS3Response.java
--
```
/*
 * ******************************************************************************
 *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
 *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 *   this file except in compliance with the License. A copy of the License is located at
 *
 *   http://www.apache.org/licenses/LICENSE-2.0
 *
 *   or in the "license" file accompanying this file.
 *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
 *   specific language governing permissions and limitations under the License.
 * ****************************************************************************
 */

// This code is auto-generated, do not modify
package com.spectralogic.ds3client.commands.spectrads3;

import com.spectralogic.ds3client.models.BucketList;
import com.spectralogic.ds3client.commands.interfaces.AbstractPaginationResponse;

public class GetBucketsSpectraS3Response extends AbstractPaginationResponse {

    private final BucketList bucketListResult;

    public GetBucketsSpectraS3Response(final BucketList bucketListResult, final Integer pagingTotalResultCount, final Integer pagingTruncated) {
        super(pagingTotalResultCount, pagingTruncated);
        this.bucketListResult = bucketListResult;
    }

    public BucketList getBucketListResult() {
        return this.bucketListResult;
    }

}
```