### PR TITLE
Generate Python3 module

### DIFF
--- a/ds3-autogen-cli/build.gradle
+++ b/ds3-autogen-cli/build.gradle
@@ -12,4 +12,5 @@ dependencies {
     compile project(':ds3-autogen-java')
     compile project(':ds3-autogen-net')
     compile project(':ds3-autogen-python')
+    compile project(':ds3-autogen-python3')
 }

--- a/ds3-autogen-cli/src/main/java/com/spectralogic/autogen/cli/GeneratorType.java
+++ b/ds3-autogen-cli/src/main/java/com/spectralogic/autogen/cli/GeneratorType.java
@@ -1,5 +1,5 @@
 package com.spectralogic.autogen.cli;
 
 public enum GeneratorType {
-    C, JAVA, NET, PYTHON
+    C, JAVA, NET, PYTHON, PYTHON3
 }

--- a/ds3-autogen-cli/src/main/java/com/spectralogic/autogen/cli/Main.java
+++ b/ds3-autogen-cli/src/main/java/com/spectralogic/autogen/cli/Main.java
@@ -29,6 +29,7 @@ import com.spectralogic.ds3autogen.c.CCodeGenerator;
 import com.spectralogic.ds3autogen.java.JavaCodeGenerator;
 import com.spectralogic.ds3autogen.net.NetCodeGenerator;
 import com.spectralogic.ds3autogen.python.PythonCodeGenerator;
+import com.spectralogic.ds3autogen.python3.Python3CodeGenerator;
 import com.spectralogic.ds3autogen.utils.FileUtilsImpl;
 
 import java.nio.file.Files;
@@ -95,6 +96,9 @@ public class Main {
                 break;
             case PYTHON:
                 generator = new PythonCodeGenerator();
+                break;
+            case PYTHON3:
+                generator = new Python3CodeGenerator();
                 break;
             default:
                 throw new IllegalArgumentException("Unknown generator typeName " + args.getType().toString());

--- a/ds3-autogen-python/build.gradle
+++ b/ds3-autogen-python/build.gradle
@@ -1,4 +1,7 @@
+apply plugin: 'kotlin'
+
 dependencies {
+    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compile project(':ds3-autogen-api')
     compile project(':ds3-autogen-utils')
     compile project(':ds3-autogen-test-util')

--- a/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/generators/request/PutObjectRequestGenerator.java
+++ b/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/generators/request/PutObjectRequestGenerator.java
@@ -27,8 +27,7 @@ import static com.spectralogic.ds3autogen.utils.Helper.camelToUnderscore;
 import static com.spectralogic.ds3autogen.utils.RequestConverterUtil.getNonVoidArgsFromParamList;
 
 /**
- * Creates the python request model for the Amazon request Put Object which has the optional
- * request payload of real_file_name, and which opens the specified file
+ * Creates the python request model for the Amazon request Put Object
  */
 public class PutObjectRequestGenerator extends BaseRequestGenerator {
 

--- a/ds3-autogen-python/src/main/kotlin/com/spectralogic/ds3autogen/python/PythonCodeGeneratorInterface.kt
+++ b/ds3-autogen-python/src/main/kotlin/com/spectralogic/ds3autogen/python/PythonCodeGeneratorInterface.kt
@@ -1,0 +1,50 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.python
+
+import com.google.common.collect.ImmutableList
+import com.google.common.collect.ImmutableMap
+import com.spectralogic.ds3autogen.api.models.apispec.Ds3Request
+import com.spectralogic.ds3autogen.api.models.apispec.Ds3Type
+import com.spectralogic.ds3autogen.api.models.docspec.Ds3DocSpec
+import com.spectralogic.ds3autogen.python.generators.request.BaseRequestGenerator
+import com.spectralogic.ds3autogen.python.generators.request.RequestModelGenerator
+import com.spectralogic.ds3autogen.python.model.request.BaseRequest
+import freemarker.template.Configuration
+import freemarker.template.Template
+import freemarker.template.TemplateException
+import java.io.IOException
+
+interface PythonCodeGeneratorInterface {
+
+    @Throws (IOException::class, TemplateException::class)
+    fun generateCommands(ds3Requests: ImmutableList<Ds3Request>,
+                         typeMap: ImmutableMap<String, Ds3Type>,
+                         docSpec: Ds3DocSpec)
+
+    @Throws (IOException::class)
+    fun getCommandTemplate(config: Configuration) : Template
+
+    fun getPutObjectRequestGenerator() : BaseRequestGenerator
+
+    fun getRequestGenerator(ds3Request: Ds3Request) : BaseRequestGenerator
+
+    fun toRequestModel(ds3Request: Ds3Request,
+                       docSpec: Ds3DocSpec) : BaseRequest
+
+    fun toRequestModelList(ds3Requests: ImmutableList<Ds3Request>,
+                           docSpec: Ds3DocSpec) : ImmutableList<BaseRequest>
+}

--- a/ds3-autogen-python/src/main/resources/tmpls/python/commands/create_client.ftl
+++ b/ds3-autogen-python/src/main/resources/tmpls/python/commands/create_client.ftl
@@ -1,0 +1,18 @@
+def createClientFromEnv():
+  """Build a Client from environment variables.
+
+     Required: DS3_ACCESS_KEY, DS3_SECRET_KEY, DS3_ENDPOINT
+
+     Optional: http_proxy
+  """
+  access_key = os.environ.get('DS3_ACCESS_KEY')
+  secret_key = os.environ.get('DS3_SECRET_KEY')
+  endpoint = os.environ.get('DS3_ENDPOINT')
+  proxy = os.environ.get('http_proxy')
+
+  if None in (access_key, secret_key, endpoint):
+    raise Exception('Required environment variables are not set: DS3_ACCESS_KEY, DS3_SECRET_KEY, DS3_ENDPOINT')
+
+  creds = Credentials(access_key, secret_key)
+  client = Client(endpoint, creds, proxy)
+  return client

--- a/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/PythonCodeGenerator_Test.java
+++ b/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/PythonCodeGenerator_Test.java
@@ -33,6 +33,7 @@ import com.spectralogic.ds3autogen.python.model.client.BaseClient;
 import com.spectralogic.ds3autogen.python.model.request.BaseRequest;
 import com.spectralogic.ds3autogen.python.model.response.BaseResponse;
 import com.spectralogic.ds3autogen.python.model.type.TypeDescriptor;
+import freemarker.template.TemplateModelException;
 import org.junit.Test;
 
 import static com.spectralogic.ds3autogen.python.PythonCodeGenerator.*;
@@ -43,34 +44,45 @@ import static org.junit.Assert.assertThat;
 
 public class PythonCodeGenerator_Test {
 
+    private static final PythonCodeGenerator generator = initTestGenerator();
+
+    private static PythonCodeGenerator initTestGenerator() {
+        try {
+            return new PythonCodeGenerator();
+        } catch (final TemplateModelException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
     private static Ds3DocSpec getTestDocSpec() {
         return new Ds3DocSpecEmptyImpl();
     }
 
     @Test
     public void getRequestGenerator_Test() {
-        assertThat(getRequestGenerator(getRequestCreateNotification()), instanceOf(BaseRequestGenerator.class));
-        assertThat(getRequestGenerator(getEjectStorageDomainRequest()), instanceOf(BaseRequestGenerator.class));
+        assertThat(generator.getRequestGenerator(getRequestCreateNotification()), instanceOf(BaseRequestGenerator.class));
+        assertThat(generator.getRequestGenerator(getEjectStorageDomainRequest()), instanceOf(BaseRequestGenerator.class));
 
-        assertThat(getRequestGenerator(getRequestCreateObject()), instanceOf(PutObjectRequestGenerator.class));
+        assertThat(generator.getRequestGenerator(getRequestCreateObject()), instanceOf(PutObjectRequestGenerator.class));
 
-        assertThat(getRequestGenerator(getRequestAmazonS3GetObject()), instanceOf(GetObjectRequestGenerator.class));
+        assertThat(generator.getRequestGenerator(getRequestAmazonS3GetObject()), instanceOf(GetObjectRequestGenerator.class));
 
-        assertThat(getRequestGenerator(getCreateMultiPartUploadPart()), instanceOf(StringPayloadGenerator.class));
-        assertThat(getRequestGenerator(getGetBlobPersistence()), instanceOf(StringPayloadGenerator.class));
-        assertThat(getRequestGenerator(getReplicatePutJob()), instanceOf(StringPayloadGenerator.class));
+        assertThat(generator.getRequestGenerator(getCreateMultiPartUploadPart()), instanceOf(StringPayloadGenerator.class));
+        assertThat(generator.getRequestGenerator(getGetBlobPersistence()), instanceOf(StringPayloadGenerator.class));
+        assertThat(generator.getRequestGenerator(getReplicatePutJob()), instanceOf(StringPayloadGenerator.class));
 
-        assertThat(getRequestGenerator(getRequestBulkGet()), instanceOf(ObjectsPayloadGenerator.class));
-        assertThat(getRequestGenerator(getRequestBulkPut()), instanceOf(ObjectsPayloadGenerator.class));
-        assertThat(getRequestGenerator(getRequestVerifyPhysicalPlacement()), instanceOf(ObjectsPayloadGenerator.class));
-        assertThat(getRequestGenerator(getEjectStorageDomainBlobsRequest()), instanceOf(ObjectsPayloadGenerator.class));
-        assertThat(getRequestGenerator(getRequestMultiFileDelete()), instanceOf(ObjectsPayloadGenerator.class));
-        assertThat(getRequestGenerator(getCompleteMultipartUploadRequest()), instanceOf(ObjectsPayloadGenerator.class));
+        assertThat(generator.getRequestGenerator(getRequestBulkGet()), instanceOf(ObjectsPayloadGenerator.class));
+        assertThat(generator.getRequestGenerator(getRequestBulkPut()), instanceOf(ObjectsPayloadGenerator.class));
+        assertThat(generator.getRequestGenerator(getRequestVerifyPhysicalPlacement()), instanceOf(ObjectsPayloadGenerator.class));
+        assertThat(generator.getRequestGenerator(getEjectStorageDomainBlobsRequest()), instanceOf(ObjectsPayloadGenerator.class));
+        assertThat(generator.getRequestGenerator(getRequestMultiFileDelete()), instanceOf(ObjectsPayloadGenerator.class));
+        assertThat(generator.getRequestGenerator(getCompleteMultipartUploadRequest()), instanceOf(ObjectsPayloadGenerator.class));
     }
 
     @Test
     public void toRequestModel_Test() {
-        final BaseRequest result = toRequestModel(getRequestCreateNotification(), getTestDocSpec());
+        final BaseRequest result = generator.toRequestModel(getRequestCreateNotification(), getTestDocSpec());
         assertThat(result.getName(), is("CreateJobCreatedNotificationRegistrationRequestHandler"));
         assertThat(result.getPath(), is("'/_rest_/job_created_notification_registration'"));
         assertThat(result.getHttpVerb(), is(HttpVerb.POST.toString()));
@@ -85,13 +97,13 @@ public class PythonCodeGenerator_Test {
 
     @Test
     public void toRequestModelList_NullList_Test() {
-        final ImmutableList<BaseRequest> result = toRequestModelList(null, new Ds3DocSpecEmptyImpl());
+        final ImmutableList<BaseRequest> result = generator.toRequestModelList(null, new Ds3DocSpecEmptyImpl());
         assertThat(result.size(), is(0));
     }
 
     @Test
     public void toRequestModelList_EmptyList_Test() {
-        final ImmutableList<BaseRequest> result = toRequestModelList(ImmutableList.of(), new Ds3DocSpecEmptyImpl());
+        final ImmutableList<BaseRequest> result = generator.toRequestModelList(ImmutableList.of(), new Ds3DocSpecEmptyImpl());
         assertThat(result.size(), is(0));
     }
 
@@ -100,7 +112,7 @@ public class PythonCodeGenerator_Test {
         final ImmutableList<Ds3Request> requests = ImmutableList.of(
                 getRequestCreateNotification());
 
-        final ImmutableList<BaseRequest> result = toRequestModelList(requests, getTestDocSpec());
+        final ImmutableList<BaseRequest> result = generator.toRequestModelList(requests, getTestDocSpec());
         assertThat(result.size(), is(1));
         assertThat(result.get(0).getName(), is("CreateJobCreatedNotificationRegistrationRequestHandler"));
     }

--- a/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/PythonFunctionalTests.java
+++ b/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/PythonFunctionalTests.java
@@ -68,6 +68,9 @@ public class PythonFunctionalTests {
 
         //Test Client
         hasClient(ImmutableList.of(requestName), ds3Code);
+
+        //Test static functions present
+        assertTrue(ds3Code.contains("def createClientFromEnv():"));
     }
 
     @Test

--- a/ds3-autogen-python3/build.gradle
+++ b/ds3-autogen-python3/build.gradle
@@ -1,0 +1,6 @@
+apply plugin: 'kotlin'
+
+dependencies {
+    compile project(':ds3-autogen-python')
+    testCompile project(':ds3-autogen-parser')
+}

--- a/ds3-autogen-python3/build.gradle
+++ b/ds3-autogen-python3/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'kotlin'
 
 dependencies {
+    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compile project(':ds3-autogen-python')
     testCompile project(':ds3-autogen-parser')
 }

--- a/ds3-autogen-python3/src/main/kotlin/com/spectralogic/ds3autogen/python3/Python3CodeGenerator.kt
+++ b/ds3-autogen-python3/src/main/kotlin/com/spectralogic/ds3autogen/python3/Python3CodeGenerator.kt
@@ -1,0 +1,39 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.python3
+
+import com.spectralogic.ds3autogen.python.PythonCodeGenerator
+import com.spectralogic.ds3autogen.python.generators.request.BaseRequestGenerator
+import com.spectralogic.ds3autogen.python3.generators.request.P3PutObjectRequestGenerator
+import freemarker.template.Configuration
+import freemarker.template.Template
+
+class Python3CodeGenerator() : PythonCodeGenerator() {
+
+    /**
+     * Retrieves the base command template used to generate the Python 3 ds3.py
+     */
+    override fun getCommandTemplate(config: Configuration): Template {
+        return config.getTemplate("python3/commands/p3_all_commands.ftl")
+    }
+
+    /**
+     * Retrieves the Python 3 request generator for the Amazon PutObject command
+     */
+    override fun getPutObjectRequestGenerator() : BaseRequestGenerator {
+        return P3PutObjectRequestGenerator()
+    }
+}

--- a/ds3-autogen-python3/src/main/kotlin/com/spectralogic/ds3autogen/python3/generators/request/P3PutObjectRequestGenerator.kt
+++ b/ds3-autogen-python3/src/main/kotlin/com/spectralogic/ds3autogen/python3/generators/request/P3PutObjectRequestGenerator.kt
@@ -1,0 +1,25 @@
+package com.spectralogic.ds3autogen.python3.generators.request
+
+import com.spectralogic.ds3autogen.api.models.apispec.Ds3Request
+import com.spectralogic.ds3autogen.python.generators.request.PutObjectRequestGenerator
+import com.spectralogic.ds3autogen.python.helpers.PythonHelper.pythonIndent
+
+/**
+ * Creates the Python 3 request model for the Amazon request Put Object
+ */
+class P3PutObjectRequestGenerator : PutObjectRequestGenerator() {
+
+    /**
+     * Gets the Python 3 code that handles processing the request payload and headers
+     */
+    override fun getAdditionalContent(ds3Request: Ds3Request, requestName : String) : String {
+        return "if headers is not None:\n" +
+                pythonIndent(3) + "for key, val in headers.items():\n" +
+                pythonIndent(4) + "if val:\n" +
+                pythonIndent(5) + "self.headers[key] = val\n" +
+                pythonIndent(2) + "self.headers['Content-Length'] = length\n" +
+                pythonIndent(2) + "self.object_name = typeCheckString(object_name)\n" +
+                pythonIndent(2) + "object_data = StreamWithLength(stream, length)\n" +
+                pythonIndent(2) + "self.body = object_data\n"
+    }
+}

--- a/ds3-autogen-python3/src/main/resources/tmpls/python3/commands/p3_all_commands.ftl
+++ b/ds3-autogen-python3/src/main/resources/tmpls/python3/commands/p3_all_commands.ftl
@@ -1,30 +1,29 @@
-<#include "../common/copyright.ftl" />
+<#include "../../python/common/copyright.ftl" />
 
 import xml.etree.ElementTree as xmldom
 import os
 
 from abc import ABCMeta
 import posixpath
-from ds3network import *
+from .ds3network import *
 
-<#include "create_client.ftl">
+<#include "../../python/commands/create_client.ftl">
 
 # Models
 
-<#include "static_classes.ftl" />
+<#include "../../python/commands/static_classes.ftl" />
 
 # Type Descriptors
 
-<#include "types/type_descriptor.ftl" />
+<#include "../../python/commands/types/type_descriptor.ftl" />
 
-<#include "types/static_type_descriptors.ftl" />
+<#include "../../python/commands/types/static_type_descriptors.ftl" />
 
-<#include "types/parser_function.ftl" />
+<#include "../../python/commands/types/parser_function.ftl" />
 
 # Request Handlers
 
-class AbstractRequest(object):
-  __metaclass__ = ABCMeta
+class AbstractRequest(object, metaclass=ABCMeta):
   def __init__(self):
     self.path = '/'
     self.http_verb = HttpVerb.GET
@@ -32,12 +31,11 @@ class AbstractRequest(object):
     self.headers = {}
     self.body = None
 
-<#include "requests/request.ftl" />
+<#include "../../python/commands/requests/request.ftl" />
 
 # Response Handlers
 
-class AbstractResponse(object):
-  __metaclass__ = ABCMeta
+class AbstractResponse(object, metaclass=ABCMeta):
   def __init__(self, response, request):
     self.request = request
     self.response = response
@@ -71,10 +69,10 @@ class AbstractResponse(object):
     if not headers:
       return None
     for header in headers:
-      if header[0] == key:
+      if header[0].lower() == key.lower():
         return int(header[1])
     return None
 
-<#include "responses/response.ftl" />
+<#include "../../python/commands/responses/response.ftl" />
 
-<#include "client/client_class.ftl" />
+<#include "../../python/commands/client/client_class.ftl" />

--- a/ds3-autogen-python3/src/test/java/com/spectralogic/ds3autogen/python3/Python3FunctionalTests.java
+++ b/ds3-autogen-python3/src/test/java/com/spectralogic/ds3autogen/python3/Python3FunctionalTests.java
@@ -1,0 +1,90 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.python3;
+
+import com.spectralogic.ds3autogen.api.FileUtils;
+import com.spectralogic.ds3autogen.python3.utils.TestPython3GeneratedCode;
+import com.spectralogic.ds3autogen.testutil.logging.FileTypeToLog;
+import com.spectralogic.ds3autogen.testutil.logging.GeneratedCodeLogger;
+import freemarker.template.TemplateModelException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+public class Python3FunctionalTests {
+
+    private final static Logger LOG = LoggerFactory.getLogger(Python3FunctionalTests.class);
+    private final static GeneratedCodeLogger CODE_LOGGER = new GeneratedCodeLogger(FileTypeToLog.REQUEST, LOG);
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    @Test
+    public void simpleRequest() throws IOException, TemplateModelException {
+        final FileUtils fileUtils = mock(FileUtils.class);
+        final TestPython3GeneratedCode codeGenerator = new TestPython3GeneratedCode(fileUtils);
+
+        codeGenerator.generateCode(fileUtils, "/input/requests/simpleRequest.xml");
+        final String ds3Code = codeGenerator.getDs3Code();
+        assertThat(ds3Code, is(notNullValue()));
+
+        CODE_LOGGER.logFile(ds3Code, FileTypeToLog.REQUEST);
+
+        //test template imports from python 2 module
+        assertTrue(ds3Code.contains("def createClientFromEnv():"));
+
+        //test imports
+        assertTrue(ds3Code.contains("from .ds3network import *"));
+        assertFalse(ds3Code.contains("from ds3network import *"));
+
+        //test abstract request
+        assertTrue(ds3Code.contains("class AbstractRequest(object, metaclass=ABCMeta):"));
+        assertFalse(ds3Code.contains("class AbstractRequest(object):"));
+
+        //test abstract response
+        assertTrue(ds3Code.contains("class AbstractResponse(object, metaclass=ABCMeta):"));
+        assertFalse(ds3Code.contains("class AbstractResponse(object):"));
+
+        assertTrue(ds3Code.contains("if header[0].lower() == key.lower():"));
+        assertFalse(ds3Code.contains("if header[0] == key:"));
+    }
+
+    @Test
+    public void putObjectRequestTest() throws IOException, TemplateModelException {
+        final FileUtils fileUtils = mock(FileUtils.class);
+        final TestPython3GeneratedCode codeGenerator = new TestPython3GeneratedCode(fileUtils);
+
+        codeGenerator.generateCode(fileUtils, "/input/requests/putObject.xml");
+        final String ds3Code = codeGenerator.getDs3Code();
+        assertThat(ds3Code, is(notNullValue()));
+
+        CODE_LOGGER.logFile(ds3Code, FileTypeToLog.REQUEST);
+
+        assertTrue(ds3Code.contains("for key, val in headers.items():"));
+        assertFalse(ds3Code.contains("for key, val in headers.iteritems():"));
+    }
+}

--- a/ds3-autogen-python3/src/test/java/com/spectralogic/ds3autogen/python3/generators/request/P3PutObjectRequestGenerator_Test.java
+++ b/ds3-autogen-python3/src/test/java/com/spectralogic/ds3autogen/python3/generators/request/P3PutObjectRequestGenerator_Test.java
@@ -1,0 +1,41 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.python3.generators.request;
+
+import org.junit.Test;
+
+import static com.spectralogic.ds3autogen.testutil.Ds3ModelFixtures.getRequestCreateObject;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class P3PutObjectRequestGenerator_Test {
+
+    private static final P3PutObjectRequestGenerator generator = new P3PutObjectRequestGenerator();
+
+    @Test
+    public void getAdditionalContent_Test() {
+        final String expected = "if headers is not None:\n" +
+                "      for key, val in headers.items():\n" +
+                "        if val:\n" +
+                "          self.headers[key] = val\n" +
+                "    self.headers['Content-Length'] = length\n" +
+                "    self.object_name = typeCheckString(object_name)\n" +
+                "    object_data = StreamWithLength(stream, length)\n" +
+                "    self.body = object_data\n";
+        final String result = generator.getAdditionalContent(getRequestCreateObject(), "PutObjectRequest");
+        assertThat(result, is(expected));
+    }
+}

--- a/ds3-autogen-python3/src/test/java/com/spectralogic/ds3autogen/python3/utils/TestPython3GeneratedCode.java
+++ b/ds3-autogen-python3/src/test/java/com/spectralogic/ds3autogen/python3/utils/TestPython3GeneratedCode.java
@@ -1,0 +1,94 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.python3.utils;
+
+import com.spectralogic.ds3autogen.Ds3SpecParserImpl;
+import com.spectralogic.ds3autogen.NameMapper;
+import com.spectralogic.ds3autogen.api.CodeGenerator;
+import com.spectralogic.ds3autogen.api.Ds3DocSpecParser;
+import com.spectralogic.ds3autogen.api.Ds3SpecParser;
+import com.spectralogic.ds3autogen.api.FileUtils;
+import com.spectralogic.ds3autogen.api.models.apispec.Ds3ApiSpec;
+import com.spectralogic.ds3autogen.api.models.docspec.Ds3DocSpec;
+import com.spectralogic.ds3autogen.docspec.Ds3DocSpecParserImpl;
+import com.spectralogic.ds3autogen.python3.Python3CodeGenerator;
+import freemarker.template.TemplateModelException;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.mockito.Mockito.when;
+
+public class TestPython3GeneratedCode {
+
+    private final static String BASE_PATH = "./ds3/";
+
+    private final ByteArrayOutputStream ds3OutputStream;
+    private String ds3Code;
+
+    public TestPython3GeneratedCode(
+            final FileUtils fileUtils) throws IOException {
+        this.ds3OutputStream = setupOutputStream(fileUtils, BASE_PATH + "ds3.py");
+    }
+
+    /**
+     * Generates the Python 3 code associated with an input file. This utilizes the
+     * default Ds3DocSpec.
+     * Captured code: ds3.py
+     */
+    public void generateCode(final FileUtils fileUtils, final String inputFileName) throws IOException, TemplateModelException {
+        final Ds3DocSpecParser docSpecParser = new Ds3DocSpecParserImpl(new NameMapper());
+        generateCode(fileUtils, inputFileName, docSpecParser.getDocSpec());
+    }
+
+    /**
+     * Generates the Python 3 code associated with an input file. This allows
+     * for a Ds3DocSpec to be specified
+     * Captured code: ds3.py
+     */
+    public void generateCode(
+            final FileUtils fileUtils,
+            final String inputFileName,
+            final Ds3DocSpec docSpec) throws IOException, TemplateModelException {
+        final Ds3SpecParser parser = new Ds3SpecParserImpl();
+        final Ds3ApiSpec spec = parser.getSpec(TestPython3GeneratedCode.class.getResourceAsStream(inputFileName));
+        final CodeGenerator codeGenerator = new Python3CodeGenerator();
+
+        codeGenerator.generate(spec, fileUtils, Paths.get("."), docSpec);
+
+        ds3Code = new String(ds3OutputStream.toByteArray());
+    }
+
+    /**
+     * Sets up an output stream to capture the content of generated code that would otherwise
+     * have been written to a file
+     */
+    public static ByteArrayOutputStream setupOutputStream(
+            final FileUtils fileUtils,
+            final String pathName) throws IOException {
+        final Path path = Paths.get(pathName);
+
+        final ByteArrayOutputStream outputStream = new ByteArrayOutputStream(1024 * 8);
+        when(fileUtils.getOutputFile(path)).thenReturn(outputStream);
+        return outputStream;
+    }
+
+    public String getDs3Code() {
+        return ds3Code;
+    }
+}

--- a/ds3-autogen-python3/src/test/resources/input/requests/putObject.xml
+++ b/ds3-autogen-python3/src/test/resources/input/requests/putObject.xml
@@ -1,0 +1,60 @@
+<Data>
+    <Contract>
+        <RequestHandlers>
+            <RequestHandler Classification="amazons3" Name="com.spectralogic.s3.server.handler.reqhandler.amazons3.CreateObjectRequestHandler">
+                <Request BucketRequirement="REQUIRED" HttpVerb="PUT" IncludeIdInPath="false" ObjectRequirement="REQUIRED">
+                    <OptionalQueryParams>
+                        <Param Name="Job" Type="java.util.UUID"/>
+                        <Param Name="Offset" Type="long"/>
+                    </OptionalQueryParams>
+                    <RequiredQueryParams/>
+                </Request>
+                <ResponseCodes>
+                    <ResponseCode>
+                        <Code>200</Code>
+                        <ResponseTypes>
+                            <ResponseType Type="null"/>
+                        </ResponseTypes>
+                    </ResponseCode>
+                    <ResponseCode>
+                        <Code>400</Code>
+                        <ResponseTypes>
+                            <ResponseType Type="com.spectralogic.s3.server.domain.HttpErrorResultApiBean"/>
+                        </ResponseTypes>
+                    </ResponseCode>
+                    <ResponseCode>
+                        <Code>404</Code>
+                        <ResponseTypes>
+                            <ResponseType Type="com.spectralogic.s3.server.domain.HttpErrorResultApiBean"/>
+                        </ResponseTypes>
+                    </ResponseCode>
+                    <ResponseCode>
+                        <Code>409</Code>
+                        <ResponseTypes>
+                            <ResponseType Type="com.spectralogic.s3.server.domain.HttpErrorResultApiBean"/>
+                        </ResponseTypes>
+                    </ResponseCode>
+                    <ResponseCode>
+                        <Code>410</Code>
+                        <ResponseTypes>
+                            <ResponseType Type="com.spectralogic.s3.server.domain.HttpErrorResultApiBean"/>
+                        </ResponseTypes>
+                    </ResponseCode>
+                    <ResponseCode>
+                        <Code>411</Code>
+                        <ResponseTypes>
+                            <ResponseType Type="com.spectralogic.s3.server.domain.HttpErrorResultApiBean"/>
+                        </ResponseTypes>
+                    </ResponseCode>
+                    <ResponseCode>
+                        <Code>503</Code>
+                        <ResponseTypes>
+                            <ResponseType Type="com.spectralogic.s3.server.domain.HttpErrorResultApiBean"/>
+                        </ResponseTypes>
+                    </ResponseCode>
+                </ResponseCodes>
+                <Version>1.5B99BA64EAFD43AEC9359E716A93B234</Version>
+            </RequestHandler>
+        </RequestHandlers>
+    </Contract>
+</Data>

--- a/ds3-autogen-python3/src/test/resources/input/requests/simpleRequest.xml
+++ b/ds3-autogen-python3/src/test/resources/input/requests/simpleRequest.xml
@@ -1,0 +1,28 @@
+<Data>
+    <Contract>
+        <RequestHandlers>
+            <RequestHandler Classification="amazons3" Name="com.spectralogic.s3.server.handler.reqhandler.amazons3.SimpleTestRequestHandler">
+                <Request BucketRequirement="REQUIRED" HttpVerb="GET" IncludeIdInPath="false" Operation="START_BULK_PUT" ObjectRequirement="NOT_ALLOWED">
+                    <OptionalQueryParams>
+                        <Param Name="Delimiter" Type="java.lang.String"/>
+                        <Param Name="Marker" Type="java.lang.String"/>
+                        <Param Name="MaxKeys" Type="int"/>
+                        <Param Name="Prefix" Type="java.lang.String"/>
+                    </OptionalQueryParams>
+                    <RequiredQueryParams>
+                        <Param Name="TestVoidParam" Type="void"/>
+                    </RequiredQueryParams>
+                </Request>
+                <ResponseCodes>
+                    <ResponseCode>
+                        <Code>200</Code>
+                        <ResponseTypes>
+                            <ResponseType Type="com.spectralogic.s3.server.domain.BucketObjectsApiBean"/>
+                        </ResponseTypes>
+                    </ResponseCode>
+                </ResponseCodes>
+                <Version>1.3A8DB55ED9BC0A138E7E63E96E6EF55F</Version>
+            </RequestHandler>
+        </RequestHandlers>
+    </Contract>
+</Data>

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,3 @@
 include 'ds3-autogen-parser', 'ds3-autogen-api', 'ds3-autogen-c', 'ds3-autogen-java', 'ds3-autogen-net', 'ds3-autogen-python', 'ds3-autogen-cli', 'ds3-autogen-utils', 'ds3-autogen-test-util'
+include 'ds3-autogen-python3'
+


### PR DESCRIPTION
**Changes**
- Added cli option for `PYTHON3`
- Added Python3 module which depends on Python module
  - Updated static code in Templates:
    - Updated `AbstractRequest` constructor for specifying metaclass
    - Updated `AbstractResponse` constructor for specifying metaclass
    - Updated import to `from .ds3network import *` from `from ds3network import *`
  - Updated request generator:
    - Updated `GetObjectRequest` generation to iterate through lists with `headers.items()` vs `headers.iteritems()`