### PR TITLE
Changes Get Object Parser generation to use the old networking code format

### DIFF
--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responseparser/GetObjectParserGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responseparser/GetObjectParserGenerator.java
@@ -30,7 +30,6 @@ import static com.spectralogic.ds3autogen.java.utils.ResponseAndParserUtils.getR
  */
 public class GetObjectParserGenerator extends BaseResponseParserGenerator {
 
-    protected static final String DS3_RESPONSE_PARSER_IMPORT = "com.spectralogic.ds3client.networking.Ds3ResponseParser";
     protected static final ImmutableList<Integer> EXPECTED_RESPONSE_CODES = ImmutableList.of(200, 206);
 
     /**
@@ -54,14 +53,6 @@ public class GetObjectParserGenerator extends BaseResponseParserGenerator {
     }
 
     /**
-     * Retrieves the import for the Ds3 response parser interface
-     */
-    @Override
-    public String getParentClassImport() {
-        return DS3_RESPONSE_PARSER_IMPORT;
-    }
-
-    /**
      * Retrieves the java imports needed to generate the response parser
      */
     @Override
@@ -71,20 +62,17 @@ public class GetObjectParserGenerator extends BaseResponseParserGenerator {
             final ImmutableList<Ds3ResponseCode> responseCodes) {
         final ImmutableSet.Builder<String> builder = ImmutableSet.builder();
 
-        builder.add("com.google.common.util.concurrent.ListeningExecutorService");
-        builder.add("com.google.common.util.concurrent.MoreExecutors");
         builder.add("com.spectralogic.ds3client.commands.interfaces.MetadataImpl");
-        builder.add("com.spectralogic.ds3client.commands.parsers.interfaces.ResponseFutureCallable");
         builder.add("com.spectralogic.ds3client.commands.parsers.utils.ResponseParserUtils");
-        builder.add("com.spectralogic.ds3client.networking.Headers");
-        builder.add("com.spectralogic.ds3client.networking.NettyBlockingByteChannel");
+        builder.add("com.spectralogic.ds3client.exceptions.ContentLengthNotMatchException");
+        builder.add("com.spectralogic.ds3client.networking.Metadata");
         builder.add("com.spectralogic.ds3client.networking.WebResponse");
-        builder.add("org.slf4j.Logger");
-        builder.add("org.slf4j.LoggerFactory");
+        builder.add("com.spectralogic.ds3client.utils.IOUtils");
+        builder.add("com.spectralogic.ds3client.utils.PerformanceUtils");
         builder.add("java.io.IOException");
+        builder.add("java.io.InputStream");
+        builder.add("java.nio.channels.ReadableByteChannel");
         builder.add("java.nio.channels.WritableByteChannel");
-        builder.add("java.util.concurrent.Executors");
-        builder.add("java.util.concurrent.FutureTask");
 
         builder.add(getParentClassImport());
         builder.add(getCommandPackage(ds3Request) + "." + responseName);

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaFunctionalTests.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaFunctionalTests.java
@@ -53,7 +53,7 @@ import static org.mockito.Mockito.mock;
 public class JavaFunctionalTests {
 
     private static final Logger LOG = LoggerFactory.getLogger(JavaFunctionalTests.class);
-    private final static GeneratedCodeLogger CODE_LOGGER = new GeneratedCodeLogger(FileTypeToLog.RESPONSE, LOG);
+    private final static GeneratedCodeLogger CODE_LOGGER = new GeneratedCodeLogger(FileTypeToLog.PARSER, LOG);
 
     @Rule
     public TemporaryFolder tempFolder = new TemporaryFolder();
@@ -1252,24 +1252,20 @@ public class JavaFunctionalTests {
 
         assertTrue(isOfPackage("com.spectralogic.ds3client.commands.parsers", responseParserCode));
 
-        assertTrue(hasImport("com.google.common.util.concurrent.ListeningExecutorService", responseParserCode));
-        assertTrue(hasImport("com.google.common.util.concurrent.MoreExecutors", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.commands.GetObjectResponse", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.commands.interfaces.MetadataImpl", responseParserCode));
-        assertTrue(hasImport("com.spectralogic.ds3client.commands.parsers.interfaces.ResponseFutureCallable", responseParserCode));
+        assertTrue(hasImport("com.spectralogic.ds3client.commands.parsers.interfaces.AbstractResponseParser", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.commands.parsers.utils.ResponseParserUtils", responseParserCode));
-        assertTrue(hasImport("com.spectralogic.ds3client.networking.Ds3ResponseParser", responseParserCode));
-        assertTrue(hasImport("com.spectralogic.ds3client.networking.Headers", responseParserCode));
-        assertTrue(hasImport("com.spectralogic.ds3client.networking.NettyBlockingByteChannel", responseParserCode));
+        assertTrue(hasImport("com.spectralogic.ds3client.exceptions.ContentLengthNotMatchException", responseParserCode));
+        assertTrue(hasImport("com.spectralogic.ds3client.networking.Metadata", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.networking.WebResponse", responseParserCode));
-        assertTrue(hasImport("org.slf4j.Logger", responseParserCode));
-        assertTrue(hasImport("org.slf4j.LoggerFactory", responseParserCode));
+        assertTrue(hasImport("com.spectralogic.ds3client.utils.IOUtils", responseParserCode));
+        assertTrue(hasImport("com.spectralogic.ds3client.utils.PerformanceUtils", responseParserCode));
         assertTrue(hasImport("java.io.IOException", responseParserCode));
+        assertTrue(hasImport("java.io.InputStream", responseParserCode));
+        assertTrue(hasImport("java.nio.channels.ReadableByteChannel", responseParserCode));
         assertTrue(hasImport("java.nio.channels.WritableByteChannel", responseParserCode));
-        assertTrue(hasImport("java.util.concurrent.Executors", responseParserCode));
-        assertTrue(hasImport("java.util.concurrent.FutureTask", responseParserCode));
 
-        assertTrue(responseParserCode.contains("public class GetObjectResponseParser implements Ds3ResponseParser<GetObjectResponse> {"));
         assertTrue(responseParserCode.contains("private final int[] expectedStatusCodes = new int[]{200, 206};"));
     }
     

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responseparser/GetObjectParserGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responseparser/GetObjectParserGenerator_Test.java
@@ -39,29 +39,20 @@ public class GetObjectParserGenerator_Test {
                 request,
                 request.getDs3ResponseCodes());
 
-        assertThat(result.size(), is(16));
-        assertThat(result, hasItem("com.google.common.util.concurrent.ListeningExecutorService"));
-        assertThat(result, hasItem("com.google.common.util.concurrent.MoreExecutors"));
+        assertThat(result.size(), is(13));
         assertThat(result, hasItem("com.spectralogic.ds3client.commands.GetObjectResponse"));
         assertThat(result, hasItem("com.spectralogic.ds3client.commands.interfaces.MetadataImpl"));
-        assertThat(result, hasItem("com.spectralogic.ds3client.commands.parsers.interfaces.ResponseFutureCallable"));
+        assertThat(result, hasItem("com.spectralogic.ds3client.commands.parsers.interfaces.AbstractResponseParser"));
         assertThat(result, hasItem("com.spectralogic.ds3client.commands.parsers.utils.ResponseParserUtils"));
-        assertThat(result, hasItem("com.spectralogic.ds3client.networking.Ds3ResponseParser"));
-        assertThat(result, hasItem("com.spectralogic.ds3client.networking.Headers"));
-        assertThat(result, hasItem("com.spectralogic.ds3client.networking.NettyBlockingByteChannel"));
+        assertThat(result, hasItem("com.spectralogic.ds3client.exceptions.ContentLengthNotMatchException"));
+        assertThat(result, hasItem("com.spectralogic.ds3client.networking.Metadata"));
         assertThat(result, hasItem("com.spectralogic.ds3client.networking.WebResponse"));
-        assertThat(result, hasItem("org.slf4j.Logger"));
-        assertThat(result, hasItem("org.slf4j.LoggerFactory"));
+        assertThat(result, hasItem("com.spectralogic.ds3client.utils.IOUtils"));
+        assertThat(result, hasItem("com.spectralogic.ds3client.utils.PerformanceUtils"));
         assertThat(result, hasItem("java.io.IOException"));
+        assertThat(result, hasItem("java.io.InputStream"));
+        assertThat(result, hasItem("java.nio.channels.ReadableByteChannel"));
         assertThat(result, hasItem("java.nio.channels.WritableByteChannel"));
-        assertThat(result, hasItem("java.util.concurrent.Executors"));
-        assertThat(result, hasItem("java.util.concurrent.FutureTask"));
-    }
-
-    @Test
-    public void getParentClassImport_Test() {
-        assertThat(generator.getParentClassImport(),
-                is("com.spectralogic.ds3client.networking.Ds3ResponseParser"));
     }
 
     @Test (expected = IllegalArgumentException.class)


### PR DESCRIPTION
**Changes**
Updates the generation of GetObjectParser to use the existing SDK networking code instead of the new networking code (which uses futures)