### PR TITLE
Moved Guards from cli module to utils module

### DIFF
--- a/ds3-autogen-cli/src/main/java/com/spectralogic/autogen/cli/CLI.java
+++ b/ds3-autogen-cli/src/main/java/com/spectralogic/autogen/cli/CLI.java
@@ -15,6 +15,7 @@
 
 package com.spectralogic.autogen.cli;
 
+import com.spectralogic.ds3autogen.utils.Guards;
 import org.apache.commons.cli.*;
 
 public class CLI {

--- a/ds3-autogen-utils/src/main/java/com/spectralogic/ds3autogen/utils/Guards.java
+++ b/ds3-autogen-utils/src/main/java/com/spectralogic/ds3autogen/utils/Guards.java
@@ -1,4 +1,4 @@
-package com.spectralogic.autogen.cli;
+package com.spectralogic.ds3autogen.utils;
 
 public class Guards {
     public static <T, E> T returnIfNull(final E e, final Convert<T, E> converter) throws Exception {


### PR DESCRIPTION
This was done so that the util can be reused within the contract comparator project.