### PR TITLE
Removed blockingByteChannel from response parser generation

### DIFF
--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responseparser/AllocateJobChunkParserGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responseparser/AllocateJobChunkParserGenerator.java
@@ -63,7 +63,7 @@ public class AllocateJobChunkParserGenerator extends BaseResponseParserGenerator
             final String responseName) {
         final String responseModelName = getResponseModelName(ds3ResponseCode.getDs3ResponseTypes().get(0));
 
-        return "try (final InputStream inputStream = new ReadableByteChannelInputStream(blockingByteChannel)) {\n"
+        return "try (final InputStream inputStream = response.getResponseStream()) {\n"
                 + indent(5) + "final " + responseModelName + " result = XmlOutput.fromXml(inputStream, " + responseModelName + ".class);\n"
                 + indent(5) + "return new " + responseName + "(result, 0, " + responseName + ".Status.ALLOCATED);\n"
                 + indent(4) + "}\n";

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responseparser/BaseResponseParserGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responseparser/BaseResponseParserGenerator.java
@@ -158,7 +158,6 @@ public class BaseResponseParserGenerator implements ResponseParserGenerator<Resp
         //If a response type has an associated import, then the XmlOutput import is also needed
         if (builder.build().size() > 0) {
             builder.add("com.spectralogic.ds3client.serializer.XmlOutput");
-            builder.add("com.spectralogic.ds3client.utils.ReadableByteChannelInputStream");
             builder.add("java.io.InputStream");
         }
         if (builder.build().contains("java.lang.String") || builder.build().contains("String")) {
@@ -183,7 +182,6 @@ public class BaseResponseParserGenerator implements ResponseParserGenerator<Resp
     protected static ImmutableSet<String> requiredImportList() {
         return ImmutableSet.of(
                 "java.io.IOException",
-                "java.nio.channels.ReadableByteChannel",
                 "com.spectralogic.ds3client.networking.WebResponse");
     }
 

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responseparser/GetJobChunksReadyParserGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responseparser/GetJobChunksReadyParserGenerator.java
@@ -59,7 +59,7 @@ public class GetJobChunksReadyParserGenerator extends BaseResponseParserGenerato
             final String responseName) {
         final String responseModelName = getResponseModelName(ds3ResponseCode.getDs3ResponseTypes().get(0));
 
-        return "try (final InputStream inputStream = new ReadableByteChannelInputStream(blockingByteChannel)) {\n" +
+        return "try (final InputStream inputStream = response.getResponseStream()) {\n" +
                 indent(5) + "final " + responseModelName + " result = XmlOutput.fromXml(inputStream, " + responseModelName + ".class);\n" +
                 indent(5) + "if (isNullOrEmpty(result.getObjects())) {\n" +
                 indent(6) + "return new " + responseName + "(result, parseRetryAfter(response), " + responseName +".Status.RETRYLATER);\n" +

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responseparser/GetObjectParserGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responseparser/GetObjectParserGenerator.java
@@ -71,7 +71,6 @@ public class GetObjectParserGenerator extends BaseResponseParserGenerator {
         builder.add("com.spectralogic.ds3client.utils.PerformanceUtils");
         builder.add("java.io.IOException");
         builder.add("java.io.InputStream");
-        builder.add("java.nio.channels.ReadableByteChannel");
         builder.add("java.nio.channels.WritableByteChannel");
 
         builder.add(getParentClassImport());

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/parseresponse/BaseParseResponse.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/parseresponse/BaseParseResponse.java
@@ -43,7 +43,7 @@ public class BaseParseResponse implements ParseResponse {
 
     @Override
     public String toJavaCode() {
-        return "try (final InputStream inputStream = new ReadableByteChannelInputStream(blockingByteChannel)) {\n"
+        return "try (final InputStream inputStream = response.getResponseStream()) {\n"
                 + indent(INDENT + 1) + "final " + responseModelName + " result = XmlOutput.fromXml(inputStream, " + responseModelName + ".class);\n"
                 + indent(INDENT + 1) + "return new " + responseName + "(" + getConstructorParams(hasPaginationHeaders) + ");\n"
                 + indent(INDENT) + "}\n";

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/parseresponse/StringParseResponse.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/parseresponse/StringParseResponse.java
@@ -38,7 +38,7 @@ public class StringParseResponse implements ParseResponse {
 
     @Override
     public String toJavaCode() {
-        return "try (final InputStream inputStream = new ReadableByteChannelInputStream(blockingByteChannel)) {\n"
+        return "try (final InputStream inputStream = response.getResponseStream()) {\n"
                 + indent(INDENT + 1) + "final String result = IOUtils.toString(inputStream, StandardCharsets.UTF_8);\n"
                 + indent(INDENT + 1) + "return new " + responseName + "(" + getConstructorParams(hasPaginationHeaders) + ");\n"
                 + indent(INDENT) + "}\n";

--- a/ds3-autogen-java/src/main/resources/tmpls/responseparser/allocate_job_chunk_parser.ftl
+++ b/ds3-autogen-java/src/main/resources/tmpls/responseparser/allocate_job_chunk_parser.ftl
@@ -9,7 +9,7 @@ public class ${name} extends ${parentClass}<${responseName}> {
     private final int[] expectedStatusCodes = new int[]{${expectedStatusCodes}};
 
     @Override
-    public ${responseName} parseXmlResponse(final WebResponse response, final ReadableByteChannel blockingByteChannel) throws IOException {
+    public ${responseName} parseXmlResponse(final WebResponse response) throws IOException {
         final int statusCode = response.getStatusCode();
         if (ResponseParserUtils.validateStatusCode(statusCode, expectedStatusCodes)) {
             switch (statusCode) {
@@ -22,7 +22,7 @@ public class ${name} extends ${parentClass}<${responseName}> {
             }
         }
 
-        throw ResponseParserUtils.createFailedRequest(response, blockingByteChannel, expectedStatusCodes);
+        throw ResponseParserUtils.createFailedRequest(response, expectedStatusCodes);
     }
 
 <#include "common/parse_retry_after.ftl"/>

--- a/ds3-autogen-java/src/main/resources/tmpls/responseparser/bulk_response_parser.ftl
+++ b/ds3-autogen-java/src/main/resources/tmpls/responseparser/bulk_response_parser.ftl
@@ -8,7 +8,7 @@ public class ${name} extends ${parentClass}<${responseName}> {
     private final int[] expectedStatusCodes = new int[]{${expectedStatusCodes}};
 
     @Override
-    public ${responseName} parseXmlResponse(final WebResponse response, final ReadableByteChannel blockingByteChannel) throws IOException {
+    public ${responseName} parseXmlResponse(final WebResponse response) throws IOException {
         final int statusCode = response.getStatusCode();
         if (ResponseParserUtils.validateStatusCode(statusCode, expectedStatusCodes)) {
             switch (statusCode) {
@@ -24,6 +24,6 @@ public class ${name} extends ${parentClass}<${responseName}> {
             }
         }
 
-        throw ResponseParserUtils.createFailedRequest(response, blockingByteChannel, expectedStatusCodes);
+        throw ResponseParserUtils.createFailedRequest(response, expectedStatusCodes);
     }
 }

--- a/ds3-autogen-java/src/main/resources/tmpls/responseparser/get_job_chunks_ready_parser.ftl
+++ b/ds3-autogen-java/src/main/resources/tmpls/responseparser/get_job_chunks_ready_parser.ftl
@@ -11,7 +11,7 @@ public class ${name} extends ${parentClass}<${responseName}> {
     private final int[] expectedStatusCodes = new int[]{${expectedStatusCodes}};
 
     @Override
-    public ${responseName} parseXmlResponse(final WebResponse response, final ReadableByteChannel blockingByteChannel) throws IOException {
+    public ${responseName} parseXmlResponse(final WebResponse response) throws IOException {
         final int statusCode = response.getStatusCode();
         if (ResponseParserUtils.validateStatusCode(statusCode, expectedStatusCodes)) {
             switch (statusCode) {
@@ -24,7 +24,7 @@ public class ${name} extends ${parentClass}<${responseName}> {
             }
         }
 
-        throw ResponseParserUtils.createFailedRequest(response, blockingByteChannel, expectedStatusCodes);
+        throw ResponseParserUtils.createFailedRequest(response, expectedStatusCodes);
     }
 
 <#include "common/parse_retry_after.ftl"/>

--- a/ds3-autogen-java/src/main/resources/tmpls/responseparser/get_object_parser.ftl
+++ b/ds3-autogen-java/src/main/resources/tmpls/responseparser/get_object_parser.ftl
@@ -20,7 +20,7 @@ public class ${name} extends ${parentClass}<${responseName}> {
     }
 
     @Override
-    public ${responseName} parseXmlResponse(final WebResponse response, final ReadableByteChannel blockingByteChannel) throws IOException {
+    public ${responseName} parseXmlResponse(final WebResponse response) throws IOException {
         final int statusCode = response.getStatusCode();
         if (ResponseParserUtils.validateStatusCode(statusCode, expectedStatusCodes)) {
             final Metadata metadata = new MetadataImpl(this.getResponse().getHeaders());
@@ -29,7 +29,7 @@ public class ${name} extends ${parentClass}<${responseName}> {
             return new GetObjectResponse(this.getChecksum(), this.getChecksumType(), metadata, objectSize);
         }
 
-        throw ResponseParserUtils.createFailedRequest(response, blockingByteChannel, expectedStatusCodes);
+        throw ResponseParserUtils.createFailedRequest(response, expectedStatusCodes);
     }
 
     protected void download(final long objectSize, final WebResponse response) throws IOException {

--- a/ds3-autogen-java/src/main/resources/tmpls/responseparser/head_object_parser.ftl
+++ b/ds3-autogen-java/src/main/resources/tmpls/responseparser/head_object_parser.ftl
@@ -12,7 +12,7 @@ public class ${name} extends ${parentClass}<${responseName}> {
     private final int[] expectedStatusCodes = new int[]{${expectedStatusCodes}};
 
     @Override
-    public ${responseName} parseXmlResponse(final WebResponse response, final ReadableByteChannel blockingByteChannel) throws IOException {
+    public ${responseName} parseXmlResponse(final WebResponse response) throws IOException {
         final int statusCode = response.getStatusCode();
         if (ResponseParserUtils.validateStatusCode(statusCode, expectedStatusCodes)) {
             final Metadata metadata = new MetadataImpl(response.getHeaders());
@@ -27,6 +27,6 @@ public class ${name} extends ${parentClass}<${responseName}> {
             }
         }
 
-        throw ResponseParserUtils.createFailedRequest(response, blockingByteChannel, expectedStatusCodes);
+        throw ResponseParserUtils.createFailedRequest(response, expectedStatusCodes);
     }
 }

--- a/ds3-autogen-java/src/main/resources/tmpls/responseparser/response_parser_template.ftl
+++ b/ds3-autogen-java/src/main/resources/tmpls/responseparser/response_parser_template.ftl
@@ -8,7 +8,7 @@ public class ${name} extends ${parentClass}<${responseName}> {
     private final int[] expectedStatusCodes = new int[]{${expectedStatusCodes}};
 
     @Override
-    public ${responseName} parseXmlResponse(final WebResponse response, final ReadableByteChannel blockingByteChannel) throws IOException {
+    public ${responseName} parseXmlResponse(final WebResponse response) throws IOException {
         final int statusCode = response.getStatusCode();
         <#if hasPaginationHeaders == true>
         final Integer pagingTruncated = parseIntHeader("page-truncated");
@@ -25,6 +25,6 @@ public class ${name} extends ${parentClass}<${responseName}> {
             }
         }
 
-        throw ResponseParserUtils.createFailedRequest(response, blockingByteChannel, expectedStatusCodes);
+        throw ResponseParserUtils.createFailedRequest(response, expectedStatusCodes);
     }
 }

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaFunctionalTests.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaFunctionalTests.java
@@ -166,10 +166,8 @@ public class JavaFunctionalTests {
         assertTrue(hasImport("com.spectralogic.ds3client.models.CompleteMultipartUploadResult", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.networking.WebResponse", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.serializer.XmlOutput", responseParserCode));
-        assertTrue(hasImport("com.spectralogic.ds3client.utils.ReadableByteChannelInputStream", responseParserCode));
         assertTrue(hasImport("java.io.IOException", responseParserCode));
         assertTrue(hasImport("java.io.InputStream", responseParserCode));
-        assertTrue(hasImport("java.nio.channels.ReadableByteChannel", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.commands.parsers.utils.ResponseParserUtils", responseParserCode));
 
         final BaseParseResponse expectedParsing = new BaseParseResponse(responseName, "CompleteMultipartUploadResult");
@@ -240,10 +238,8 @@ public class JavaFunctionalTests {
         assertTrue(hasImport("com.spectralogic.ds3client.models.ListBucketResult", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.networking.WebResponse", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.serializer.XmlOutput", responseParserCode));
-        assertTrue(hasImport("com.spectralogic.ds3client.utils.ReadableByteChannelInputStream", responseParserCode));
         assertTrue(hasImport("java.io.IOException", responseParserCode));
         assertTrue(hasImport("java.io.InputStream", responseParserCode));
-        assertTrue(hasImport("java.nio.channels.ReadableByteChannel", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.commands.parsers.utils.ResponseParserUtils", responseParserCode));
 
         final BaseParseResponse expectedParsing = new BaseParseResponse(responseName, "ListBucketResult");
@@ -318,10 +314,8 @@ public class JavaFunctionalTests {
         assertTrue(hasImport("com.spectralogic.ds3client.models.Bucket", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.networking.WebResponse", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.serializer.XmlOutput", responseParserCode));
-        assertTrue(hasImport("com.spectralogic.ds3client.utils.ReadableByteChannelInputStream", responseParserCode));
         assertTrue(hasImport("java.io.IOException", responseParserCode));
         assertTrue(hasImport("java.io.InputStream", responseParserCode));
-        assertTrue(hasImport("java.nio.channels.ReadableByteChannel", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.commands.parsers.utils.ResponseParserUtils", responseParserCode));
 
         final BaseParseResponse expectedParsing = new BaseParseResponse(responseName, "Bucket");
@@ -400,7 +394,6 @@ public class JavaFunctionalTests {
         assertTrue(hasImport("com.spectralogic.ds3client.commands.parsers.interfaces.AbstractResponseParser", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.networking.WebResponse", responseParserCode));
         assertTrue(hasImport("java.io.IOException", responseParserCode));
-        assertTrue(hasImport("java.nio.channels.ReadableByteChannel", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.commands.spectrads3." + responseName, responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.commands.parsers.utils.ResponseParserUtils", responseParserCode));
 
@@ -639,10 +632,8 @@ public class JavaFunctionalTests {
         assertTrue(hasImport("com.spectralogic.ds3client.models.PhysicalPlacement", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.networking.WebResponse", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.serializer.XmlOutput", responseParserCode));
-        assertTrue(hasImport("com.spectralogic.ds3client.utils.ReadableByteChannelInputStream", responseParserCode));
         assertTrue(hasImport("java.io.IOException", responseParserCode));
         assertTrue(hasImport("java.io.InputStream", responseParserCode));
-        assertTrue(hasImport("java.nio.channels.ReadableByteChannel", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.commands.parsers.utils.ResponseParserUtils", responseParserCode));
 
         final BaseParseResponse expectedParsing = new BaseParseResponse(responseName, "PhysicalPlacement");
@@ -734,10 +725,8 @@ public class JavaFunctionalTests {
         assertTrue(hasImport("com.spectralogic.ds3client.models.BulkObjectList", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.networking.WebResponse", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.serializer.XmlOutput", responseParserCode));
-        assertTrue(hasImport("com.spectralogic.ds3client.utils.ReadableByteChannelInputStream", responseParserCode));
         assertTrue(hasImport("java.io.IOException", responseParserCode));
         assertTrue(hasImport("java.io.InputStream", responseParserCode));
-        assertTrue(hasImport("java.nio.channels.ReadableByteChannel", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.commands.parsers.utils.ResponseParserUtils", responseParserCode));
 
         final BaseParseResponse expectedParsing = new BaseParseResponse(responseName, "BulkObjectList");
@@ -822,10 +811,8 @@ public class JavaFunctionalTests {
         assertTrue(hasImport("com.spectralogic.ds3client.models.PhysicalPlacement", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.networking.WebResponse", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.serializer.XmlOutput", responseParserCode));
-        assertTrue(hasImport("com.spectralogic.ds3client.utils.ReadableByteChannelInputStream", responseParserCode));
         assertTrue(hasImport("java.io.IOException", responseParserCode));
         assertTrue(hasImport("java.io.InputStream", responseParserCode));
-        assertTrue(hasImport("java.nio.channels.ReadableByteChannel", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.commands.parsers.utils.ResponseParserUtils", responseParserCode));
 
         final BaseParseResponse expectedParsing = new BaseParseResponse(responseName, "PhysicalPlacement");
@@ -914,10 +901,8 @@ public class JavaFunctionalTests {
         assertTrue(hasImport("com.spectralogic.ds3client.models.BulkObjectList", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.networking.WebResponse", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.serializer.XmlOutput", responseParserCode));
-        assertTrue(hasImport("com.spectralogic.ds3client.utils.ReadableByteChannelInputStream", responseParserCode));
         assertTrue(hasImport("java.io.IOException", responseParserCode));
         assertTrue(hasImport("java.io.InputStream", responseParserCode));
-        assertTrue(hasImport("java.nio.channels.ReadableByteChannel", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.commands.parsers.utils.ResponseParserUtils", responseParserCode));
 
         final BaseParseResponse expectedParsing = new BaseParseResponse(responseName, "BulkObjectList");
@@ -998,10 +983,8 @@ public class JavaFunctionalTests {
         assertTrue(hasImport("com.spectralogic.ds3client.models.DeleteResult", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.networking.WebResponse", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.serializer.XmlOutput", responseParserCode));
-        assertTrue(hasImport("com.spectralogic.ds3client.utils.ReadableByteChannelInputStream", responseParserCode));
         assertTrue(hasImport("java.io.IOException", responseParserCode));
         assertTrue(hasImport("java.io.InputStream", responseParserCode));
-        assertTrue(hasImport("java.nio.channels.ReadableByteChannel", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.commands.parsers.utils.ResponseParserUtils", responseParserCode));
 
         final BaseParseResponse expectedParsing = new BaseParseResponse(responseName, "DeleteResult");
@@ -1052,7 +1035,6 @@ public class JavaFunctionalTests {
         assertTrue(hasImport("com.spectralogic.ds3client.commands.parsers.interfaces.AbstractResponseParser", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.networking.WebResponse", responseParserCode));
         assertTrue(hasImport("java.io.IOException", responseParserCode));
-        assertTrue(hasImport("java.nio.channels.ReadableByteChannel", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.commands.DeleteObjectResponse", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.commands.parsers.utils.ResponseParserUtils", responseParserCode));
 
@@ -1153,7 +1135,6 @@ public class JavaFunctionalTests {
         assertTrue(hasImport("com.spectralogic.ds3client.commands.parsers.interfaces.AbstractResponseParser", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.networking.WebResponse", responseParserCode));
         assertTrue(hasImport("java.io.IOException", responseParserCode));
-        assertTrue(hasImport("java.nio.channels.ReadableByteChannel", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.commands.PutObjectResponse", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.commands.parsers.utils.ResponseParserUtils", responseParserCode));
 
@@ -1266,7 +1247,6 @@ public class JavaFunctionalTests {
         assertTrue(hasImport("com.spectralogic.ds3client.utils.PerformanceUtils", responseParserCode));
         assertTrue(hasImport("java.io.IOException", responseParserCode));
         assertTrue(hasImport("java.io.InputStream", responseParserCode));
-        assertTrue(hasImport("java.nio.channels.ReadableByteChannel", responseParserCode));
         assertTrue(hasImport("java.nio.channels.WritableByteChannel", responseParserCode));
 
         assertTrue(responseParserCode.contains("private final int[] expectedStatusCodes = new int[]{200, 206};"));
@@ -1350,10 +1330,8 @@ public class JavaFunctionalTests {
         assertTrue(hasImport("com.spectralogic.ds3client.models.S3Object", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.networking.WebResponse", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.serializer.XmlOutput", responseParserCode));
-        assertTrue(hasImport("com.spectralogic.ds3client.utils.ReadableByteChannelInputStream", responseParserCode));
         assertTrue(hasImport("java.io.IOException", responseParserCode));
         assertTrue(hasImport("java.io.InputStream", responseParserCode));
-        assertTrue(hasImport("java.nio.channels.ReadableByteChannel", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.commands.parsers.utils.ResponseParserUtils", responseParserCode));
 
         final BaseParseResponse expectedParsing = new BaseParseResponse(responseName, "S3Object");
@@ -1418,7 +1396,6 @@ public class JavaFunctionalTests {
         assertTrue(hasImport("com.spectralogic.ds3client.commands.parsers.interfaces.AbstractResponseParser", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.networking.WebResponse", responseParserCode));
         assertTrue(hasImport("java.io.IOException", responseParserCode));
-        assertTrue(hasImport("java.nio.channels.ReadableByteChannel", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.commands.parsers.utils.ResponseParserUtils", responseParserCode));
 
         final EmptyParseResponse expectedParsing = new EmptyParseResponse(responseName);
@@ -1500,10 +1477,8 @@ public class JavaFunctionalTests {
         assertTrue(hasImport("com.spectralogic.ds3client.models.JobCompletedNotificationRegistration", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.networking.WebResponse", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.serializer.XmlOutput", responseParserCode));
-        assertTrue(hasImport("com.spectralogic.ds3client.utils.ReadableByteChannelInputStream", responseParserCode));
         assertTrue(hasImport("java.io.IOException", responseParserCode));
         assertTrue(hasImport("java.io.InputStream", responseParserCode));
-        assertTrue(hasImport("java.nio.channels.ReadableByteChannel", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.commands.parsers.utils.ResponseParserUtils", responseParserCode));
 
         final BaseParseResponse expectedParsing = new BaseParseResponse(responseName, "JobCompletedNotificationRegistration");
@@ -1583,10 +1558,8 @@ public class JavaFunctionalTests {
         assertTrue(hasImport("com.spectralogic.ds3client.models.JobCompletedNotificationRegistrationList", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.networking.WebResponse", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.serializer.XmlOutput", responseParserCode));
-        assertTrue(hasImport("com.spectralogic.ds3client.utils.ReadableByteChannelInputStream", responseParserCode));
         assertTrue(hasImport("java.io.IOException", responseParserCode));
         assertTrue(hasImport("java.io.InputStream", responseParserCode));
-        assertTrue(hasImport("java.nio.channels.ReadableByteChannel", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.commands.parsers.utils.ResponseParserUtils", responseParserCode));
 
         final BaseParseResponse expectedParsing = new BaseParseResponse(responseName, "JobCompletedNotificationRegistrationList", true);
@@ -1670,10 +1643,8 @@ public class JavaFunctionalTests {
         assertTrue(hasImport("com.spectralogic.ds3client.models.MasterObjectList", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.networking.WebResponse", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.serializer.XmlOutput", responseParserCode));
-        assertTrue(hasImport("com.spectralogic.ds3client.utils.ReadableByteChannelInputStream", responseParserCode));
         assertTrue(hasImport("java.io.IOException", responseParserCode));
         assertTrue(hasImport("java.io.InputStream", responseParserCode));
-        assertTrue(hasImport("java.nio.channels.ReadableByteChannel", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.commands.parsers.utils.ResponseParserUtils", responseParserCode));
 
         final BaseParseResponse expectedParsing = new BaseParseResponse(responseName, "MasterObjectList");
@@ -1750,10 +1721,8 @@ public class JavaFunctionalTests {
         assertTrue(hasImport("com.spectralogic.ds3client.models.InitiateMultipartUploadResult", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.networking.WebResponse", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.serializer.XmlOutput", responseParserCode));
-        assertTrue(hasImport("com.spectralogic.ds3client.utils.ReadableByteChannelInputStream", responseParserCode));
         assertTrue(hasImport("java.io.IOException", responseParserCode));
         assertTrue(hasImport("java.io.InputStream", responseParserCode));
-        assertTrue(hasImport("java.nio.channels.ReadableByteChannel", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.commands.parsers.utils.ResponseParserUtils", responseParserCode));
 
         final BaseParseResponse expectedParsing = new BaseParseResponse(responseName, "InitiateMultipartUploadResult");
@@ -1831,13 +1800,11 @@ public class JavaFunctionalTests {
         assertTrue(hasImport("com.spectralogic.ds3client.commands.parsers.interfaces.AbstractResponseParser", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.networking.WebResponse", responseParserCode));
         assertTrue(hasImport("java.io.IOException", responseParserCode));
-        assertTrue(hasImport("java.nio.channels.ReadableByteChannel", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.commands.spectrads3." + responseName, responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.commands.parsers.utils.ResponseParserUtils", responseParserCode));
 
         assertTrue(hasImport("com.spectralogic.ds3client.models.Objects", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.serializer.XmlOutput", responseParserCode));
-        assertTrue(hasImport("com.spectralogic.ds3client.utils.ReadableByteChannelInputStream", responseParserCode));
         assertTrue(hasImport("java.io.InputStream", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.exceptions.RetryAfterExpectedException", responseParserCode));
 
@@ -1916,14 +1883,12 @@ public class JavaFunctionalTests {
         assertTrue(hasImport("com.spectralogic.ds3client.commands.parsers.interfaces.AbstractResponseParser", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.networking.WebResponse", responseParserCode));
         assertTrue(hasImport("java.io.IOException", responseParserCode));
-        assertTrue(hasImport("java.nio.channels.ReadableByteChannel", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.commands.spectrads3." + responseName, responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.commands.parsers.utils.ResponseParserUtils", responseParserCode));
 
         assertTrue(hasImport("com.spectralogic.ds3client.exceptions.RetryAfterExpectedException", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.models.MasterObjectList", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.serializer.XmlOutput", responseParserCode));
-        assertTrue(hasImport("com.spectralogic.ds3client.utils.ReadableByteChannelInputStream", responseParserCode));
         assertTrue(hasImport("java.io.InputStream", responseParserCode));
         assertTrue(responseParserCode.contains("import static com.spectralogic.ds3client.utils.Guard.isNullOrEmpty"));
 
@@ -1995,7 +1960,6 @@ public class JavaFunctionalTests {
         assertTrue(hasImport("com.spectralogic.ds3client.commands.parsers.interfaces.AbstractResponseParser", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.networking.WebResponse", responseParserCode));
         assertTrue(hasImport("java.io.IOException", responseParserCode));
-        assertTrue(hasImport("java.nio.channels.ReadableByteChannel", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.commands." + responseName, responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.commands.parsers.utils.ResponseParserUtils", responseParserCode));
 
@@ -2072,7 +2036,6 @@ public class JavaFunctionalTests {
         assertTrue(hasImport("com.spectralogic.ds3client.commands.parsers.interfaces.AbstractResponseParser", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.networking.WebResponse", responseParserCode));
         assertTrue(hasImport("java.io.IOException", responseParserCode));
-        assertTrue(hasImport("java.nio.channels.ReadableByteChannel", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.commands." + responseName, responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.commands.parsers.utils.ResponseParserUtils", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.commands.interfaces.MetadataImpl", responseParserCode));
@@ -2154,10 +2117,8 @@ public class JavaFunctionalTests {
         assertTrue(hasImport("com.spectralogic.ds3client.models.MasterObjectList", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.networking.WebResponse", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.serializer.XmlOutput", responseParserCode));
-        assertTrue(hasImport("com.spectralogic.ds3client.utils.ReadableByteChannelInputStream", responseParserCode));
         assertTrue(hasImport("java.io.IOException", responseParserCode));
         assertTrue(hasImport("java.io.InputStream", responseParserCode));
-        assertTrue(hasImport("java.nio.channels.ReadableByteChannel", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.commands.parsers.utils.ResponseParserUtils", responseParserCode));
 
         final BaseParseResponse expectedParsing = new BaseParseResponse(responseName, "MasterObjectList");
@@ -2227,10 +2188,8 @@ public class JavaFunctionalTests {
         assertTrue(hasImport("com.spectralogic.ds3client.commands.parsers.interfaces.AbstractResponseParser", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.networking.WebResponse", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.serializer.XmlOutput", responseParserCode));
-        assertTrue(hasImport("com.spectralogic.ds3client.utils.ReadableByteChannelInputStream", responseParserCode));
         assertTrue(hasImport("java.io.IOException", responseParserCode));
         assertTrue(hasImport("java.io.InputStream", responseParserCode));
-        assertTrue(hasImport("java.nio.channels.ReadableByteChannel", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.commands.parsers.utils.ResponseParserUtils", responseParserCode));
         assertTrue(hasImport("org.apache.commons.io.IOUtils", responseParserCode));
         assertTrue(hasImport("java.nio.charset.StandardCharsets", responseParserCode));
@@ -2283,10 +2242,8 @@ public class JavaFunctionalTests {
         assertTrue(hasImport("com.spectralogic.ds3client.models.ListAllMyBucketsResult", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.serializer.XmlOutput", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.networking.WebResponse", responseParserCode));
-        assertTrue(hasImport("com.spectralogic.ds3client.utils.ReadableByteChannelInputStream", responseParserCode));
         assertTrue(hasImport("java.io.IOException", responseParserCode));
         assertTrue(hasImport("java.io.InputStream", responseParserCode));
-        assertTrue(hasImport("java.nio.channels.ReadableByteChannel", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.commands.GetServiceResponse", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.commands.parsers.utils.ResponseParserUtils", responseParserCode));
 
@@ -2337,7 +2294,6 @@ public class JavaFunctionalTests {
         assertTrue(hasImport("com.spectralogic.ds3client.commands.parsers.interfaces.AbstractResponseParser", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.networking.WebResponse", responseParserCode));
         assertTrue(hasImport("java.io.IOException", responseParserCode));
-        assertTrue(hasImport("java.nio.channels.ReadableByteChannel", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.commands.spectrads3.DeleteBucketSpectraS3Response", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.commands.parsers.utils.ResponseParserUtils", responseParserCode));
 
@@ -2396,10 +2352,8 @@ public class JavaFunctionalTests {
         assertTrue(hasImport("com.spectralogic.ds3client.models.BucketList", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.networking.WebResponse", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.serializer.XmlOutput", responseParserCode));
-        assertTrue(hasImport("com.spectralogic.ds3client.utils.ReadableByteChannelInputStream", responseParserCode));
         assertTrue(hasImport("java.io.IOException", responseParserCode));
         assertTrue(hasImport("java.io.InputStream", responseParserCode));
-        assertTrue(hasImport("java.nio.channels.ReadableByteChannel", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.commands.parsers.utils.ResponseParserUtils", responseParserCode));
 
         final BaseParseResponse expectedParsing = new BaseParseResponse(responseName, "BucketList", true);
@@ -2491,7 +2445,6 @@ public class JavaFunctionalTests {
         assertTrue(hasImport("com.spectralogic.ds3client.commands.parsers.interfaces.AbstractResponseParser", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.networking.WebResponse", responseParserCode));
         assertTrue(hasImport("java.io.IOException", responseParserCode));
-        assertTrue(hasImport("java.nio.channels.ReadableByteChannel", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.commands.parsers.utils.ResponseParserUtils", responseParserCode));
 
         final EmptyParseResponse expectedParsing = new EmptyParseResponse(responseName);
@@ -2586,10 +2539,8 @@ public class JavaFunctionalTests {
         assertTrue(hasImport("com.spectralogic.ds3client.models.S3ObjectList", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.networking.WebResponse", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.serializer.XmlOutput", responseParserCode));
-        assertTrue(hasImport("com.spectralogic.ds3client.utils.ReadableByteChannelInputStream", responseParserCode));
         assertTrue(hasImport("java.io.IOException", responseParserCode));
         assertTrue(hasImport("java.io.InputStream", responseParserCode));
-        assertTrue(hasImport("java.nio.channels.ReadableByteChannel", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.commands.parsers.utils.ResponseParserUtils", responseParserCode));
 
         final BaseParseResponse expectedParsing = new BaseParseResponse(responseName, "S3ObjectList", true);

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responseparser/AllocateJobChunkParserGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responseparser/AllocateJobChunkParserGenerator_Test.java
@@ -38,7 +38,7 @@ public class AllocateJobChunkParserGenerator_Test {
 
     @Test
     public void toParsePayloadCode_Test() {
-        final String expected = "try (final InputStream inputStream = new ReadableByteChannelInputStream(blockingByteChannel)) {\n" +
+        final String expected = "try (final InputStream inputStream = response.getResponseStream()) {\n" +
                 "                    final JobChunkApiBean result = XmlOutput.fromXml(inputStream, JobChunkApiBean.class);\n" +
                 "                    return new MyResponse(result, 0, MyResponse.Status.ALLOCATED);\n" +
                 "                }\n";
@@ -58,7 +58,7 @@ public class AllocateJobChunkParserGenerator_Test {
 
     @Test
     public void toResponseCodeList_Test() {
-        final ImmutableList responseCodes = ImmutableList.of(
+        final ImmutableList<Ds3ResponseCode> responseCodes = ImmutableList.of(
                 new Ds3ResponseCode(
                         200,
                         ImmutableList.of(

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responseparser/BaseResponseParserGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responseparser/BaseResponseParserGenerator_Test.java
@@ -42,7 +42,6 @@ public class BaseResponseParserGenerator_Test {
 
     private static void hasRequiredInputs(final ImmutableSet<String> imports) {
         assertTrue(imports.contains("java.io.IOException"));
-        assertTrue(imports.contains("java.nio.channels.ReadableByteChannel"));
         assertTrue(imports.contains("com.spectralogic.ds3client.networking.WebResponse"));
         assertTrue(imports.contains("com.spectralogic.ds3client.commands.TestResponse"));
         assertTrue(imports.contains("com.spectralogic.ds3client.commands.parsers.interfaces.AbstractResponseParser"));
@@ -51,7 +50,7 @@ public class BaseResponseParserGenerator_Test {
 
     @Test
     public void toResponseCodes_Test() {
-        final String expectedProcessingCode = "try (final InputStream inputStream = new ReadableByteChannelInputStream(blockingByteChannel)) {\n" +
+        final String expectedProcessingCode = "try (final InputStream inputStream = response.getResponseStream()) {\n" +
                 "                    final DefaultType result = XmlOutput.fromXml(inputStream, DefaultType.class);\n" +
                 "                    return new TestResponse(result);\n" +
                 "                }\n";
@@ -84,7 +83,7 @@ public class BaseResponseParserGenerator_Test {
                 createEmptyDs3Request(),
                 null);
 
-        assertThat(result.size(), is(6));
+        assertThat(result.size(), is(5));
         hasRequiredInputs(result);
     }
 
@@ -95,7 +94,7 @@ public class BaseResponseParserGenerator_Test {
                 createEmptyDs3Request(),
                 ImmutableList.of());
 
-        assertThat(result.size(), is(6));
+        assertThat(result.size(), is(5));
         hasRequiredInputs(result);
     }
 
@@ -111,12 +110,11 @@ public class BaseResponseParserGenerator_Test {
                 createEmptyDs3Request(),
                 responseCodes);
 
-        assertThat(result.size(), is(11));
+        assertThat(result.size(), is(9));
         hasRequiredInputs(result);
         assertTrue(result.contains("com.spectralogic.ds3client.models.Type_v1"));
         assertTrue(result.contains("com.spectralogic.ds3client.models.Type_v2"));
         assertTrue(result.contains("com.spectralogic.ds3client.serializer.XmlOutput"));
-        assertTrue(result.contains("com.spectralogic.ds3client.utils.ReadableByteChannelInputStream"));
         assertTrue(result.contains("java.io.InputStream"));
     }
 
@@ -124,9 +122,8 @@ public class BaseResponseParserGenerator_Test {
     public void requiredImportList_Test() {
         final ImmutableSet<String> result = requiredImportList();
 
-        assertThat(result.size(), is(3));
+        assertThat(result.size(), is(2));
         assertTrue(result.contains("java.io.IOException"));
-        assertTrue(result.contains("java.nio.channels.ReadableByteChannel"));
         assertTrue(result.contains("com.spectralogic.ds3client.networking.WebResponse"));
     }
 
@@ -191,7 +188,7 @@ public class BaseResponseParserGenerator_Test {
 
     @Test
     public void toResponseCode_StringResponse_Test() {
-        final String expected = "try (final InputStream inputStream = new ReadableByteChannelInputStream(blockingByteChannel)) {\n" +
+        final String expected = "try (final InputStream inputStream = response.getResponseStream()) {\n" +
                 "                    final String result = IOUtils.toString(inputStream, StandardCharsets.UTF_8);\n" +
                 "                    return new TestResponse(result);\n" +
                 "                }\n";
@@ -202,7 +199,7 @@ public class BaseResponseParserGenerator_Test {
 
     @Test
     public void toResponseCode_BaseResponse_Test() {
-        final String expected = "try (final InputStream inputStream = new ReadableByteChannelInputStream(blockingByteChannel)) {\n" +
+        final String expected = "try (final InputStream inputStream = response.getResponseStream()) {\n" +
                 "                    final Type result = XmlOutput.fromXml(inputStream, Type.class);\n" +
                 "                    return new TestResponse(result);\n" +
                 "                }\n";

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responseparser/GetJobChunksReadyParserGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responseparser/GetJobChunksReadyParserGenerator_Test.java
@@ -33,7 +33,7 @@ public class GetJobChunksReadyParserGenerator_Test {
 
     @Test
     public void toParsePayloadCode_Test() {
-        final String expected = "try (final InputStream inputStream = new ReadableByteChannelInputStream(blockingByteChannel)) {\n" +
+        final String expected = "try (final InputStream inputStream = response.getResponseStream()) {\n" +
                 "                    final JobWithChunksApiBean result = XmlOutput.fromXml(inputStream, JobWithChunksApiBean.class);\n" +
                 "                    if (isNullOrEmpty(result.getObjects())) {\n" +
                 "                        return new TestResponse(result, parseRetryAfter(response), TestResponse.Status.RETRYLATER);\n" +

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responseparser/GetObjectParserGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responseparser/GetObjectParserGenerator_Test.java
@@ -39,7 +39,7 @@ public class GetObjectParserGenerator_Test {
                 request,
                 request.getDs3ResponseCodes());
 
-        assertThat(result.size(), is(13));
+        assertThat(result.size(), is(12));
         assertThat(result, hasItem("com.spectralogic.ds3client.commands.GetObjectResponse"));
         assertThat(result, hasItem("com.spectralogic.ds3client.commands.interfaces.MetadataImpl"));
         assertThat(result, hasItem("com.spectralogic.ds3client.commands.parsers.interfaces.AbstractResponseParser"));
@@ -51,7 +51,6 @@ public class GetObjectParserGenerator_Test {
         assertThat(result, hasItem("com.spectralogic.ds3client.utils.PerformanceUtils"));
         assertThat(result, hasItem("java.io.IOException"));
         assertThat(result, hasItem("java.io.InputStream"));
-        assertThat(result, hasItem("java.nio.channels.ReadableByteChannel"));
         assertThat(result, hasItem("java.nio.channels.WritableByteChannel"));
     }
 

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/models/parseresponse/ParseResponse_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/models/parseresponse/ParseResponse_Test.java
@@ -56,7 +56,7 @@ public class ParseResponse_Test {
 
     @Test
     public void stringParseResponse_Test() {
-        final String expected = "try (final InputStream inputStream = new ReadableByteChannelInputStream(blockingByteChannel)) {\n" +
+        final String expected = "try (final InputStream inputStream = response.getResponseStream()) {\n" +
                 "                    final String result = IOUtils.toString(inputStream, StandardCharsets.UTF_8);\n" +
                 "                    return new TestResponse(result);\n" +
                 "                }\n";
@@ -66,7 +66,7 @@ public class ParseResponse_Test {
 
     @Test
     public void stringParseResponse_WithPagination_Test() {
-        final String expected = "try (final InputStream inputStream = new ReadableByteChannelInputStream(blockingByteChannel)) {\n" +
+        final String expected = "try (final InputStream inputStream = response.getResponseStream()) {\n" +
                 "                    final String result = IOUtils.toString(inputStream, StandardCharsets.UTF_8);\n" +
                 "                    return new TestResponse(result, pagingTotalResultCount, pagingTruncated);\n" +
                 "                }\n";
@@ -76,7 +76,7 @@ public class ParseResponse_Test {
 
     @Test
     public void baseParseResponse_Test() {
-        final String expected = "try (final InputStream inputStream = new ReadableByteChannelInputStream(blockingByteChannel)) {\n" +
+        final String expected = "try (final InputStream inputStream = response.getResponseStream()) {\n" +
                 "                    final TestType result = XmlOutput.fromXml(inputStream, TestType.class);\n" +
                 "                    return new TestResponse(result);\n" +
                 "                }\n";
@@ -86,7 +86,7 @@ public class ParseResponse_Test {
 
     @Test
     public void baseParseResponse_WithPagination_Test() {
-        final String expected = "try (final InputStream inputStream = new ReadableByteChannelInputStream(blockingByteChannel)) {\n" +
+        final String expected = "try (final InputStream inputStream = response.getResponseStream()) {\n" +
                 "                    final TestType result = XmlOutput.fromXml(inputStream, TestType.class);\n" +
                 "                    return new TestResponse(result, pagingTotalResultCount, pagingTruncated);\n" +
                 "                }\n";

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/utils/TestHelper.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/utils/TestHelper.java
@@ -284,7 +284,6 @@ public final class TestHelper {
         assertTrue(hasImport("com.spectralogic.ds3client.commands.parsers.interfaces.AbstractResponseParser", code));
         assertTrue(hasImport("com.spectralogic.ds3client.networking.WebResponse", code));
         assertTrue(hasImport("java.io.IOException", code));
-        assertTrue(hasImport("java.nio.channels.ReadableByteChannel", code));
         assertTrue(hasImport("com.spectralogic.ds3client.commands.spectrads3." + responseName, code));
         assertTrue(hasImport("com.spectralogic.ds3client.commands.parsers.utils.ResponseParserUtils", code));
 


### PR DESCRIPTION
**Changes**
Removed BlockingByteChannel in the response parsers as this is only used with the new networking code, and is not supported with the current networking code.