### PR TITLE
Updated copyright dates in java template

### DIFF
--- a/ds3-autogen-java/src/main/resources/tmpls/copyright.ftl
+++ b/ds3-autogen-java/src/main/resources/tmpls/copyright.ftl
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/utils/TestHelper.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/utils/TestHelper.java
@@ -154,7 +154,7 @@ public final class TestHelper {
         final String copyright =
                 "/*\n" +
                 " * ******************************************************************************\n" +
-                " *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.\n" +
+                " *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.\n" +
                 " *   Licensed under the Apache License, Version 2.0 (the \"License\"). You may not use\n" +
                 " *   this file except in compliance with the License. A copy of the License is located at\n" +
                 " *\n" +


### PR DESCRIPTION
All java generated code now has the updated copyright dates 2014-2016