### PR TITLE
Updating Java PutObjectRequest template 

### DIFF
--- a/ds3-autogen-java/src/main/resources/tmpls/request/create_object_template.ftl
+++ b/ds3-autogen-java/src/main/resources/tmpls/request/create_object_template.ftl
@@ -55,7 +55,7 @@ public class ${name} extends ${parentClass} {
         }
         final String modifiedKey;
         if (!key.toLowerCase().startsWith(AMZ_META_HEADER)){
-            modifiedKey = AMZ_META_HEADER + key;
+            modifiedKey = AMZ_META_HEADER + key.toLowerCase();
         } else {
             modifiedKey = key;
         }


### PR DESCRIPTION
The Java SDK file PutObjectRequest was manually modified to make metadata keys' lower case. This updates the associated template within autogen to preserve this change.