### PR TITLE
Update copyright range to include 2017

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-api/src/main/java/com/spectralogic/ds3autogen/api/CodeGenerator.java
+++ b/ds3-autogen-api/src/main/java/com/spectralogic/ds3autogen/api/CodeGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-api/src/main/java/com/spectralogic/ds3autogen/api/Ds3DocSpecParser.java
+++ b/ds3-autogen-api/src/main/java/com/spectralogic/ds3autogen/api/Ds3DocSpecParser.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-api/src/main/java/com/spectralogic/ds3autogen/api/Ds3NameMapperParser.java
+++ b/ds3-autogen-api/src/main/java/com/spectralogic/ds3autogen/api/Ds3NameMapperParser.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-api/src/main/java/com/spectralogic/ds3autogen/api/Ds3SpecParser.java
+++ b/ds3-autogen-api/src/main/java/com/spectralogic/ds3autogen/api/Ds3SpecParser.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-api/src/main/java/com/spectralogic/ds3autogen/api/FileUtils.java
+++ b/ds3-autogen-api/src/main/java/com/spectralogic/ds3autogen/api/FileUtils.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-api/src/main/java/com/spectralogic/ds3autogen/api/ResourceUtils.java
+++ b/ds3-autogen-api/src/main/java/com/spectralogic/ds3autogen/api/ResourceUtils.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-api/src/main/java/com/spectralogic/ds3autogen/api/TypeRenamingConflictException.java
+++ b/ds3-autogen-api/src/main/java/com/spectralogic/ds3autogen/api/TypeRenamingConflictException.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-api/src/main/java/com/spectralogic/ds3autogen/api/models/Arguments.java
+++ b/ds3-autogen-api/src/main/java/com/spectralogic/ds3autogen/api/models/Arguments.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-api/src/main/java/com/spectralogic/ds3autogen/api/models/docspec/Ds3DocSpec.java
+++ b/ds3-autogen-api/src/main/java/com/spectralogic/ds3autogen/api/models/docspec/Ds3DocSpec.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-api/src/main/java/com/spectralogic/ds3autogen/api/models/enums/Action.java
+++ b/ds3-autogen-api/src/main/java/com/spectralogic/ds3autogen/api/models/enums/Action.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-api/src/main/java/com/spectralogic/ds3autogen/api/models/enums/Classification.java
+++ b/ds3-autogen-api/src/main/java/com/spectralogic/ds3autogen/api/models/enums/Classification.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-api/src/main/java/com/spectralogic/ds3autogen/api/models/enums/HttpVerb.java
+++ b/ds3-autogen-api/src/main/java/com/spectralogic/ds3autogen/api/models/enums/HttpVerb.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-api/src/main/java/com/spectralogic/ds3autogen/api/models/enums/Operation.java
+++ b/ds3-autogen-api/src/main/java/com/spectralogic/ds3autogen/api/models/enums/Operation.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-api/src/main/java/com/spectralogic/ds3autogen/api/models/enums/Requirement.java
+++ b/ds3-autogen-api/src/main/java/com/spectralogic/ds3autogen/api/models/enums/Requirement.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-api/src/main/java/com/spectralogic/ds3autogen/api/models/enums/Resource.java
+++ b/ds3-autogen-api/src/main/java/com/spectralogic/ds3autogen/api/models/enums/Resource.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-api/src/main/java/com/spectralogic/ds3autogen/api/models/enums/ResourceType.java
+++ b/ds3-autogen-api/src/main/java/com/spectralogic/ds3autogen/api/models/enums/ResourceType.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-api/src/main/java/com/spectralogic/ds3autogen/api/models/namemap/Ds3NameMapper.java
+++ b/ds3-autogen-api/src/main/java/com/spectralogic/ds3autogen/api/models/namemap/Ds3NameMapper.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-api/src/main/java/com/spectralogic/ds3autogen/api/models/namemap/NameMapperType.java
+++ b/ds3-autogen-api/src/main/java/com/spectralogic/ds3autogen/api/models/namemap/NameMapperType.java
@@ -1,3 +1,18 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
 package com.spectralogic.ds3autogen.api.models.namemap;
 
 /**

--- a/ds3-autogen-api/src/main/java/com/spectralogic/ds3autogen/api/models/namemap/TypeRename.java
+++ b/ds3-autogen-api/src/main/java/com/spectralogic/ds3autogen/api/models/namemap/TypeRename.java
@@ -1,3 +1,18 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
 package com.spectralogic.ds3autogen.api.models.namemap;
 
 public class TypeRename {

--- a/ds3-autogen-api/src/main/kotlin/com/spectralogic/ds3autogen/api/models/apispec/Ds3Annotation.kt
+++ b/ds3-autogen-api/src/main/kotlin/com/spectralogic/ds3autogen/api/models/apispec/Ds3Annotation.kt
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-api/src/main/kotlin/com/spectralogic/ds3autogen/api/models/apispec/Ds3AnnotationElement.kt
+++ b/ds3-autogen-api/src/main/kotlin/com/spectralogic/ds3autogen/api/models/apispec/Ds3AnnotationElement.kt
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-api/src/main/kotlin/com/spectralogic/ds3autogen/api/models/apispec/Ds3ApiSpec.kt
+++ b/ds3-autogen-api/src/main/kotlin/com/spectralogic/ds3autogen/api/models/apispec/Ds3ApiSpec.kt
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-api/src/main/kotlin/com/spectralogic/ds3autogen/api/models/apispec/Ds3Element.kt
+++ b/ds3-autogen-api/src/main/kotlin/com/spectralogic/ds3autogen/api/models/apispec/Ds3Element.kt
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-api/src/main/kotlin/com/spectralogic/ds3autogen/api/models/apispec/Ds3EnumConstant.kt
+++ b/ds3-autogen-api/src/main/kotlin/com/spectralogic/ds3autogen/api/models/apispec/Ds3EnumConstant.kt
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-api/src/main/kotlin/com/spectralogic/ds3autogen/api/models/apispec/Ds3Param.kt
+++ b/ds3-autogen-api/src/main/kotlin/com/spectralogic/ds3autogen/api/models/apispec/Ds3Param.kt
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-api/src/main/kotlin/com/spectralogic/ds3autogen/api/models/apispec/Ds3Property.kt
+++ b/ds3-autogen-api/src/main/kotlin/com/spectralogic/ds3autogen/api/models/apispec/Ds3Property.kt
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-api/src/main/kotlin/com/spectralogic/ds3autogen/api/models/apispec/Ds3Request.kt
+++ b/ds3-autogen-api/src/main/kotlin/com/spectralogic/ds3autogen/api/models/apispec/Ds3Request.kt
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-api/src/main/kotlin/com/spectralogic/ds3autogen/api/models/apispec/Ds3ResponseCode.kt
+++ b/ds3-autogen-api/src/main/kotlin/com/spectralogic/ds3autogen/api/models/apispec/Ds3ResponseCode.kt
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-api/src/main/kotlin/com/spectralogic/ds3autogen/api/models/apispec/Ds3ResponseType.kt
+++ b/ds3-autogen-api/src/main/kotlin/com/spectralogic/ds3autogen/api/models/apispec/Ds3ResponseType.kt
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-api/src/main/kotlin/com/spectralogic/ds3autogen/api/models/apispec/Ds3Type.kt
+++ b/ds3-autogen-api/src/main/kotlin/com/spectralogic/ds3autogen/api/models/apispec/Ds3Type.kt
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-c/build.gradle
+++ b/ds3-autogen-c/build.gradle
@@ -1,3 +1,18 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
 dependencies {
     compile project(':ds3-autogen-api')
     compile project(':ds3-autogen-utils')

--- a/ds3-autogen-c/src/main/java/com/spectralogic/ds3autogen/c/CCodeGenerator.java
+++ b/ds3-autogen-c/src/main/java/com/spectralogic/ds3autogen/c/CCodeGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-c/src/main/java/com/spectralogic/ds3autogen/c/converters/EnumConverter.java
+++ b/ds3-autogen-c/src/main/java/com/spectralogic/ds3autogen/c/converters/EnumConverter.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-c/src/main/java/com/spectralogic/ds3autogen/c/converters/HeaderConverter.java
+++ b/ds3-autogen-c/src/main/java/com/spectralogic/ds3autogen/c/converters/HeaderConverter.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-c/src/main/java/com/spectralogic/ds3autogen/c/converters/ParameterConverter.java
+++ b/ds3-autogen-c/src/main/java/com/spectralogic/ds3autogen/c/converters/ParameterConverter.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-c/src/main/java/com/spectralogic/ds3autogen/c/converters/RequestConverter.java
+++ b/ds3-autogen-c/src/main/java/com/spectralogic/ds3autogen/c/converters/RequestConverter.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-c/src/main/java/com/spectralogic/ds3autogen/c/converters/SourceConverter.java
+++ b/ds3-autogen-c/src/main/java/com/spectralogic/ds3autogen/c/converters/SourceConverter.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-c/src/main/java/com/spectralogic/ds3autogen/c/converters/StructConverter.java
+++ b/ds3-autogen-c/src/main/java/com/spectralogic/ds3autogen/c/converters/StructConverter.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-c/src/main/java/com/spectralogic/ds3autogen/c/helpers/C_TypeHelper.java
+++ b/ds3-autogen-c/src/main/java/com/spectralogic/ds3autogen/c/helpers/C_TypeHelper.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-c/src/main/java/com/spectralogic/ds3autogen/c/helpers/EnumHelper.java
+++ b/ds3-autogen-c/src/main/java/com/spectralogic/ds3autogen/c/helpers/EnumHelper.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-c/src/main/java/com/spectralogic/ds3autogen/c/helpers/ParameterHelper.java
+++ b/ds3-autogen-c/src/main/java/com/spectralogic/ds3autogen/c/helpers/ParameterHelper.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-c/src/main/java/com/spectralogic/ds3autogen/c/helpers/RequestHelper.java
+++ b/ds3-autogen-c/src/main/java/com/spectralogic/ds3autogen/c/helpers/RequestHelper.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-c/src/main/java/com/spectralogic/ds3autogen/c/helpers/StructHelper.java
+++ b/ds3-autogen-c/src/main/java/com/spectralogic/ds3autogen/c/helpers/StructHelper.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-c/src/main/java/com/spectralogic/ds3autogen/c/helpers/StructMemberHelper.java
+++ b/ds3-autogen-c/src/main/java/com/spectralogic/ds3autogen/c/helpers/StructMemberHelper.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-c/src/main/java/com/spectralogic/ds3autogen/c/models/C_Type.java
+++ b/ds3-autogen-c/src/main/java/com/spectralogic/ds3autogen/c/models/C_Type.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-c/src/main/java/com/spectralogic/ds3autogen/c/models/Enum.java
+++ b/ds3-autogen-c/src/main/java/com/spectralogic/ds3autogen/c/models/Enum.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-c/src/main/java/com/spectralogic/ds3autogen/c/models/FreeableType.java
+++ b/ds3-autogen-c/src/main/java/com/spectralogic/ds3autogen/c/models/FreeableType.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-c/src/main/java/com/spectralogic/ds3autogen/c/models/Header.java
+++ b/ds3-autogen-c/src/main/java/com/spectralogic/ds3autogen/c/models/Header.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-c/src/main/java/com/spectralogic/ds3autogen/c/models/Parameter.java
+++ b/ds3-autogen-c/src/main/java/com/spectralogic/ds3autogen/c/models/Parameter.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-c/src/main/java/com/spectralogic/ds3autogen/c/models/ParameterModifier.java
+++ b/ds3-autogen-c/src/main/java/com/spectralogic/ds3autogen/c/models/ParameterModifier.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-c/src/main/java/com/spectralogic/ds3autogen/c/models/ParameterPointerType.java
+++ b/ds3-autogen-c/src/main/java/com/spectralogic/ds3autogen/c/models/ParameterPointerType.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-c/src/main/java/com/spectralogic/ds3autogen/c/models/PrimitiveType.java
+++ b/ds3-autogen-c/src/main/java/com/spectralogic/ds3autogen/c/models/PrimitiveType.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-c/src/main/java/com/spectralogic/ds3autogen/c/models/Request.java
+++ b/ds3-autogen-c/src/main/java/com/spectralogic/ds3autogen/c/models/Request.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-c/src/main/java/com/spectralogic/ds3autogen/c/models/Source.java
+++ b/ds3-autogen-c/src/main/java/com/spectralogic/ds3autogen/c/models/Source.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-c/src/main/java/com/spectralogic/ds3autogen/c/models/Struct.java
+++ b/ds3-autogen-c/src/main/java/com/spectralogic/ds3autogen/c/models/Struct.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-c/src/main/java/com/spectralogic/ds3autogen/c/models/StructMember.java
+++ b/ds3-autogen-c/src/main/java/com/spectralogic/ds3autogen/c/models/StructMember.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-c/src/main/resources/templates/CopyrightHeader.ftl
+++ b/ds3-autogen-c/src/main/resources/templates/CopyrightHeader.ftl
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-c/src/test/java/com/spectralogic/ds3autogen/c/CCodeGeneratorAmazonS3InitRequests_Test.java
+++ b/ds3-autogen-c/src/test/java/com/spectralogic/ds3autogen/c/CCodeGeneratorAmazonS3InitRequests_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-c/src/test/java/com/spectralogic/ds3autogen/c/CCodeGeneratorAmazonS3Requests_Test.java
+++ b/ds3-autogen-c/src/test/java/com/spectralogic/ds3autogen/c/CCodeGeneratorAmazonS3Requests_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-c/src/test/java/com/spectralogic/ds3autogen/c/CCodeGeneratorSpectraS3InitRequests_Test.java
+++ b/ds3-autogen-c/src/test/java/com/spectralogic/ds3autogen/c/CCodeGeneratorSpectraS3InitRequests_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-c/src/test/java/com/spectralogic/ds3autogen/c/CCodeGeneratorSpectraS3Requests_Test.java
+++ b/ds3-autogen-c/src/test/java/com/spectralogic/ds3autogen/c/CCodeGeneratorSpectraS3Requests_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-c/src/test/java/com/spectralogic/ds3autogen/c/CCodeGenerator_Test.java
+++ b/ds3-autogen-c/src/test/java/com/spectralogic/ds3autogen/c/CCodeGenerator_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-c/src/test/java/com/spectralogic/ds3autogen/c/C_Type_Test.java
+++ b/ds3-autogen-c/src/test/java/com/spectralogic/ds3autogen/c/C_Type_Test.java
@@ -1,3 +1,18 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
 package com.spectralogic.ds3autogen.c;
 
 import com.google.common.collect.ImmutableSet;

--- a/ds3-autogen-c/src/test/java/com/spectralogic/ds3autogen/c/EnumHelper_Test.java
+++ b/ds3-autogen-c/src/test/java/com/spectralogic/ds3autogen/c/EnumHelper_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-c/src/test/java/com/spectralogic/ds3autogen/c/HeaderConverter_Test.java
+++ b/ds3-autogen-c/src/test/java/com/spectralogic/ds3autogen/c/HeaderConverter_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-c/src/test/java/com/spectralogic/ds3autogen/c/Parameter_Test.java
+++ b/ds3-autogen-c/src/test/java/com/spectralogic/ds3autogen/c/Parameter_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-c/src/test/java/com/spectralogic/ds3autogen/c/RequestConverter_Test.java
+++ b/ds3-autogen-c/src/test/java/com/spectralogic/ds3autogen/c/RequestConverter_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-c/src/test/java/com/spectralogic/ds3autogen/c/SourceConverter_Test.java
+++ b/ds3-autogen-c/src/test/java/com/spectralogic/ds3autogen/c/SourceConverter_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-c/src/test/java/com/spectralogic/ds3autogen/c/StructConverter_Test.java
+++ b/ds3-autogen-c/src/test/java/com/spectralogic/ds3autogen/c/StructConverter_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-c/src/test/java/com/spectralogic/ds3autogen/c/StructHelper_Test.java
+++ b/ds3-autogen-c/src/test/java/com/spectralogic/ds3autogen/c/StructHelper_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-c/src/test/java/com/spectralogic/ds3autogen/c/StructMemberHelper_Test.java
+++ b/ds3-autogen-c/src/test/java/com/spectralogic/ds3autogen/c/StructMemberHelper_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-cli/build.gradle
+++ b/ds3-autogen-cli/build.gradle
@@ -1,3 +1,18 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
 apply plugin: 'application'
 
 mainClassName = 'com.spectralogic.autogen.cli.Main'

--- a/ds3-autogen-cli/src/main/java/com/spectralogic/autogen/cli/Arguments.java
+++ b/ds3-autogen-cli/src/main/java/com/spectralogic/autogen/cli/Arguments.java
@@ -1,3 +1,18 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
 package com.spectralogic.autogen.cli;
 
 

--- a/ds3-autogen-cli/src/main/java/com/spectralogic/autogen/cli/CLI.java
+++ b/ds3-autogen-cli/src/main/java/com/spectralogic/autogen/cli/CLI.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-cli/src/main/java/com/spectralogic/autogen/cli/GeneratorType.java
+++ b/ds3-autogen-cli/src/main/java/com/spectralogic/autogen/cli/GeneratorType.java
@@ -1,3 +1,18 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
 package com.spectralogic.autogen.cli;
 
 public enum GeneratorType {

--- a/ds3-autogen-cli/src/main/java/com/spectralogic/autogen/cli/Main.java
+++ b/ds3-autogen-cli/src/main/java/com/spectralogic/autogen/cli/Main.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/build.gradle
+++ b/ds3-autogen-java/build.gradle
@@ -1,3 +1,18 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
 dependencies {
     compile project(':ds3-autogen-api')
     compile project(':ds3-autogen-utils')

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/JavaCodeGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/JavaCodeGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/converters/ClientConverter.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/converters/ClientConverter.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/converters/ConvertType.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/converters/ConvertType.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/requestmodels/BaseRequestGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/requestmodels/BaseRequestGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/requestmodels/BulkRequestGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/requestmodels/BulkRequestGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/requestmodels/CompleteMultipartUploadRequestGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/requestmodels/CompleteMultipartUploadRequestGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/requestmodels/CreateNotificationRequestGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/requestmodels/CreateNotificationRequestGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/requestmodels/CreateObjectRequestGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/requestmodels/CreateObjectRequestGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/requestmodels/GetObjectRequestGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/requestmodels/GetObjectRequestGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/requestmodels/MultiFileDeleteRequestGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/requestmodels/MultiFileDeleteRequestGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/requestmodels/NotificationRequestGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/requestmodels/NotificationRequestGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/requestmodels/ObjectsRequestPayloadGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/requestmodels/ObjectsRequestPayloadGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/requestmodels/RequestGeneratorUtils.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/requestmodels/RequestGeneratorUtils.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/requestmodels/RequestModelGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/requestmodels/RequestModelGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/requestmodels/StreamRequestPayloadGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/requestmodels/StreamRequestPayloadGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/requestmodels/StringRequestPayloadGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/requestmodels/StringRequestPayloadGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responsemodels/BaseResponseGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responsemodels/BaseResponseGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responsemodels/BulkResponseGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responsemodels/BulkResponseGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responsemodels/GetObjectResponseGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responsemodels/GetObjectResponseGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responsemodels/HeadBucketResponseGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responsemodels/HeadBucketResponseGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responsemodels/HeadObjectResponseGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responsemodels/HeadObjectResponseGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responsemodels/PaginationResponseGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responsemodels/PaginationResponseGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responsemodels/ResponseGeneratorUtil.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responsemodels/ResponseGeneratorUtil.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responsemodels/ResponseModelGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responsemodels/ResponseModelGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responsemodels/RetryAfterResponseGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responsemodels/RetryAfterResponseGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responseparser/AllocateJobChunkParserGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responseparser/AllocateJobChunkParserGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responseparser/BaseResponseParserGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responseparser/BaseResponseParserGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responseparser/GetJobChunksReadyParserGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responseparser/GetJobChunksReadyParserGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responseparser/GetObjectParserGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responseparser/GetObjectParserGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responseparser/HeadBucketParserGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responseparser/HeadBucketParserGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responseparser/HeadObjectParserGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responseparser/HeadObjectParserGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responseparser/ResponseParserGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responseparser/ResponseParserGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responseparser/ResponseParserGeneratorUtil.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responseparser/ResponseParserGeneratorUtil.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/typemodels/BaseTypeGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/typemodels/BaseTypeGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/typemodels/ChecksumTypeGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/typemodels/ChecksumTypeGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/typemodels/CommonPrefixGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/typemodels/CommonPrefixGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/typemodels/JobsApiBeanTypeGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/typemodels/JobsApiBeanTypeGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/typemodels/TypeGeneratorUtil.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/typemodels/TypeGeneratorUtil.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/typemodels/TypeModelGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/typemodels/TypeModelGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/helpers/CustomElementComparator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/helpers/CustomElementComparator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/helpers/JavaHelper.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/helpers/JavaHelper.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/AnnotationInfo.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/AnnotationInfo.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/Client.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/Client.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/Command.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/Command.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/Constants.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/Constants.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/CustomCommand.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/CustomCommand.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/Element.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/Element.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/EnumConstant.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/EnumConstant.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/Model.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/Model.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/QueryParam.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/QueryParam.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/Request.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/Request.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/RequestConstructor.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/RequestConstructor.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/Response.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/Response.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/ResponseCode.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/ResponseCode.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/ResponseParser.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/ResponseParser.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/Variable.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/Variable.java
@@ -1,3 +1,18 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
 package com.spectralogic.ds3autogen.java.models;
 
 public class Variable {

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/parseresponse/BaseParseResponse.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/parseresponse/BaseParseResponse.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/parseresponse/EmptyParseResponse.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/parseresponse/EmptyParseResponse.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/parseresponse/NullParseResponse.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/parseresponse/NullParseResponse.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/parseresponse/ParseResponse.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/parseresponse/ParseResponse.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/parseresponse/StringParseResponse.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/parseresponse/StringParseResponse.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/withconstructor/BaseWithConstructor.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/withconstructor/BaseWithConstructor.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/withconstructor/BulkWithConstructor.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/withconstructor/BulkWithConstructor.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/withconstructor/MaxUploadSizeWithConstructor.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/withconstructor/MaxUploadSizeWithConstructor.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/withconstructor/VoidWithConstructor.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/withconstructor/VoidWithConstructor.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/withconstructor/WithConstructor.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/withconstructor/WithConstructor.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/utils/CommonRequestGeneratorUtils.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/utils/CommonRequestGeneratorUtils.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/utils/JavaDocGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/utils/JavaDocGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/utils/JavaModuleUtil.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/utils/JavaModuleUtil.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/utils/ResponseAndParserUtils.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/utils/ResponseAndParserUtils.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/utils/WithConstructorUtil.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/utils/WithConstructorUtil.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/main/resources/tmpls/copyright.ftl
+++ b/ds3-autogen-java/src/main/resources/tmpls/copyright.ftl
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaCodeGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaCodeGenerator_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaFunctionalModels_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaFunctionalModels_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaFunctionalTests.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaFunctionalTests.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/converters/ClientConverter_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/converters/ClientConverter_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/converters/ConverterType_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/converters/ConverterType_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/requestmodels/BaseRequestGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/requestmodels/BaseRequestGenerator_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/requestmodels/BulkRequestGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/requestmodels/BulkRequestGenerator_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/requestmodels/CreateNotificationRequestGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/requestmodels/CreateNotificationRequestGenerator_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/requestmodels/CreateObjectRequestGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/requestmodels/CreateObjectRequestGenerator_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/requestmodels/GetObjectRequestGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/requestmodels/GetObjectRequestGenerator_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/requestmodels/MultiFileDeleteRequestGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/requestmodels/MultiFileDeleteRequestGenerator_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/requestmodels/NotificationRequestGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/requestmodels/NotificationRequestGenerator_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/requestmodels/ObjectsRequestPayloadGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/requestmodels/ObjectsRequestPayloadGenerator_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/requestmodels/StreamRequestPayloadGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/requestmodels/StreamRequestPayloadGenerator_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/requestmodels/StringRequestPayloadGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/requestmodels/StringRequestPayloadGenerator_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responsemodels/BaseResponseGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responsemodels/BaseResponseGenerator_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responsemodels/BulkResponseGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responsemodels/BulkResponseGenerator_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responsemodels/GetObjectResponseGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responsemodels/GetObjectResponseGenerator_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responsemodels/HeadBucketResponseGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responsemodels/HeadBucketResponseGenerator_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responsemodels/HeadObjectResponseGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responsemodels/HeadObjectResponseGenerator_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responsemodels/PaginationResponseGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responsemodels/PaginationResponseGenerator_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responsemodels/RetryAfterResponseGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responsemodels/RetryAfterResponseGenerator_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responseparser/AllocateJobChunkParserGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responseparser/AllocateJobChunkParserGenerator_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responseparser/BaseResponseParserGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responseparser/BaseResponseParserGenerator_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responseparser/GetJobChunksReadyParserGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responseparser/GetJobChunksReadyParserGenerator_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responseparser/GetObjectParserGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responseparser/GetObjectParserGenerator_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responseparser/HeadBucketParserGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responseparser/HeadBucketParserGenerator_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responseparser/HeadObjectParserGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responseparser/HeadObjectParserGenerator_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/typemodels/BaseTypeGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/typemodels/BaseTypeGenerator_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/typemodels/ChecksumTypeGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/typemodels/ChecksumTypeGenerator_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/typemodels/CommonPrefixGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/typemodels/CommonPrefixGenerator_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/typemodels/JobsApiBeanTypeGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/typemodels/JobsApiBeanTypeGenerator_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/helpers/JavaHelper_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/helpers/JavaHelper_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/models/parseresponse/ParseResponse_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/models/parseresponse/ParseResponse_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/models/withconstructor/WithConstructor_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/models/withconstructor/WithConstructor_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/test/helpers/Ds3ResponseCodeFixtureTestHelper.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/test/helpers/Ds3ResponseCodeFixtureTestHelper.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/test/helpers/JavaCodeGeneratorTestHelper.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/test/helpers/JavaCodeGeneratorTestHelper.java
@@ -1,3 +1,18 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
 package com.spectralogic.ds3autogen.java.test.helpers;
 
 import static com.spectralogic.ds3autogen.java.utils.TestHelper.*;

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/test/helpers/RequestGeneratorTestHelper.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/test/helpers/RequestGeneratorTestHelper.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/utils/CommonRequestGeneratorUtils_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/utils/CommonRequestGeneratorUtils_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/utils/JavaDocGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/utils/JavaDocGenerator_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/utils/JavaFunctionalDocs_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/utils/JavaFunctionalDocs_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/utils/JavaModuleUtil_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/utils/JavaModuleUtil_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/utils/ResponseAndParserUtil_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/utils/ResponseAndParserUtil_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/utils/ResponseParserGeneratorTestUtil.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/utils/ResponseParserGeneratorTestUtil.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/utils/TestGeneratedCode.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/utils/TestGeneratedCode.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/utils/TestGeneratedCodeHelper.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/utils/TestGeneratedCodeHelper.java
@@ -1,3 +1,18 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
 package com.spectralogic.ds3autogen.java.utils;
 
 import com.spectralogic.ds3autogen.api.FileUtils;

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/utils/TestGeneratedComponentResponseCode.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/utils/TestGeneratedComponentResponseCode.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/utils/TestGeneratedModelCode.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/utils/TestGeneratedModelCode.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/utils/TestHelper.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/utils/TestHelper.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/utils/TestHelper.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/utils/TestHelper.java
@@ -177,7 +177,7 @@ public final class TestHelper {
         final String copyright =
                 "/*\n" +
                 " * ******************************************************************************\n" +
-                " *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.\n" +
+                " *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.\n" +
                 " *   Licensed under the Apache License, Version 2.0 (the \"License\"). You may not use\n" +
                 " *   this file except in compliance with the License. A copy of the License is located at\n" +
                 " *\n" +

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/utils/WithConstructorUtil_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/utils/WithConstructorUtil_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/build.gradle
+++ b/ds3-autogen-net/build.gradle
@@ -1,3 +1,18 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
 dependencies {
     compile project(':ds3-autogen-api')
     compile project(':ds3-autogen-utils')

--- a/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/NetCodeGenerator.java
+++ b/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/NetCodeGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/NetHelper.java
+++ b/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/NetHelper.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/clientmodels/BaseClientGenerator.java
+++ b/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/clientmodels/BaseClientGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/clientmodels/ClientModelGenerator.java
+++ b/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/clientmodels/ClientModelGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/parsers/element/BaseNullableElement.java
+++ b/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/parsers/element/BaseNullableElement.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/parsers/element/NullableAttributeElement.java
+++ b/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/parsers/element/NullableAttributeElement.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/parsers/element/NullableElement.java
+++ b/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/parsers/element/NullableElement.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/parsers/element/NullableEncapsulatedListElement.java
+++ b/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/parsers/element/NullableEncapsulatedListElement.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/parsers/element/NullableListElement.java
+++ b/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/parsers/element/NullableListElement.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/parsers/response/BaseResponseParserGenerator.java
+++ b/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/parsers/response/BaseResponseParserGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/parsers/response/JobListPayloadParserGenerator.java
+++ b/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/parsers/response/JobListPayloadParserGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/parsers/response/ResponseParserModelGenerator.java
+++ b/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/parsers/response/ResponseParserModelGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/parsers/response/ResponseParserModelGeneratorUtils.java
+++ b/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/parsers/response/ResponseParserModelGeneratorUtils.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/parsers/type/BaseTypeParserGenerator.java
+++ b/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/parsers/type/BaseTypeParserGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/parsers/type/JobListParserGenerator.java
+++ b/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/parsers/type/JobListParserGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/parsers/type/TypeParserGenerator.java
+++ b/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/parsers/type/TypeParserGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/parsers/type/TypeParserGeneratorUtils.java
+++ b/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/parsers/type/TypeParserGeneratorUtils.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/parsers/typeset/BaseTypeParserSetGenerator.java
+++ b/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/parsers/typeset/BaseTypeParserSetGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/parsers/typeset/TypeParserSetGenerator.java
+++ b/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/parsers/typeset/TypeParserSetGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/requestmodels/BaseRequestGenerator.java
+++ b/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/requestmodels/BaseRequestGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/requestmodels/BulkGetRequestGenerator.java
+++ b/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/requestmodels/BulkGetRequestGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/requestmodels/BulkPutRequestGenerator.java
+++ b/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/requestmodels/BulkPutRequestGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/requestmodels/GetObjectRequestGenerator.java
+++ b/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/requestmodels/GetObjectRequestGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/requestmodels/ObjectsRequestPayloadGenerator.java
+++ b/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/requestmodels/ObjectsRequestPayloadGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/requestmodels/PutObjectRequestGenerator.java
+++ b/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/requestmodels/PutObjectRequestGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/requestmodels/RequestModelGenerator.java
+++ b/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/requestmodels/RequestModelGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/requestmodels/RequestModelGeneratorUtils.java
+++ b/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/requestmodels/RequestModelGeneratorUtils.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/requestmodels/StreamRequestPayloadGenerator.java
+++ b/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/requestmodels/StreamRequestPayloadGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/requestmodels/StringRequestPayloadGenerator.java
+++ b/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/requestmodels/StringRequestPayloadGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/responsemodels/BaseResponseGenerator.java
+++ b/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/responsemodels/BaseResponseGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/responsemodels/ResponseModelGenerator.java
+++ b/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/responsemodels/ResponseModelGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/typemodels/BaseTypeGenerator.java
+++ b/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/typemodels/BaseTypeGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/typemodels/NoneEnumGenerator.java
+++ b/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/typemodels/NoneEnumGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/typemodels/ObjectsGenerator.java
+++ b/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/typemodels/ObjectsGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/typemodels/TypeModelGenerator.java
+++ b/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/typemodels/TypeModelGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/typemodels/TypeModelGeneratorUtils.java
+++ b/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/typemodels/TypeModelGeneratorUtils.java
@@ -1,3 +1,18 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
 package com.spectralogic.ds3autogen.net.generators.typemodels;
 
 import com.google.common.collect.ImmutableList;

--- a/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/model/client/BaseClient.java
+++ b/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/model/client/BaseClient.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/model/client/BaseCommand.java
+++ b/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/model/client/BaseCommand.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/model/client/PayloadCommand.java
+++ b/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/model/client/PayloadCommand.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/model/client/SpecializedCommand.java
+++ b/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/model/client/SpecializedCommand.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/model/client/VoidCommand.java
+++ b/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/model/client/VoidCommand.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/model/common/NetNullableVariable.java
+++ b/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/model/common/NetNullableVariable.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/model/parser/BaseParser.java
+++ b/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/model/parser/BaseParser.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/model/request/BaseRequest.java
+++ b/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/model/request/BaseRequest.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/model/request/RequestConstructor.java
+++ b/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/model/request/RequestConstructor.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/model/request/WithConstructorVariable.java
+++ b/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/model/request/WithConstructorVariable.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/model/response/BaseResponse.java
+++ b/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/model/response/BaseResponse.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/model/type/BaseType.java
+++ b/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/model/type/BaseType.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/model/type/EnumConstant.java
+++ b/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/model/type/EnumConstant.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/model/typeparser/BaseTypeParserSet.java
+++ b/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/model/typeparser/BaseTypeParserSet.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/model/typeparser/TypeParser.java
+++ b/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/model/typeparser/TypeParser.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/utils/GeneratorUtils.java
+++ b/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/utils/GeneratorUtils.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/utils/NetDocGeneratorUtil.java
+++ b/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/utils/NetDocGeneratorUtil.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/utils/NetNullableElementUtils.java
+++ b/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/utils/NetNullableElementUtils.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/utils/NetNullableVariableUtils.java
+++ b/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/utils/NetNullableVariableUtils.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/main/resources/tmpls/net/common/copyright.ftl
+++ b/ds3-autogen-net/src/main/resources/tmpls/net/common/copyright.ftl
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/NetCodeGenerator_Docs_Test.java
+++ b/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/NetCodeGenerator_Docs_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/NetCodeGenerator_ModelParsers_Test.java
+++ b/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/NetCodeGenerator_ModelParsers_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/NetCodeGenerator_Test.java
+++ b/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/NetCodeGenerator_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/NetCodeGenerator_Types_Test.java
+++ b/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/NetCodeGenerator_Types_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/NetHelper_Test.java
+++ b/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/NetHelper_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/generators/clientmodels/BaseClientGenerator_Test.java
+++ b/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/generators/clientmodels/BaseClientGenerator_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/generators/parsers/response/BaseResponseParserGenerator_Test.java
+++ b/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/generators/parsers/response/BaseResponseParserGenerator_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/generators/parsers/response/JobListPayloadParserGenerator_Test.java
+++ b/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/generators/parsers/response/JobListPayloadParserGenerator_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/generators/parsers/type/BaseTypeParserGenerator_Test.java
+++ b/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/generators/parsers/type/BaseTypeParserGenerator_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/generators/parsers/type/JobListParserGenerator_Test.java
+++ b/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/generators/parsers/type/JobListParserGenerator_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/generators/parsers/typeset/BaseTypeParserSetGenerator_Test.java
+++ b/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/generators/parsers/typeset/BaseTypeParserSetGenerator_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/generators/requestmodels/BaseRequestGenerator_Test.java
+++ b/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/generators/requestmodels/BaseRequestGenerator_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/generators/requestmodels/BulkGetRequestGenerator_Test.java
+++ b/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/generators/requestmodels/BulkGetRequestGenerator_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/generators/requestmodels/BulkPutRequestGenerator_Test.java
+++ b/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/generators/requestmodels/BulkPutRequestGenerator_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/generators/requestmodels/GetObjectRequestGenerator_Test.java
+++ b/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/generators/requestmodels/GetObjectRequestGenerator_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/generators/requestmodels/ObjectsRequestPayloadGenerator_Test.java
+++ b/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/generators/requestmodels/ObjectsRequestPayloadGenerator_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/generators/requestmodels/PutObjectRequestGenerator_Test.java
+++ b/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/generators/requestmodels/PutObjectRequestGenerator_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/generators/requestmodels/StreamRequestPayloadGenerator_Test.java
+++ b/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/generators/requestmodels/StreamRequestPayloadGenerator_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/generators/requestmodels/StringRequestPayloadGenerator_Test.java
+++ b/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/generators/requestmodels/StringRequestPayloadGenerator_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/generators/responsemodels/BaseResponseGenerator_Test.java
+++ b/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/generators/responsemodels/BaseResponseGenerator_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/generators/typemodels/BaseTypeGenerator_Test.java
+++ b/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/generators/typemodels/BaseTypeGenerator_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/generators/typemodels/NoneEnumGenerator_Test.java
+++ b/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/generators/typemodels/NoneEnumGenerator_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/generators/typemodels/ObjectsGenerator_Test.java
+++ b/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/generators/typemodels/ObjectsGenerator_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/model/common/NetNullableVariable_Test.java
+++ b/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/model/common/NetNullableVariable_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/utils/GeneratorUtils_Test.java
+++ b/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/utils/GeneratorUtils_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/utils/NetDocGeneratorUtil_Test.java
+++ b/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/utils/NetDocGeneratorUtil_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/utils/NetNullableElementUtils_Test.java
+++ b/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/utils/NetNullableElementUtils_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/utils/NetNullableVariableUtils_Test.java
+++ b/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/utils/NetNullableVariableUtils_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/utils/TestGenerateCode.java
+++ b/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/utils/TestGenerateCode.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/utils/TestHelper.java
+++ b/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/utils/TestHelper.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-parser/build.gradle
+++ b/ds3-autogen-parser/build.gradle
@@ -1,3 +1,18 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
 dependencies {
     compile     project(':ds3-autogen-api')
     compile     project(':ds3-autogen-utils')

--- a/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/Ds3NameMapperParserImpl.java
+++ b/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/Ds3NameMapperParserImpl.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/Ds3SpecConverter.java
+++ b/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/Ds3SpecConverter.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/Ds3SpecNormalizer.java
+++ b/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/Ds3SpecNormalizer.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/Ds3SpecParserImpl.java
+++ b/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/Ds3SpecParserImpl.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/NameMapper.java
+++ b/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/NameMapper.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/converters/NameConverter.java
+++ b/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/converters/NameConverter.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/converters/RemoveDollarSignConverter.java
+++ b/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/converters/RemoveDollarSignConverter.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/converters/RemoveSpectraInternalConverter.java
+++ b/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/converters/RemoveSpectraInternalConverter.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/converters/ResponseTypeConverter.java
+++ b/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/converters/ResponseTypeConverter.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/converters/UpdateElementsConverter.java
+++ b/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/converters/UpdateElementsConverter.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/docspec/DocSpecConverter.java
+++ b/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/docspec/DocSpecConverter.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/docspec/Ds3DocSpecEmptyImpl.java
+++ b/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/docspec/Ds3DocSpecEmptyImpl.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/docspec/Ds3DocSpecImpl.java
+++ b/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/docspec/Ds3DocSpecImpl.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/docspec/Ds3DocSpecParserImpl.java
+++ b/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/docspec/Ds3DocSpecParserImpl.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/models/EncapsulatingTypeNames.java
+++ b/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/models/EncapsulatingTypeNames.java
@@ -1,3 +1,18 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
 package com.spectralogic.ds3autogen.models;
 
 import java.util.Objects;

--- a/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/models/xml/docspec/ParamDescriptor.java
+++ b/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/models/xml/docspec/ParamDescriptor.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/models/xml/docspec/RawDocSpec.java
+++ b/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/models/xml/docspec/RawDocSpec.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/models/xml/docspec/RequestDescriptor.java
+++ b/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/models/xml/docspec/RequestDescriptor.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/models/xml/namemap/NameMap.java
+++ b/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/models/xml/namemap/NameMap.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/models/xml/namemap/TypeNameMap.java
+++ b/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/models/xml/namemap/TypeNameMap.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/models/xml/rawspec/Annotation.java
+++ b/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/models/xml/rawspec/Annotation.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/models/xml/rawspec/AnnotationElement.java
+++ b/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/models/xml/rawspec/AnnotationElement.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/models/xml/rawspec/Contract.java
+++ b/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/models/xml/rawspec/Contract.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/models/xml/rawspec/Element.java
+++ b/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/models/xml/rawspec/Element.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/models/xml/rawspec/EnumConstant.java
+++ b/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/models/xml/rawspec/EnumConstant.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/models/xml/rawspec/Param.java
+++ b/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/models/xml/rawspec/Param.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/models/xml/rawspec/Property.java
+++ b/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/models/xml/rawspec/Property.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/models/xml/rawspec/RawSpec.java
+++ b/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/models/xml/rawspec/RawSpec.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/models/xml/rawspec/Request.java
+++ b/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/models/xml/rawspec/Request.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/models/xml/rawspec/RequestHandler.java
+++ b/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/models/xml/rawspec/RequestHandler.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/models/xml/rawspec/ResponseCode.java
+++ b/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/models/xml/rawspec/ResponseCode.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/models/xml/rawspec/ResponseType.java
+++ b/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/models/xml/rawspec/ResponseType.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/models/xml/rawspec/Type.java
+++ b/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/models/xml/rawspec/Type.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/utils/NormalizeNameUtil.java
+++ b/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/utils/NormalizeNameUtil.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-parser/src/test/java/com/spectralogic/ds3autogen/Ds3SpecConverter_Test.java
+++ b/ds3-autogen-parser/src/test/java/com/spectralogic/ds3autogen/Ds3SpecConverter_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-parser/src/test/java/com/spectralogic/ds3autogen/Ds3SpecNormalizer_Test.java
+++ b/ds3-autogen-parser/src/test/java/com/spectralogic/ds3autogen/Ds3SpecNormalizer_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-parser/src/test/java/com/spectralogic/ds3autogen/Ds3SpecParserImpl_Test.java
+++ b/ds3-autogen-parser/src/test/java/com/spectralogic/ds3autogen/Ds3SpecParserImpl_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-parser/src/test/java/com/spectralogic/ds3autogen/converters/NameConverter_Test.java
+++ b/ds3-autogen-parser/src/test/java/com/spectralogic/ds3autogen/converters/NameConverter_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-parser/src/test/java/com/spectralogic/ds3autogen/converters/RemoveDollarSignConverter_Test.java
+++ b/ds3-autogen-parser/src/test/java/com/spectralogic/ds3autogen/converters/RemoveDollarSignConverter_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-parser/src/test/java/com/spectralogic/ds3autogen/converters/RemoveSpectraInternalConverter_Test.java
+++ b/ds3-autogen-parser/src/test/java/com/spectralogic/ds3autogen/converters/RemoveSpectraInternalConverter_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-parser/src/test/java/com/spectralogic/ds3autogen/converters/ResponseTypeConverter_Test.java
+++ b/ds3-autogen-parser/src/test/java/com/spectralogic/ds3autogen/converters/ResponseTypeConverter_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-parser/src/test/java/com/spectralogic/ds3autogen/converters/UpdateElementsConverter_Test.java
+++ b/ds3-autogen-parser/src/test/java/com/spectralogic/ds3autogen/converters/UpdateElementsConverter_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-parser/src/test/java/com/spectralogic/ds3autogen/docspec/DocSpecConverter_Test.java
+++ b/ds3-autogen-parser/src/test/java/com/spectralogic/ds3autogen/docspec/DocSpecConverter_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-parser/src/test/java/com/spectralogic/ds3autogen/docspec/Ds3DocSpecEmptyImpl_Test.java
+++ b/ds3-autogen-parser/src/test/java/com/spectralogic/ds3autogen/docspec/Ds3DocSpecEmptyImpl_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-parser/src/test/java/com/spectralogic/ds3autogen/docspec/Ds3DocSpecImpl_Test.java
+++ b/ds3-autogen-parser/src/test/java/com/spectralogic/ds3autogen/docspec/Ds3DocSpecImpl_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-parser/src/test/java/com/spectralogic/ds3autogen/docspec/Ds3DocSpecParserImpl_Test.java
+++ b/ds3-autogen-parser/src/test/java/com/spectralogic/ds3autogen/docspec/Ds3DocSpecParserImpl_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-parser/src/test/java/com/spectralogic/ds3autogen/test/helpers/RemoveDollarSignConverterHelper.java
+++ b/ds3-autogen-parser/src/test/java/com/spectralogic/ds3autogen/test/helpers/RemoveDollarSignConverterHelper.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-parser/src/test/java/com/spectralogic/ds3autogen/test/helpers/ResponseTypeConverterHelper.java
+++ b/ds3-autogen-parser/src/test/java/com/spectralogic/ds3autogen/test/helpers/ResponseTypeConverterHelper.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-parser/src/test/java/com/spectralogic/ds3autogen/test/helpers/SplitConverterTestHelper.java
+++ b/ds3-autogen-parser/src/test/java/com/spectralogic/ds3autogen/test/helpers/SplitConverterTestHelper.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-parser/src/test/java/com/spectralogic/ds3autogen/utils/NormalizeNameUtil_Test.java
+++ b/ds3-autogen-parser/src/test/java/com/spectralogic/ds3autogen/utils/NormalizeNameUtil_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-python/build.gradle
+++ b/ds3-autogen-python/build.gradle
@@ -1,3 +1,18 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
 apply plugin: 'kotlin'
 
 dependencies {

--- a/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/PythonCodeGenerator.java
+++ b/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/PythonCodeGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/generators/client/BaseClientGenerator.java
+++ b/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/generators/client/BaseClientGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/generators/client/ClientModelGenerator.java
+++ b/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/generators/client/ClientModelGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/generators/request/BaseRequestGenerator.java
+++ b/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/generators/request/BaseRequestGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/generators/request/GetObjectRequestGenerator.java
+++ b/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/generators/request/GetObjectRequestGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/generators/request/ObjectsPayloadGenerator.java
+++ b/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/generators/request/ObjectsPayloadGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/generators/request/PutObjectRequestGenerator.java
+++ b/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/generators/request/PutObjectRequestGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/generators/request/RequestModelGenerator.java
+++ b/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/generators/request/RequestModelGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/generators/request/RequestModelGeneratorUtils.java
+++ b/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/generators/request/RequestModelGeneratorUtils.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/generators/request/StringPayloadGenerator.java
+++ b/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/generators/request/StringPayloadGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/generators/response/BaseResponseGenerator.java
+++ b/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/generators/response/BaseResponseGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/generators/response/GetObjectResponseGenerator.java
+++ b/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/generators/response/GetObjectResponseGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/generators/response/HeadResponseGenerator.java
+++ b/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/generators/response/HeadResponseGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/generators/response/PaginationResponseGenerator.java
+++ b/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/generators/response/PaginationResponseGenerator.java
@@ -1,3 +1,18 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
 package com.spectralogic.ds3autogen.python.generators.response;
 
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3Request;

--- a/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/generators/response/ResponseModelGenerator.java
+++ b/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/generators/response/ResponseModelGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/generators/response/ResponseModelGeneratorUtils.java
+++ b/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/generators/response/ResponseModelGeneratorUtils.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/generators/type/BaseTypeGenerator.java
+++ b/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/generators/type/BaseTypeGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/generators/type/TypeModelGenerator.java
+++ b/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/generators/type/TypeModelGenerator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/helpers/PythonHelper.java
+++ b/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/helpers/PythonHelper.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/model/client/BaseClient.java
+++ b/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/model/client/BaseClient.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/model/commands/CommandSet.java
+++ b/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/model/commands/CommandSet.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/model/request/BaseRequest.java
+++ b/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/model/request/BaseRequest.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/model/request/ConstructorParam.java
+++ b/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/model/request/ConstructorParam.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/model/request/queryparam/BaseQueryParam.java
+++ b/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/model/request/queryparam/BaseQueryParam.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/model/request/queryparam/OperationQueryParam.java
+++ b/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/model/request/queryparam/OperationQueryParam.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/model/request/queryparam/QueryParam.java
+++ b/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/model/request/queryparam/QueryParam.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/model/request/queryparam/VoidQueryParam.java
+++ b/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/model/request/queryparam/VoidQueryParam.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/model/response/BaseParsePayload.java
+++ b/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/model/response/BaseParsePayload.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/model/response/BaseResponse.java
+++ b/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/model/response/BaseResponse.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/model/response/NoPayload.java
+++ b/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/model/response/NoPayload.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/model/response/ParsePayload.java
+++ b/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/model/response/ParsePayload.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/model/type/TypeAttribute.java
+++ b/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/model/type/TypeAttribute.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/model/type/TypeContent.java
+++ b/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/model/type/TypeContent.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/model/type/TypeDescriptor.java
+++ b/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/model/type/TypeDescriptor.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/model/type/TypeElement.java
+++ b/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/model/type/TypeElement.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/model/type/TypeElementList.java
+++ b/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/model/type/TypeElementList.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/utils/GeneratorUtils.java
+++ b/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/utils/GeneratorUtils.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/utils/PythonDocGeneratorUtil.java
+++ b/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/utils/PythonDocGeneratorUtil.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-python/src/main/kotlin/com/spectralogic/ds3autogen/python/PythonCodeGeneratorInterface.kt
+++ b/ds3-autogen-python/src/main/kotlin/com/spectralogic/ds3autogen/python/PythonCodeGeneratorInterface.kt
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-python/src/main/resources/tmpls/python/common/copyright.ftl
+++ b/ds3-autogen-python/src/main/resources/tmpls/python/common/copyright.ftl
@@ -1,4 +1,4 @@
-#   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+#   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
 #   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 #   this file except in compliance with the License. A copy of the License is located at
 #

--- a/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/PythonCodeGenerator_Test.java
+++ b/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/PythonCodeGenerator_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/PythonFunctionalDocs_Test.java
+++ b/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/PythonFunctionalDocs_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/PythonFunctionalTests.java
+++ b/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/PythonFunctionalTests.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/generators/client/BaseClientGenerator_Test.java
+++ b/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/generators/client/BaseClientGenerator_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/generators/request/BaseRequestGenerator_Test.java
+++ b/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/generators/request/BaseRequestGenerator_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/generators/request/GetObjectRequestGenerator_Test.java
+++ b/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/generators/request/GetObjectRequestGenerator_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/generators/request/ObjectsPayloadGenerator_Test.java
+++ b/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/generators/request/ObjectsPayloadGenerator_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/generators/request/PutObjectRequestGenerator_Test.java
+++ b/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/generators/request/PutObjectRequestGenerator_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/generators/request/StringPayloadGenerator_Test.java
+++ b/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/generators/request/StringPayloadGenerator_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/generators/response/BaseResponseGenerator_Test.java
+++ b/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/generators/response/BaseResponseGenerator_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/generators/response/GetObjectResponseGenerator_Test.java
+++ b/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/generators/response/GetObjectResponseGenerator_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/generators/response/HeadResponseGenerator_Test.java
+++ b/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/generators/response/HeadResponseGenerator_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/generators/response/PaginationResponseGenerator_Test.java
+++ b/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/generators/response/PaginationResponseGenerator_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/generators/type/BaseTypeGenerator_Test.java
+++ b/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/generators/type/BaseTypeGenerator_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/helpers/PythonHelper_Test.java
+++ b/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/helpers/PythonHelper_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/model/response/ResponsesToPythonCode_Test.java
+++ b/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/model/response/ResponsesToPythonCode_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/model/type/TypesToPythonCode_Test.java
+++ b/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/model/type/TypesToPythonCode_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/utils/FunctionalTestHelper.java
+++ b/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/utils/FunctionalTestHelper.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/utils/GeneratorUtils_Test.java
+++ b/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/utils/GeneratorUtils_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/utils/PythonDocGeneratorUtil_Test.java
+++ b/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/utils/PythonDocGeneratorUtil_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/utils/TestPythonGeneratedCode.java
+++ b/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/utils/TestPythonGeneratedCode.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-python3/build.gradle
+++ b/ds3-autogen-python3/build.gradle
@@ -1,3 +1,18 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
 apply plugin: 'kotlin'
 
 dependencies {

--- a/ds3-autogen-python3/src/main/kotlin/com/spectralogic/ds3autogen/python3/Python3CodeGenerator.kt
+++ b/ds3-autogen-python3/src/main/kotlin/com/spectralogic/ds3autogen/python3/Python3CodeGenerator.kt
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-python3/src/main/kotlin/com/spectralogic/ds3autogen/python3/generators/request/P3PutObjectRequestGenerator.kt
+++ b/ds3-autogen-python3/src/main/kotlin/com/spectralogic/ds3autogen/python3/generators/request/P3PutObjectRequestGenerator.kt
@@ -1,3 +1,18 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
 package com.spectralogic.ds3autogen.python3.generators.request
 
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3Request

--- a/ds3-autogen-python3/src/test/java/com/spectralogic/ds3autogen/python3/Python3FunctionalTests.java
+++ b/ds3-autogen-python3/src/test/java/com/spectralogic/ds3autogen/python3/Python3FunctionalTests.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-python3/src/test/java/com/spectralogic/ds3autogen/python3/generators/request/P3PutObjectRequestGenerator_Test.java
+++ b/ds3-autogen-python3/src/test/java/com/spectralogic/ds3autogen/python3/generators/request/P3PutObjectRequestGenerator_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-python3/src/test/java/com/spectralogic/ds3autogen/python3/utils/TestPython3GeneratedCode.java
+++ b/ds3-autogen-python3/src/test/java/com/spectralogic/ds3autogen/python3/utils/TestPython3GeneratedCode.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-test-util/src/main/java/com/spectralogic/ds3autogen/testutil/Ds3AnnotationMarshaledNameFixture.java
+++ b/ds3-autogen-test-util/src/main/java/com/spectralogic/ds3autogen/testutil/Ds3AnnotationMarshaledNameFixture.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-test-util/src/main/java/com/spectralogic/ds3autogen/testutil/Ds3ModelFixtures.java
+++ b/ds3-autogen-test-util/src/main/java/com/spectralogic/ds3autogen/testutil/Ds3ModelFixtures.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-test-util/src/main/java/com/spectralogic/ds3autogen/testutil/Ds3ModelPartialDataFixture.java
+++ b/ds3-autogen-test-util/src/main/java/com/spectralogic/ds3autogen/testutil/Ds3ModelPartialDataFixture.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-test-util/src/main/java/com/spectralogic/ds3autogen/testutil/Ds3ResponseCodeFixture.java
+++ b/ds3-autogen-test-util/src/main/java/com/spectralogic/ds3autogen/testutil/Ds3ResponseCodeFixture.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-test-util/src/main/java/com/spectralogic/ds3autogen/testutil/logging/FileTypeToLog.java
+++ b/ds3-autogen-test-util/src/main/java/com/spectralogic/ds3autogen/testutil/logging/FileTypeToLog.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-test-util/src/main/java/com/spectralogic/ds3autogen/testutil/logging/GeneratedCodeLogger.java
+++ b/ds3-autogen-test-util/src/main/java/com/spectralogic/ds3autogen/testutil/logging/GeneratedCodeLogger.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-utils/build.gradle
+++ b/ds3-autogen-utils/build.gradle
@@ -1,3 +1,18 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
 dependencies {
     compile project(':ds3-autogen-api')
     compile project(':ds3-autogen-test-util')

--- a/ds3-autogen-utils/src/main/java/com/spectralogic/ds3autogen/utils/ArgumentsUtil.java
+++ b/ds3-autogen-utils/src/main/java/com/spectralogic/ds3autogen/utils/ArgumentsUtil.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-utils/src/main/java/com/spectralogic/ds3autogen/utils/ClientGeneratorUtil.java
+++ b/ds3-autogen-utils/src/main/java/com/spectralogic/ds3autogen/utils/ClientGeneratorUtil.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-utils/src/main/java/com/spectralogic/ds3autogen/utils/ConverterUtil.java
+++ b/ds3-autogen-utils/src/main/java/com/spectralogic/ds3autogen/utils/ConverterUtil.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-utils/src/main/java/com/spectralogic/ds3autogen/utils/Ds3ElementUtil.java
+++ b/ds3-autogen-utils/src/main/java/com/spectralogic/ds3autogen/utils/Ds3ElementUtil.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-utils/src/main/java/com/spectralogic/ds3autogen/utils/Ds3RequestClassificationUtil.java
+++ b/ds3-autogen-utils/src/main/java/com/spectralogic/ds3autogen/utils/Ds3RequestClassificationUtil.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-utils/src/main/java/com/spectralogic/ds3autogen/utils/Ds3RequestUtils.java
+++ b/ds3-autogen-utils/src/main/java/com/spectralogic/ds3autogen/utils/Ds3RequestUtils.java
@@ -1,3 +1,18 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
 package com.spectralogic.ds3autogen.utils;
 
 import com.google.common.collect.ImmutableList;

--- a/ds3-autogen-utils/src/main/java/com/spectralogic/ds3autogen/utils/Ds3TypeClassificationUtil.java
+++ b/ds3-autogen-utils/src/main/java/com/spectralogic/ds3autogen/utils/Ds3TypeClassificationUtil.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-utils/src/main/java/com/spectralogic/ds3autogen/utils/FileUtilsImpl.java
+++ b/ds3-autogen-utils/src/main/java/com/spectralogic/ds3autogen/utils/FileUtilsImpl.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-utils/src/main/java/com/spectralogic/ds3autogen/utils/Guards.java
+++ b/ds3-autogen-utils/src/main/java/com/spectralogic/ds3autogen/utils/Guards.java
@@ -1,3 +1,18 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
 package com.spectralogic.ds3autogen.utils;
 
 public class Guards {

--- a/ds3-autogen-utils/src/main/java/com/spectralogic/ds3autogen/utils/Helper.java
+++ b/ds3-autogen-utils/src/main/java/com/spectralogic/ds3autogen/utils/Helper.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-utils/src/main/java/com/spectralogic/ds3autogen/utils/NormalizingContractNamesUtil.java
+++ b/ds3-autogen-utils/src/main/java/com/spectralogic/ds3autogen/utils/NormalizingContractNamesUtil.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-utils/src/main/java/com/spectralogic/ds3autogen/utils/NullableVariableUtil.java
+++ b/ds3-autogen-utils/src/main/java/com/spectralogic/ds3autogen/utils/NullableVariableUtil.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-utils/src/main/java/com/spectralogic/ds3autogen/utils/ProjectConstants.java
+++ b/ds3-autogen-utils/src/main/java/com/spectralogic/ds3autogen/utils/ProjectConstants.java
@@ -1,3 +1,18 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
 package com.spectralogic.ds3autogen.utils;
 
 public final class ProjectConstants {

--- a/ds3-autogen-utils/src/main/java/com/spectralogic/ds3autogen/utils/RequestConverterUtil.java
+++ b/ds3-autogen-utils/src/main/java/com/spectralogic/ds3autogen/utils/RequestConverterUtil.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-utils/src/main/java/com/spectralogic/ds3autogen/utils/ResponsePayloadUtil.java
+++ b/ds3-autogen-utils/src/main/java/com/spectralogic/ds3autogen/utils/ResponsePayloadUtil.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-utils/src/main/java/com/spectralogic/ds3autogen/utils/TestFileUtilsImpl.java
+++ b/ds3-autogen-utils/src/main/java/com/spectralogic/ds3autogen/utils/TestFileUtilsImpl.java
@@ -1,3 +1,18 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
 package com.spectralogic.ds3autogen.utils;
 
 import com.spectralogic.ds3autogen.api.FileUtils;

--- a/ds3-autogen-utils/src/main/java/com/spectralogic/ds3autogen/utils/collections/GuavaCollectors.java
+++ b/ds3-autogen-utils/src/main/java/com/spectralogic/ds3autogen/utils/collections/GuavaCollectors.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-utils/src/main/java/com/spectralogic/ds3autogen/utils/comparators/CustomArgumentComparator.java
+++ b/ds3-autogen-utils/src/main/java/com/spectralogic/ds3autogen/utils/comparators/CustomArgumentComparator.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-utils/src/main/java/com/spectralogic/ds3autogen/utils/models/NotificationType.java
+++ b/ds3-autogen-utils/src/main/java/com/spectralogic/ds3autogen/utils/models/NotificationType.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-utils/src/test/java/com/spectralogic/ds3autogen/utils/ArgumentsUtil_Test.java
+++ b/ds3-autogen-utils/src/test/java/com/spectralogic/ds3autogen/utils/ArgumentsUtil_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-utils/src/test/java/com/spectralogic/ds3autogen/utils/ClientGeneratorUtil_Test.java
+++ b/ds3-autogen-utils/src/test/java/com/spectralogic/ds3autogen/utils/ClientGeneratorUtil_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-utils/src/test/java/com/spectralogic/ds3autogen/utils/ConverterUtil_Test.java
+++ b/ds3-autogen-utils/src/test/java/com/spectralogic/ds3autogen/utils/ConverterUtil_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-utils/src/test/java/com/spectralogic/ds3autogen/utils/Ds3ElementUtil_Test.java
+++ b/ds3-autogen-utils/src/test/java/com/spectralogic/ds3autogen/utils/Ds3ElementUtil_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-utils/src/test/java/com/spectralogic/ds3autogen/utils/Ds3RequestClassificationUtil_Test.java
+++ b/ds3-autogen-utils/src/test/java/com/spectralogic/ds3autogen/utils/Ds3RequestClassificationUtil_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-utils/src/test/java/com/spectralogic/ds3autogen/utils/Ds3TypeClassificationUtil_Test.java
+++ b/ds3-autogen-utils/src/test/java/com/spectralogic/ds3autogen/utils/Ds3TypeClassificationUtil_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-utils/src/test/java/com/spectralogic/ds3autogen/utils/Helper_Test.java
+++ b/ds3-autogen-utils/src/test/java/com/spectralogic/ds3autogen/utils/Helper_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-utils/src/test/java/com/spectralogic/ds3autogen/utils/NormalizingContractNamesUtil_Test.java
+++ b/ds3-autogen-utils/src/test/java/com/spectralogic/ds3autogen/utils/NormalizingContractNamesUtil_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-utils/src/test/java/com/spectralogic/ds3autogen/utils/NullableVariableUtil_Test.java
+++ b/ds3-autogen-utils/src/test/java/com/spectralogic/ds3autogen/utils/NullableVariableUtil_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-utils/src/test/java/com/spectralogic/ds3autogen/utils/RequestConverterUtil_Test.java
+++ b/ds3-autogen-utils/src/test/java/com/spectralogic/ds3autogen/utils/RequestConverterUtil_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/ds3-autogen-utils/src/test/java/com/spectralogic/ds3autogen/utils/ResponsePayloadUtil_Test.java
+++ b/ds3-autogen-utils/src/test/java/com/spectralogic/ds3autogen/utils/ResponsePayloadUtil_Test.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *


### PR DESCRIPTION
- Updated copyright range in Java files to include 2017
- Updated copyright templates to include 2017 for all language modules