### PR TITLE
Java refactor cleanup

### DIFF
--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/converters/ClientConverter.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/converters/ClientConverter.java
@@ -117,7 +117,7 @@ public class ClientConverter {
                 "                request.getChannel(),\n" +
                 "                this.netClient.getConnectionDetails().getBufferSize(),\n" +
                 "                request.getObjectName())\n" +
-                "                .startResponse(this.netClient.getResponse(request));";
+                "                .response(this.netClient.getResponse(request));";
 
         final String requestName = removePath(ds3Request.getName());
         return new CustomCommand(

--- a/ds3-autogen-java/src/main/resources/tmpls/client/ds3client_impl_template.ftl
+++ b/ds3-autogen-java/src/main/resources/tmpls/client/ds3client_impl_template.ftl
@@ -31,7 +31,7 @@ public class Ds3ClientImpl implements Ds3Client {
     <#list commands as cmd>
     @Override
     public ${cmd.getResponseName()} ${cmd.getName()?uncap_first}(final ${cmd.getRequestName()} request) throws IOException {
-        return new ${cmd.getResponseName()}Parser().startResponse(this.netClient.getResponse(request));
+        return new ${cmd.getResponseName()}Parser().response(this.netClient.getResponse(request));
     }
     </#list>
 

--- a/ds3-autogen-java/src/main/resources/tmpls/responseparser/get_object_parser.ftl
+++ b/ds3-autogen-java/src/main/resources/tmpls/responseparser/get_object_parser.ftl
@@ -4,6 +4,8 @@ package ${packageName};
 
 <#include "../imports.ftl"/>
 
+import static com.spectralogic.ds3client.commands.parsers.utils.ResponseParserUtils.getSizeFromHeaders;
+
 public class ${name} extends ${parentClass}<${responseName}> {
     private final int[] expectedStatusCodes = new int[]{${expectedStatusCodes}};
 

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaFunctionalTests.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaFunctionalTests.java
@@ -53,7 +53,7 @@ import static org.mockito.Mockito.mock;
 public class JavaFunctionalTests {
 
     private static final Logger LOG = LoggerFactory.getLogger(JavaFunctionalTests.class);
-    private final static GeneratedCodeLogger CODE_LOGGER = new GeneratedCodeLogger(FileTypeToLog.RESPONSE, LOG);
+    private final static GeneratedCodeLogger CODE_LOGGER = new GeneratedCodeLogger(FileTypeToLog.PARSER, LOG);
 
     @Rule
     public TemporaryFolder tempFolder = new TemporaryFolder();

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaFunctionalTests.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaFunctionalTests.java
@@ -1232,7 +1232,7 @@ public class JavaFunctionalTests {
                 "                request.getChannel(),\n" +
                 "                this.netClient.getConnectionDetails().getBufferSize(),\n" +
                 "                request.getObjectName())\n" +
-                "                .startResponse(this.netClient.getResponse(request));"));
+                "                .response(this.netClient.getResponse(request));"));
 
         //Test the response parser
         final String responseParserCode = testGeneratedCode.getResponseParserGeneratedCode();

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/converters/ClientConverter_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/converters/ClientConverter_Test.java
@@ -156,7 +156,7 @@ public class ClientConverter_Test {
                 "                request.getChannel(),\n" +
                 "                this.netClient.getConnectionDetails().getBufferSize(),\n" +
                 "                request.getObjectName())\n" +
-                "                .startResponse(this.netClient.getResponse(request));";
+                "                .response(this.netClient.getResponse(request));";
 
         final CustomCommand result = toGetObjectAmazonS3CustomCommand(getRequestAmazonS3GetObject(), getTestDocSpec());
         assertThat(result.getName(), is("GetObjectHandler"));


### PR DESCRIPTION
**Changes**
- Renamed parser function `startResponse` to `response` for clarity
- Added missing import in GetObjectResponseParser template