### PR TITLE
Added OutputStream constructor for GetObjectRequest handler in java module

### DIFF
--- a/ds3-autogen-java/src/main/resources/tmpls/request/get_object_template.ftl
+++ b/ds3-autogen-java/src/main/resources/tmpls/request/get_object_template.ftl
@@ -8,10 +8,13 @@ import com.google.common.collect.ImmutableList;
 import com.spectralogic.ds3client.networking.HttpVerb;
 import com.spectralogic.ds3client.models.common.Range;
 import org.apache.http.entity.ContentType;
+import java.io.OutputStream;
+import java.nio.channels.Channels;
 import java.nio.channels.WritableByteChannel;
 import java.util.Collection;
 <#include "../imports.ftl"/>
 <#include "common/checksum_import.ftl"/>
+
 
 public class ${name} extends ${parentClass} {
 

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaFunctionalTests.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaFunctionalTests.java
@@ -53,7 +53,7 @@ import static org.mockito.Mockito.mock;
 public class JavaFunctionalTests {
 
     private static final Logger LOG = LoggerFactory.getLogger(JavaFunctionalTests.class);
-    private final static GeneratedCodeLogger CODE_LOGGER = new GeneratedCodeLogger(FileTypeToLog.PARSER, LOG);
+    private final static GeneratedCodeLogger CODE_LOGGER = new GeneratedCodeLogger(FileTypeToLog.REQUEST, LOG);
 
     @Rule
     public TemporaryFolder tempFolder = new TemporaryFolder();
@@ -1176,6 +1176,8 @@ public class JavaFunctionalTests {
         assertTrue(hasImport("com.spectralogic.ds3client.networking.HttpVerb", requestGeneratedCode));
         assertTrue(hasImport("com.spectralogic.ds3client.models.common.Range", requestGeneratedCode));
         assertTrue(hasImport("org.apache.http.entity.ContentType", requestGeneratedCode));
+        assertTrue(hasImport("java.io.OutputStream", requestGeneratedCode));
+        assertTrue(hasImport("java.nio.channels.Channels", requestGeneratedCode));
         assertTrue(hasImport("java.nio.channels.WritableByteChannel", requestGeneratedCode));
         assertTrue(hasImport("java.util.Collection", requestGeneratedCode));
         assertTrue(hasImport("java.util.UUID", requestGeneratedCode));
@@ -1200,6 +1202,15 @@ public class JavaFunctionalTests {
         builder.add(new Arguments("long", "Offset"));
         assertTrue(hasConstructor(requestName, builder.build(), requestGeneratedCode));
         assertTrue(hasConstructor(requestName, modifyType(builder.build(), "UUID", "String"), requestGeneratedCode));
+
+        final ImmutableList<Arguments> streamConstructorArgs = ImmutableList.of(
+                new Arguments("String", "BucketName"),
+                new Arguments("String", "ObjectName"),
+                new Arguments("OutputStream", "Stream"),
+                new Arguments("UUID", "Job"),
+                new Arguments("long", "Offset"));
+        assertTrue(hasConstructor(requestName, streamConstructorArgs, requestGeneratedCode));
+        assertTrue(hasConstructor(requestName, modifyType(streamConstructorArgs, "UUID", "String"), requestGeneratedCode));
 
         assertTrue(requestGeneratedCode.contains("this.getQueryParams().put(\"job\", job.toString())"));
         assertTrue(requestGeneratedCode.contains("this.getQueryParams().put(\"offset\", Long.toString(offset))"));

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/requestmodels/GetObjectRequestGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/requestmodels/GetObjectRequestGenerator_Test.java
@@ -24,7 +24,8 @@ import com.spectralogic.ds3autogen.java.models.RequestConstructor;
 import org.junit.Test;
 
 import static com.spectralogic.ds3autogen.java.generators.requestmodels.GetObjectRequestGenerator.createDeprecatedConstructor;
-import static com.spectralogic.ds3autogen.java.generators.requestmodels.GetObjectRequestGenerator.createRegularConstructor;
+import static com.spectralogic.ds3autogen.java.generators.requestmodels.GetObjectRequestGenerator.createChannelConstructor;
+import static com.spectralogic.ds3autogen.java.generators.requestmodels.GetObjectRequestGenerator.createOutputStreamConstructor;
 import static com.spectralogic.ds3autogen.java.test.helpers.RequestGeneratorTestHelper.createSimpleTestDs3Request;
 import static com.spectralogic.ds3autogen.testutil.Ds3ModelFixtures.getRequestAmazonS3GetObject;
 import static org.hamcrest.CoreMatchers.is;
@@ -39,13 +40,12 @@ public class GetObjectRequestGenerator_Test {
         final Ds3Request request = createSimpleTestDs3Request();
 
         final ImmutableList<Arguments> result = generator.toConstructorArgumentsList(request);
-        assertThat(result.size(), is(6));
+        assertThat(result.size(), is(5));
         assertThat(result.get(0).getName(), is("BucketName"));
         assertThat(result.get(1).getName(), is("ObjectName"));
         assertThat(result.get(2).getName(), is("JobId"));
-        assertThat(result.get(3).getName(), is("Channel"));
-        assertThat(result.get(4).getName(), is("Priority"));
-        assertThat(result.get(5).getName(), is("NotificationEndPoint"));
+        assertThat(result.get(3).getName(), is("Priority"));
+        assertThat(result.get(4).getName(), is("NotificationEndPoint"));
     }
 
     @Test
@@ -53,7 +53,7 @@ public class GetObjectRequestGenerator_Test {
         final Ds3Request request = getRequestAmazonS3GetObject();
 
         final ImmutableList<RequestConstructor> result = generator.toConstructorList(request, "", new Ds3DocSpecEmptyImpl());
-        assertThat(result.size(), is(2));
+        assertThat(result.size(), is(3));
 
         //Deprecated Constructor
         final RequestConstructor constructor1 = result.get(0);
@@ -75,7 +75,7 @@ public class GetObjectRequestGenerator_Test {
         final ImmutableList<QueryParam> queryParams1 = constructor1.getQueryParams();
         assertThat(queryParams1.size(), is(0));
 
-        //Regular Constructor
+        //Channel Constructor
         final RequestConstructor constructor2 = result.get(1);
         assertThat(constructor2.isDeprecated(), is(false));
         assertThat(constructor2.getAdditionalLines().size(), is(0));
@@ -84,22 +84,49 @@ public class GetObjectRequestGenerator_Test {
         assertThat(constructorParams2.size(), is(5));
         assertThat(constructorParams2.get(0).getName(), is("BucketName"));
         assertThat(constructorParams2.get(1).getName(), is("ObjectName"));
-        assertThat(constructorParams2.get(2).getName(), is("Channel"));
-        assertThat(constructorParams2.get(3).getName(), is("Job"));
-        assertThat(constructorParams2.get(4).getName(), is("Offset"));
+        assertThat(constructorParams2.get(2).getName(), is("Job"));
+        assertThat(constructorParams2.get(3).getName(), is("Offset"));
+        assertThat(constructorParams2.get(4).getName(), is("Channel"));
 
         final ImmutableList<Arguments> constructorAssignments2 = constructor2.getAssignments();
         assertThat(constructorAssignments2.size(), is(5));
         assertThat(constructorAssignments2.get(0).getName(), is("BucketName"));
         assertThat(constructorAssignments2.get(1).getName(), is("ObjectName"));
-        assertThat(constructorAssignments2.get(2).getName(), is("Channel"));
-        assertThat(constructorAssignments2.get(3).getName(), is("Job"));
-        assertThat(constructorAssignments2.get(4).getName(), is("Offset"));
+        assertThat(constructorAssignments2.get(2).getName(), is("Job"));
+        assertThat(constructorAssignments2.get(3).getName(), is("Offset"));
+        assertThat(constructorAssignments2.get(4).getName(), is("Channel"));
 
         final ImmutableList<QueryParam> queryParams2 = constructor2.getQueryParams();
         assertThat(queryParams2.size(), is(2));
         assertThat(queryParams2.get(0).getName(), is("Job"));
         assertThat(queryParams2.get(1).getName(), is("Offset"));
+
+        //
+        //Channel Constructor
+        final RequestConstructor constructor3 = result.get(2);
+        assertThat(constructor3.isDeprecated(), is(false));
+        assertThat(constructor3.getAdditionalLines().size(), is(1));
+        assertThat(constructor3.getAdditionalLines().get(0), is("this.channel = Channels.newChannel(stream);"));
+
+        final ImmutableList<Arguments> constructorParams3 = constructor3.getParameters();
+        assertThat(constructorParams3.size(), is(5));
+        assertThat(constructorParams3.get(0).getName(), is("BucketName"));
+        assertThat(constructorParams3.get(1).getName(), is("ObjectName"));
+        assertThat(constructorParams3.get(2).getName(), is("Job"));
+        assertThat(constructorParams3.get(3).getName(), is("Offset"));
+        assertThat(constructorParams3.get(4).getName(), is("Stream"));
+
+        final ImmutableList<Arguments> constructorAssignments3 = constructor3.getAssignments();
+        assertThat(constructorAssignments3.size(), is(4));
+        assertThat(constructorAssignments3.get(0).getName(), is("BucketName"));
+        assertThat(constructorAssignments3.get(1).getName(), is("ObjectName"));
+        assertThat(constructorAssignments3.get(2).getName(), is("Job"));
+        assertThat(constructorAssignments3.get(3).getName(), is("Offset"));
+
+        final ImmutableList<QueryParam> queryParams3 = constructor3.getQueryParams();
+        assertThat(queryParams3.size(), is(2));
+        assertThat(queryParams3.get(0).getName(), is("Job"));
+        assertThat(queryParams3.get(1).getName(), is("Offset"));
     }
 
     @Test
@@ -114,12 +141,14 @@ public class GetObjectRequestGenerator_Test {
         assertThat(result.getAdditionalLines().size(), is(0));
 
         final ImmutableList<Arguments> params = result.getParameters();
-        assertThat(params.size(), is(1));
+        assertThat(params.size(), is(2));
         assertThat(params.get(0).getName(), is("Arg1"));
+        assertThat(params.get(1).getName(), is("Channel"));
 
         final ImmutableList<Arguments> assignments = result.getAssignments();
-        assertThat(assignments.size(), is(1));
+        assertThat(assignments.size(), is(2));
         assertThat(assignments.get(0).getName(), is("Arg1"));
+        assertThat(assignments.get(1).getName(), is("Channel"));
 
         final ImmutableList<QueryParam> queryParams = result.getQueryParams();
         assertThat(queryParams.size(), is(1));
@@ -128,7 +157,7 @@ public class GetObjectRequestGenerator_Test {
 
     @Test
     public void createRegularConstructor_Test() {
-        final RequestConstructor result = createRegularConstructor(
+        final RequestConstructor result = createChannelConstructor(
                 ImmutableList.of(new Arguments("Type", "Arg1")),
                 ImmutableList.of(new Arguments("Type", "Arg2")),
                 ImmutableList.of(new QueryParam("Type", "Arg3")),
@@ -139,14 +168,46 @@ public class GetObjectRequestGenerator_Test {
         assertThat(result.getAdditionalLines().size(), is(0));
 
         final ImmutableList<Arguments> params = result.getParameters();
-        assertThat(params.size(), is(2));
+        assertThat(params.size(), is(3));
         assertThat(params.get(0).getName(), is("Arg1"));
         assertThat(params.get(1).getName(), is("Arg2"));
+        assertThat(params.get(2).getName(), is("Channel"));
 
         final ImmutableList<Arguments> assignments = result.getAssignments();
-        assertThat(assignments.size(), is(2));
+        assertThat(assignments.size(), is(3));
         assertThat(assignments.get(0).getName(), is("Arg1"));
         assertThat(assignments.get(1).getName(), is("Arg2"));
+        assertThat(assignments.get(2).getName(), is("Channel"));
+
+        final ImmutableList<QueryParam> queryParams = result.getQueryParams();
+        assertThat(queryParams.size(), is(2));
+        assertThat(queryParams.get(0).getName(), is("Arg3"));
+        assertThat(queryParams.get(1).getName(), is("Arg2"));
+    }
+
+    @Test
+    public void createOutputStreamConstructor_Test() {
+        final RequestConstructor result = createOutputStreamConstructor(
+                ImmutableList.of(new Arguments("Type", "Arg1")),
+                ImmutableList.of(new Arguments("Type", "Arg2")),
+                ImmutableList.of(new QueryParam("Type", "Arg3")),
+                "",
+                new Ds3DocSpecEmptyImpl());
+
+        assertThat(result.isDeprecated(), is(false));
+        assertThat(result.getAdditionalLines().size(), is(1));
+        assertThat(result.getAdditionalLines().get(0), is("this.channel = Channels.newChannel(stream);"));
+
+        final ImmutableList<Arguments> constructorParams = result.getParameters();
+        assertThat(constructorParams.size(), is(3));
+        assertThat(constructorParams.get(0).getName(), is("Arg1"));
+        assertThat(constructorParams.get(1).getName(), is("Arg2"));
+        assertThat(constructorParams.get(2).getName(), is("Stream"));
+
+        final ImmutableList<Arguments> constructorAssignments = result.getAssignments();
+        assertThat(constructorAssignments.size(), is(2));
+        assertThat(constructorAssignments.get(0).getName(), is("Arg1"));
+        assertThat(constructorAssignments.get(1).getName(), is("Arg2"));
 
         final ImmutableList<QueryParam> queryParams = result.getQueryParams();
         assertThat(queryParams.size(), is(2));


### PR DESCRIPTION
**Changes**
- Added generation of a constructor that accepts an OutputStream and internally converts it to a channel for `GetObjectRequest` handler in java module
- Since the `channel` variable is not required for all constructors, the implementation of `toConstructorArgumentsList` was removed and replaced with `toClassVariableArguments` which guarantees that the `channel` var exists within the generated class and has a getter function.

---
Generated Code: GetObjectRequest.java
---
```
/*
 * ******************************************************************************
 *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
 *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 *   this file except in compliance with the License. A copy of the License is located at
 *
 *   http://www.apache.org/licenses/LICENSE-2.0
 *
 *   or in the "license" file accompanying this file.
 *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
 *   specific language governing permissions and limitations under the License.
 * ****************************************************************************
 */

// This code is auto-generated, do not modify
package com.spectralogic.ds3client.commands;

import com.google.common.base.Joiner;
import com.google.common.collect.ImmutableCollection;
import com.google.common.collect.ImmutableList;
import com.spectralogic.ds3client.networking.HttpVerb;
import com.spectralogic.ds3client.models.common.Range;
import org.apache.http.entity.ContentType;
import java.io.OutputStream;
import java.nio.channels.Channels;
import java.nio.channels.WritableByteChannel;
import java.util.Collection;
import com.spectralogic.ds3client.commands.interfaces.AbstractRequest;
import java.util.UUID;
import com.google.common.net.UrlEscapers;
import com.spectralogic.ds3client.models.ChecksumType;

public class GetObjectRequest extends AbstractRequest {

    // Variables
    
    private final WritableByteChannel channel;

    private final String bucketName;

    private final String objectName;

    private String job;

    private long offset;
    private ImmutableCollection<Range> byteRanges = null;
    private ChecksumType checksum = ChecksumType.none();
    private ChecksumType.Type checksumType = ChecksumType.Type.NONE;

    // Constructor
    
    /** @deprecated use {@link #GetObjectRequest(String, String, WritableByteChannel, UUID, long)} instead */
    @Deprecated
    public GetObjectRequest(final String bucketName, final String objectName, final WritableByteChannel channel) {
        this.bucketName = bucketName;
        this.objectName = objectName;
        this.channel = channel;
        

    }

    
    public GetObjectRequest(final String bucketName, final String objectName, final WritableByteChannel channel, final UUID job, final long offset) {
        this.bucketName = bucketName;
        this.objectName = objectName;
        this.job = job.toString();
        this.offset = offset;
        this.channel = channel;
        
        this.getQueryParams().put("job", job.toString());
        this.getQueryParams().put("offset", Long.toString(offset));

    }

    
    public GetObjectRequest(final String bucketName, final String objectName, final WritableByteChannel channel, final String job, final long offset) {
        this.bucketName = bucketName;
        this.objectName = objectName;
        this.job = job;
        this.offset = offset;
        this.channel = channel;
        
        this.getQueryParams().put("job", UrlEscapers.urlFragmentEscaper().escape(job).replace("+", "%2B"));
        this.getQueryParams().put("offset", Long.toString(offset));

    }

    
    public GetObjectRequest(final String bucketName, final String objectName, final UUID job, final long offset, final OutputStream stream) {
        this.bucketName = bucketName;
        this.objectName = objectName;
        this.job = job.toString();
        this.offset = offset;
        this.channel = Channels.newChannel(stream);
        
        this.getQueryParams().put("job", job.toString());
        this.getQueryParams().put("offset", Long.toString(offset));

    }

    
    public GetObjectRequest(final String bucketName, final String objectName, final String job, final long offset, final OutputStream stream) {
        this.bucketName = bucketName;
        this.objectName = objectName;
        this.job = job;
        this.offset = offset;
        this.channel = Channels.newChannel(stream);
        
        this.getQueryParams().put("job", UrlEscapers.urlFragmentEscaper().escape(job).replace("+", "%2B"));
        this.getQueryParams().put("offset", Long.toString(offset));

    }


    public GetObjectRequest withJob(final UUID job) {
        this.job = job.toString();
        this.updateQueryParam("job", job);
        return this;
    }


    public GetObjectRequest withJob(final String job) {
        this.job = job;
        this.updateQueryParam("job", job);
        return this;
    }


    public GetObjectRequest withOffset(final long offset) {
        this.offset = offset;
        this.updateQueryParam("offset", offset);
        return this;
    }



    /**
     * Set a MD5 checksum for the request.
     */
    public GetObjectRequest withChecksum(final ChecksumType checksum) {
        return withChecksum(checksum, ChecksumType.Type.MD5);
    }

    public GetObjectRequest withChecksum(final ChecksumType checksum, final ChecksumType.Type checksumType) {
        this.checksum = checksum;
        this.checksumType = checksumType;
        return this;
    }

    @Override
    public ChecksumType getChecksum() {
        return this.checksum;
    }


    @Override
    public ChecksumType.Type getChecksumType() {
        return this.checksumType;
    }


    /**
     * Sets a Range of bytes that should be retrieved from the object in the
     * format: 'Range: bytes=[start]-[end],...'.
     */
    public GetObjectRequest withByteRanges(final Range... byteRanges) {
        if (byteRanges != null) {
            this.setRanges(ImmutableList.copyOf(byteRanges));
        }
        return this;
    }

    public GetObjectRequest withByteRanges(final Collection<Range> byteRanges) {
        if (byteRanges != null) {
            this.setRanges(ImmutableList.copyOf(byteRanges));
        }
        return this;
    }

    private void setRanges(final ImmutableList<Range> byteRanges) {
        this.byteRanges = byteRanges;
        if (this.getHeaders().containsKey("Range")) {
            this.getHeaders().removeAll("Range");
        }
        this.getHeaders().put("Range", buildRangeHeaderText(byteRanges));
    }

    private static String buildRangeHeaderText(final ImmutableList<Range> byteRanges) {
        final ImmutableList.Builder<String> builder = ImmutableList.builder();
        for (final Range range : byteRanges) {
            builder.add(String.format("%d-%d", range.getStart(), range.getEnd()));
        }
        final Joiner stringJoiner = Joiner.on(",");
        return "bytes=" + stringJoiner.join(builder.build());
    }

    @Override
    public HttpVerb getVerb() {
        return HttpVerb.GET;
    }

    @Override
    public String getPath() {
        return "/" + this.bucketName + "/" + this.objectName;
    }
    @Override
    public String getContentType() {
        return ContentType.APPLICATION_OCTET_STREAM.toString();
    }

    
    public WritableByteChannel getChannel() {
        return this.channel;
    }


    public String getBucketName() {
        return this.bucketName;
    }


    public String getObjectName() {
        return this.objectName;
    }


    public String getJob() {
        return this.job;
    }


    public long getOffset() {
        return this.offset;
    }


    public Collection<Range> getByteRanges() {
        return this.byteRanges;
    }


}
```