### PR TITLE
SA 173- Generation of non-special-cased Go request handlers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@
  */
 
 buildscript {
-    ext.kotlin_version = '1.0.5-2'
+    ext.kotlin_version = '1.1.1'
 
     repositories {
         mavenCentral()

--- a/ds3-autogen-api/src/main/java/com/spectralogic/ds3autogen/api/models/Arguments.java
+++ b/ds3-autogen-api/src/main/java/com/spectralogic/ds3autogen/api/models/Arguments.java
@@ -15,5 +15,21 @@
 
 package com.spectralogic.ds3autogen.api.models;
 
-data class Arguments(val type: String,
-                     val name: String)
+public class Arguments {
+    final private String type;
+    final private String name;
+
+
+    public Arguments(final String type, final String name) {
+        this.type = type;
+        this.name = name;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/ds3-autogen-api/src/main/kotlin/com/spectralogic/ds3autogen/api/models/Arguments.kt
+++ b/ds3-autogen-api/src/main/kotlin/com/spectralogic/ds3autogen/api/models/Arguments.kt
@@ -15,20 +15,5 @@
 
 package com.spectralogic.ds3autogen.api.models;
 
-public class Arguments {
-    final private String type;
-    final private String name;
-
-    public Arguments(final String type, final String name) {
-        this.type = type;
-        this.name = name;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public String getType() {
-        return type;
-    }
-}
+data class Arguments(val type: String,
+                     val name: String)

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/request/BaseRequestGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/request/BaseRequestGenerator.kt
@@ -1,0 +1,155 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.go.generators.request
+
+import com.google.common.collect.ImmutableList
+import com.spectralogic.ds3autogen.api.models.Arguments
+import com.spectralogic.ds3autogen.api.models.apispec.Ds3Param
+import com.spectralogic.ds3autogen.api.models.apispec.Ds3Request
+import com.spectralogic.ds3autogen.api.models.enums.Operation
+import com.spectralogic.ds3autogen.api.models.enums.Requirement
+import com.spectralogic.ds3autogen.go.models.request.*
+import com.spectralogic.ds3autogen.go.utils.toGoType
+import com.spectralogic.ds3autogen.utils.ConverterUtil
+import com.spectralogic.ds3autogen.utils.ConverterUtil.isEmpty
+import com.spectralogic.ds3autogen.utils.Helper.camelToUnderscore
+import com.spectralogic.ds3autogen.utils.Helper.uncapFirst
+import com.spectralogic.ds3autogen.utils.NormalizingContractNamesUtil
+import com.spectralogic.ds3autogen.utils.RequestConverterUtil
+import com.spectralogic.ds3autogen.utils.collections.GuavaCollectors
+import com.spectralogic.ds3autogen.utils.comparators.CustomArgumentComparator
+
+class BaseRequestGenerator : RequestModelGenerator<Request>, RequestModelGeneratorUtil {
+
+    override fun generate(ds3Request: Ds3Request): Request {
+        val name: String = NormalizingContractNamesUtil.removePath(ds3Request.name)
+        val constructor: Constructor = toConstructor(ds3Request)
+        val structParams: ImmutableList<Arguments> = toStructParams(ds3Request)
+        val withConstructors: ImmutableList<WithConstructor> = toWithConstructors(ds3Request.optionalQueryParams)
+
+        return Request(
+                name,
+                constructor,
+                getHttpVerb(ds3Request.httpVerb),
+                toRequestPath(ds3Request),
+                structParams,
+                withConstructors)
+    }
+
+    //TODO test
+    override fun toWithConstructors(optionalParams: ImmutableList<Ds3Param>?): ImmutableList<WithConstructor> {
+        if (isEmpty(optionalParams)) {
+            return ImmutableList.of()
+        }
+        return optionalParams!!.stream()
+                .map { param -> WithConstructor(
+                        param.name,
+                        toGoType(param.type, param.nullable),
+                        camelToUnderscore(param.name)) }
+                .collect(GuavaCollectors.immutableList())
+    }
+
+    //TODO test
+    override fun toStructParams(ds3Request: Ds3Request): ImmutableList<Arguments> {
+        val builder: ImmutableList.Builder<Arguments> = ImmutableList.builder()
+        if (ds3Request.bucketRequirement != null && ds3Request.bucketRequirement == Requirement.REQUIRED) {
+            builder.add(Arguments("string", "bucketName"))
+        }
+        if (ds3Request.objectRequirement != null && ds3Request.objectRequirement == Requirement.REQUIRED) {
+            builder.add(Arguments("string", "objectName"))
+        }
+        if (RequestConverterUtil.isResourceAnArg(ds3Request.resource, ds3Request.includeInPath)) {
+            val resourceArg: Arguments = RequestConverterUtil.getArgFromResource(ds3Request.resource)
+            builder.add(Arguments(toGoType(resourceArg.type), resourceArg.name))
+        }
+
+        builder.addAll(toGoArgumentsList(removeVoidDs3Params(ds3Request.requiredQueryParams)))
+        builder.addAll(toGoArgumentsList(removeVoidDs3Params(ds3Request.optionalQueryParams)))
+
+        // Sort the arguments
+        return builder.build().stream()
+                .sorted(CustomArgumentComparator())
+                .collect(GuavaCollectors.immutableList())
+    }
+
+    //TODO test
+    override fun toConstructor(ds3Request: Ds3Request): Constructor {
+        val constructorParams: String = toConstructorParams(ds3Request)
+        val queryParams: ImmutableList<VariableInterface> = toQueryParamsList(ds3Request.requiredQueryParams, ds3Request.operation)
+        val structParams: ImmutableList<VariableInterface> = toStructAssignmentParams(ds3Request)
+
+        return Constructor(constructorParams, queryParams, structParams)
+    }
+
+    //TODO test
+    override fun toConstructorParams(ds3Request: Ds3Request): String {
+        val constructorArgs: ImmutableList<Arguments> = toConstructorParamsList(ds3Request)
+        return toFunctionInput(constructorArgs)
+    }
+
+    //TODO test
+    override fun toConstructorParamsList(ds3Request: Ds3Request): ImmutableList<Arguments> {
+        val builder: ImmutableList.Builder<Arguments> = ImmutableList.builder()
+        if (ds3Request.bucketRequirement != null && ds3Request.bucketRequirement == Requirement.REQUIRED) {
+            builder.add(Arguments("string", "bucketName"))
+        }
+        if (ds3Request.objectRequirement != null && ds3Request.objectRequirement == Requirement.REQUIRED) {
+            builder.add(Arguments("string", "objectName"))
+        }
+        if (RequestConverterUtil.isResourceAnArg(ds3Request.resource, ds3Request.includeInPath)) {
+            val resourceArg: Arguments = RequestConverterUtil.getArgFromResource(ds3Request.resource)
+            builder.add(Arguments(toGoType(resourceArg.type), resourceArg.name))
+        }
+
+        builder.addAll(toGoArgumentsList(removeVoidDs3Params(ds3Request.requiredQueryParams)))
+        return builder.build()
+    }
+
+    //TODO test
+    override fun toQueryParamsList(requiredParams: ImmutableList<Ds3Param>?, operation: Operation?): ImmutableList<VariableInterface> {
+        if (ConverterUtil.isEmpty(requiredParams)) {
+            return ImmutableList.of()
+        }
+        val builder: ImmutableList.Builder<VariableInterface> = ImmutableList.builder()
+
+        if (operation != null) {
+            builder.add(Variable("operation", "\"" + operation.toString().toLowerCase() + "\""))
+        }
+
+        builder.addAll(toQueryParamVars(requiredParams))
+
+        return builder.build()
+    }
+
+    //TODO test
+    override fun toStructAssignmentParams(ds3Request: Ds3Request): ImmutableList<VariableInterface> {
+        val builder: ImmutableList.Builder<VariableInterface> = ImmutableList.builder()
+        if (ds3Request.bucketRequirement != null && ds3Request.bucketRequirement == Requirement.REQUIRED) {
+            builder.add(SimpleVariable("bucketName"))
+        }
+        if (ds3Request.objectRequirement != null && ds3Request.objectRequirement == Requirement.REQUIRED) {
+            builder.add(SimpleVariable("objectName"))
+        }
+        if (RequestConverterUtil.isResourceAnArg(ds3Request.resource, ds3Request.includeInPath)) {
+            val resourceArg: Arguments = RequestConverterUtil.getArgFromResource(ds3Request.resource)
+            builder.add(SimpleVariable(uncapFirst(resourceArg.name)))
+        }
+
+        builder.addAll(toSimpleVariables(ds3Request.requiredQueryParams))
+
+        return builder.build()
+    }
+}

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/request/RequestGeneratorUtil.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/request/RequestGeneratorUtil.kt
@@ -1,0 +1,196 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.go.generators.request
+
+import com.google.common.collect.ImmutableList
+import com.spectralogic.ds3autogen.api.models.Arguments
+import com.spectralogic.ds3autogen.api.models.apispec.Ds3Param
+import com.spectralogic.ds3autogen.api.models.apispec.Ds3Request
+import com.spectralogic.ds3autogen.api.models.enums.Classification
+import com.spectralogic.ds3autogen.api.models.enums.HttpVerb
+import com.spectralogic.ds3autogen.api.models.enums.Requirement
+import com.spectralogic.ds3autogen.go.models.request.SimpleVariable
+import com.spectralogic.ds3autogen.go.models.request.Variable
+import com.spectralogic.ds3autogen.go.utils.toGoType
+import com.spectralogic.ds3autogen.utils.ConverterUtil
+import com.spectralogic.ds3autogen.utils.ConverterUtil.isEmpty
+import com.spectralogic.ds3autogen.utils.Ds3RequestClassificationUtil.isNotificationRequest
+import com.spectralogic.ds3autogen.utils.Ds3RequestUtils.hasBucketNameInPath
+import com.spectralogic.ds3autogen.utils.Helper
+import com.spectralogic.ds3autogen.utils.Helper.camelToUnderscore
+import com.spectralogic.ds3autogen.utils.Helper.uncapFirst
+import com.spectralogic.ds3autogen.utils.NormalizingContractNamesUtil.removePath
+import com.spectralogic.ds3autogen.utils.RequestConverterUtil.*
+import com.spectralogic.ds3autogen.utils.collections.GuavaCollectors
+import com.spectralogic.ds3autogen.utils.comparators.CustomArgumentComparator
+import com.spectralogic.ds3autogen.utils.models.NotificationType
+import java.util.stream.Collectors
+
+/**
+ * Contains utilities used in by Go request generators
+ */
+
+
+//TODO test
+/**
+ * Removes parameters with type void
+ */
+fun removeVoidDs3Params(ds3Params: ImmutableList<Ds3Param>?): ImmutableList<Ds3Param> {
+    if (ConverterUtil.isEmpty(ds3Params)) {
+        return ImmutableList.of()
+    }
+    return ds3Params!!.stream()
+            .filter{ param -> !param.type.equals("void", ignoreCase = true) }
+            .collect(GuavaCollectors.immutableList<Ds3Param>())
+}
+
+/**
+ * Converts a list of required Ds3Params into a list of Arguments. Returns an empty list
+ * if requiredParams is null or empty.
+ */
+//TODO test
+fun toGoArgumentsList(requiredParams: ImmutableList<Ds3Param>?): ImmutableList<Arguments> {
+    if (ConverterUtil.isEmpty(requiredParams)) {
+        return ImmutableList.of()
+    }
+    return requiredParams!!.stream()
+            .map(::toGoArgument)
+            .collect(GuavaCollectors.immutableList())
+}
+
+/**
+ * Converts a Ds3Param into an Argument containing the corresponding Go type and parameter name
+ */
+//TODO test
+fun toGoArgument(ds3Param: Ds3Param): Arguments {
+    return Arguments(toGoType(ds3Param.type, ds3Param.nullable), Helper.uncapFirst(ds3Param.name))
+}
+
+/**
+ * Transforms a list of Arguments into a comma-separated list of function input parameters.
+ * The parameters are sorted according to Argument name: BucketName, ObjectName, alphabetical.
+ */
+//TODO test
+fun toFunctionInput(arguments: ImmutableList<Arguments>): String {
+    return arguments.stream()
+            .sorted(CustomArgumentComparator())
+            .map { arg -> uncapFirst(arg.name) + " " + arg.type }
+            .collect(Collectors.joining(", "))
+}
+
+/**
+ * Converts a nullable HttpVerb into a non-nullable HttpVerb and throws an error
+ * if the input is null.
+ */
+//TODO test
+fun getHttpVerb(httpVerb: HttpVerb?): HttpVerb {
+    if (httpVerb == null) {
+        throw IllegalArgumentException("Cannot have a null HttpVerb")
+    }
+    return httpVerb
+}
+
+/**
+ * Converts a list of Ds3Param into a list of Variables which represent query parameter assignments.
+ */
+//TODO test
+fun toQueryParamVars(ds3Params: ImmutableList<Ds3Param>?): ImmutableList<Variable> {
+    if (isEmpty(ds3Params)) {
+        return ImmutableList.of()
+    }
+    return ds3Params!!.stream()
+            .map { param -> Variable(camelToUnderscore(param.name), uncapFirst(param.name)) }
+            .collect(GuavaCollectors.immutableList())
+}
+
+/**
+ * Converts a list of Ds3Params into a list of SimpleVariables. This is used to create
+ * assignments within the request constructor to the request struct.
+ */
+//TODO test and move
+fun toSimpleVariables(ds3Params: ImmutableList<Ds3Param>?): ImmutableList<SimpleVariable> {
+    if (isEmpty(ds3Params)) {
+        return ImmutableList.of()
+    }
+    return ds3Params!!.stream()
+            .map{ param -> SimpleVariable(uncapFirst(param.name)) }
+            .collect(GuavaCollectors.immutableList())
+}
+
+/**
+ * Creates the Go request path code for a Ds3 request
+ */
+//TODO test
+fun toRequestPath(ds3Request: Ds3Request): String {
+    if (ds3Request.classification == Classification.amazons3) {
+        return getAmazonS3RequestPath(ds3Request)
+    }
+    if (ds3Request.classification == Classification.spectrads3) {
+        return getSpectraDs3RequestPath(ds3Request)
+    }
+
+    throw IllegalArgumentException("Unsupported classification: " + ds3Request.classification.toString())
+}
+
+/**
+ * Creates the Go request path code for an AmazonS3 request
+ */
+//TODO test
+fun getAmazonS3RequestPath(ds3Request: Ds3Request): String {
+    val builder = StringBuilder()
+    if (ds3Request.classification != Classification.amazons3) {
+        return builder.toString()
+    }
+    builder.append("\"/\"")
+    if (ds3Request.bucketRequirement == Requirement.REQUIRED) {
+        builder.append(" + bucketName")
+    }
+    if (ds3Request.objectRequirement == Requirement.REQUIRED) {
+        builder.append(" + \"/\" + objectName")
+    }
+    return builder.toString()
+}
+
+/**
+ * Creates the Go request path code for a SpectraS3 request
+ */
+//TODO test
+fun getSpectraDs3RequestPath(ds3Request: Ds3Request): String {
+    val builder = StringBuilder()
+    if (ds3Request.classification != Classification.spectrads3) {
+        return builder.toString()
+    }
+    if (ds3Request.resource == null) {
+        return builder.append("\"/_rest_/\"").toString()
+    }
+
+    builder.append("\"/_rest_/").append(ds3Request.resource!!.toString().toLowerCase())
+    if (isNotificationRequest(ds3Request)
+            && ds3Request.includeInPath
+            && (getNotificationType(ds3Request) == NotificationType.DELETE || getNotificationType(ds3Request) == NotificationType.GET)) {
+        builder.append("/\"").append(" + notificationId")
+    } else if (hasBucketNameInPath(ds3Request)) {
+        builder.append("/\"").append(" + bucketName")
+    } else if (isResourceAnArg(ds3Request.resource, ds3Request.includeInPath)) {
+        val resourceArg = getArgFromResource(ds3Request.resource)
+        val requestName = removePath(ds3Request.name)
+        builder.append("/\"").append(" + ").append(uncapFirst(requestName))
+                .append(".").append(uncapFirst(resourceArg.name))
+    } else {
+        builder.append("\"")
+    }
+    return builder.toString()
+}

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/request/RequestModelGeneratorUtil.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/request/RequestModelGeneratorUtil.kt
@@ -60,7 +60,14 @@ interface RequestModelGeneratorUtil {
     fun toStructParams(ds3Request: Ds3Request): ImmutableList<Arguments>
 
     /**
-     * Creates the list of request handler with-constructors that each set an optional request parameter
+     * Creates the list of request handler with-constructors that have non-nullable parameters.
+     * Each constructor sets an optional request parameter
      */
     fun toWithConstructors(optionalParams: ImmutableList<Ds3Param>?): ImmutableList<WithConstructor>
+
+    /**
+     * Creates the list of request handler with-constructors that have nullable parameters.
+     * Each constructor sets an optional request parameter
+     */
+    fun toNullableWithConstructors(optionalParams: ImmutableList<Ds3Param>?): ImmutableList<WithConstructor>
 }

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/request/RequestModelGeneratorUtil.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/request/RequestModelGeneratorUtil.kt
@@ -1,0 +1,66 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.go.generators.request
+
+import com.google.common.collect.ImmutableList
+import com.spectralogic.ds3autogen.api.models.Arguments
+import com.spectralogic.ds3autogen.api.models.apispec.Ds3Param
+import com.spectralogic.ds3autogen.api.models.apispec.Ds3Request
+import com.spectralogic.ds3autogen.api.models.enums.Operation
+import com.spectralogic.ds3autogen.go.models.request.Constructor
+import com.spectralogic.ds3autogen.go.models.request.VariableInterface
+import com.spectralogic.ds3autogen.go.models.request.WithConstructor
+
+interface RequestModelGeneratorUtil {
+
+    /**
+     * Creates the request handler constructor
+     */
+    fun toConstructor(ds3Request: Ds3Request): Constructor
+
+    /**
+     * Creates the comma separated list of constructor parameters.
+     */
+    fun toConstructorParams(ds3Request: Ds3Request): String
+
+    /**
+     * Creates the list of constructor parameters. Note that the Arguments type
+     * is used for ensuring proper sort order: BucketName, ObjectName, Alphabetical.
+     */
+    fun toConstructorParamsList(ds3Request: Ds3Request): ImmutableList<Arguments>
+
+    /**
+     * Creates the list of variables that are added to the query parameters list
+     * within the request handler constructor.
+     */
+    fun toQueryParamsList(requiredParams: ImmutableList<Ds3Param>?, operation: Operation?): ImmutableList<VariableInterface>
+
+    /**
+     * Creates the list of variables that are assigned to the request handler struct
+     * within the constructor.
+     */
+    fun toStructAssignmentParams(ds3Request: Ds3Request): ImmutableList<VariableInterface>
+
+    /**
+     * Creates the list of arguments that composes the request handler struct
+     */
+    fun toStructParams(ds3Request: Ds3Request): ImmutableList<Arguments>
+
+    /**
+     * Creates the list of request handler with-constructors that each set an optional request parameter
+     */
+    fun toWithConstructors(optionalParams: ImmutableList<Ds3Param>?): ImmutableList<WithConstructor>
+}

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/models/request/Constructor.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/models/request/Constructor.kt
@@ -17,12 +17,9 @@ package com.spectralogic.ds3autogen.go.models.request
 
 import com.google.common.collect.ImmutableList
 import com.spectralogic.ds3autogen.api.models.Arguments
-import com.spectralogic.ds3autogen.api.models.enums.HttpVerb
 
-data class Request(
-        val name: String,
-        val constructor: Constructor,
-        val httpVerb: HttpVerb,
-        val path: String,
-        val structParams: ImmutableList<Arguments>, // Parameters that make up the request handler struct
-        val withConstructors: ImmutableList<WithConstructor>)
+data class Constructor(
+        val constructorParams: String,
+        val queryParams: ImmutableList<VariableInterface>,
+        val structParams: ImmutableList<VariableInterface>
+)

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/models/request/Request.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/models/request/Request.kt
@@ -25,4 +25,5 @@ data class Request(
         val httpVerb: HttpVerb,
         val path: String,
         val structParams: ImmutableList<Arguments>, // Parameters that make up the request handler struct
-        val withConstructors: ImmutableList<WithConstructor>)
+        val withConstructors: ImmutableList<WithConstructor>, // Optional constructors with non-null type
+        val nullableWithConstructors: ImmutableList<WithConstructor>) // Optional constructors that can be null

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/models/request/Variable.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/models/request/Variable.kt
@@ -13,8 +13,24 @@
  * ****************************************************************************
  */
 
-package com.spectralogic.ds3autogen.go.generators.request;
+package com.spectralogic.ds3autogen.go.models.request
 
-public interface RequestModelGeneratorUtil {
-    //TODO implement as needed
+/**
+ * Interface for a variable and its assignment.
+ */
+interface VariableInterface {
+    val name: String
+    val assignment: String
 }
+
+/**
+ * A variable where the name and assignment value are the same.
+ */
+class SimpleVariable(override val name: String) : VariableInterface {
+    override val assignment: String get() { return name }
+}
+
+/**
+ * A query param where the name and assignment values are different.
+ */
+class Variable(override val name: String, override val assignment: String) : VariableInterface

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/models/request/Variable.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/models/request/Variable.kt
@@ -26,11 +26,11 @@ interface VariableInterface {
 /**
  * A variable where the name and assignment value are the same.
  */
-class SimpleVariable(override val name: String) : VariableInterface {
+data class SimpleVariable(override val name: String) : VariableInterface {
     override val assignment: String get() { return name }
 }
 
 /**
  * A query param where the name and assignment values are different.
  */
-class Variable(override val name: String, override val assignment: String) : VariableInterface
+data class Variable(override val name: String, override val assignment: String) : VariableInterface

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/models/request/WithConstructor.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/models/request/WithConstructor.kt
@@ -21,4 +21,6 @@ package com.spectralogic.ds3autogen.go.models.request
  */
 data class WithConstructor(val name: String, // name of the optional parameter
                            val type: String, // type of the optional parameter
-                           val key: String)  // the key used to set the optional query parameter
+                           val key: String, // the key used to set the optional query parameter
+                           val assignment: String) { //The value to assign to the query parameter entry
+}

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/models/request/WithConstructor.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/models/request/WithConstructor.kt
@@ -13,18 +13,12 @@
  * ****************************************************************************
  */
 
-package com.spectralogic.ds3autogen.go.generators.request;
+package com.spectralogic.ds3autogen.go.models.request
 
-import com.spectralogic.ds3autogen.api.models.apispec.Ds3Request;
-import com.spectralogic.ds3autogen.go.models.request.Request;
-import com.spectralogic.ds3autogen.utils.NormalizingContractNamesUtil;
-
-public class BaseRequestGenerator implements RequestModelGenerator<Request>, RequestModelGeneratorUtil {
-
-    @Override
-    public Request generate(final Ds3Request ds3Request) {
-        final String name = NormalizingContractNamesUtil.removePath(ds3Request.getName());
-
-        return new Request(name);
-    }
-}
+/**
+ * Represents a with-constructor used to set optional parameters in a
+ * request handler.
+ */
+data class WithConstructor(val name: String, // name of the optional parameter
+                           val type: String, // type of the optional parameter
+                           val key: String)  // the key used to set the optional query parameter

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/utils/GoTypeUtil.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/utils/GoTypeUtil.kt
@@ -15,6 +15,7 @@
 
 package com.spectralogic.ds3autogen.go.utils
 
+import com.spectralogic.ds3autogen.utils.ConverterUtil.hasContent
 import com.spectralogic.ds3autogen.utils.NormalizingContractNamesUtil
 
 /**
@@ -26,21 +27,18 @@ import com.spectralogic.ds3autogen.utils.NormalizingContractNamesUtil
  * Retrieves the Go type associated with the specific contract type. If the
  * type is nullable, then the Go type is a pointer to the specified type.
  */
-//TODO test
 fun toGoType(contractType: String, nullable: Boolean): String {
     val goType: String = toGoType(contractType)
-    if (nullable) {
+    if (nullable && hasContent(goType)) {
         return "*" + goType
-    } else {
-        return goType
     }
+    return goType
 }
 
 /**
  * Retrieves the Go type associated with the specified contract type. Nullability
  * is not taken into account
  */
-//TODO test
 fun toGoType(contractType: String): String {
     val type: String = NormalizingContractNamesUtil.removePath(contractType)
     when (type.toLowerCase()) {
@@ -49,7 +47,7 @@ fun toGoType(contractType: String): String {
         "string", "uuid" -> return "string"
         "double" -> return "float64"
         "long" -> return "int64"
-        "void" -> return "" //TODO ???
+        "void" -> return ""
         else -> return type
     }
 }

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/utils/GoTypeUtil.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/utils/GoTypeUtil.kt
@@ -1,0 +1,55 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.go.utils
+
+import com.spectralogic.ds3autogen.utils.NormalizingContractNamesUtil
+
+/**
+ * Contains utils for converting contract types into their corresponding Go types
+ */
+
+
+/**
+ * Retrieves the Go type associated with the specific contract type. If the
+ * type is nullable, then the Go type is a pointer to the specified type.
+ */
+//TODO test
+fun toGoType(contractType: String, nullable: Boolean): String {
+    val goType: String = toGoType(contractType)
+    if (nullable) {
+        return "*" + goType
+    } else {
+        return goType
+    }
+}
+
+/**
+ * Retrieves the Go type associated with the specified contract type. Nullability
+ * is not taken into account
+ */
+//TODO test
+fun toGoType(contractType: String): String {
+    val type: String = NormalizingContractNamesUtil.removePath(contractType)
+    when (type.toLowerCase()) {
+        "boolean" -> return "bool"
+        "integer", "int" -> return "int"
+        "string", "uuid" -> return "string"
+        "double" -> return "float64"
+        "long" -> return "int64"
+        "void" -> return "" //TODO ???
+        else -> return type
+    }
+}

--- a/ds3-autogen-go/src/main/resources/tmpls/request/request_template.ftl
+++ b/ds3-autogen-go/src/main/resources/tmpls/request/request_template.ftl
@@ -9,5 +9,54 @@ import (
 )
 
 type ${name} struct {
-    //TODO implement
+    <#list structParams as param>
+    ${param.name?uncap_first} ${param.type}
+    </#list>
+    queryParams *url.Values
+}
+
+func New${name}(${constructor.constructorParams}) *${name} {
+    queryParams := &url.Values{}
+    <#list constructor.queryParams as param>
+    queryParams.Set("${param.name}", ${param.assignment})
+    </#list>
+
+    return &${name}{
+        <#list constructor.structParams as param>
+        ${param.name}: ${param.assignment},
+        </#list>
+        queryParams: queryParams,
+    }
+}
+
+<#list withConstructors as const>
+func (${name?uncap_first} *${name}) With${const.name?cap_first}(${const.name?uncap_first} ${const.type}) *${name} {
+    ${name?uncap_first}.${const.name?uncap_first} = ${const.name?uncap_first}
+    ${name?uncap_first}.queryParams.Set("${const.key}", ${const.name?uncap_first})
+    return ${name?uncap_first}
+}
+</#list>
+
+func (${name}) Verb() networking.HttpVerb {
+    return networking.${httpVerb}
+}
+
+func (${name?uncap_first} *${name}) Path() string {
+    return ${path}
+}
+
+func (${name?uncap_first} *${name}) QueryParams() *url.Values {
+    return ${name?uncap_first}.queryParams
+}
+
+func (${name}) Header() *http.Header {
+    return &http.Header{}
+}
+
+func (${name}) GetContentStream() networking.ReaderWithSizeDecorator {
+    return nil
+}
+
+func (${name}) GetChecksum() networking.Checksum {
+    return networking.NewNoneChecksum()
 }

--- a/ds3-autogen-go/src/main/resources/tmpls/request/request_template.ftl
+++ b/ds3-autogen-go/src/main/resources/tmpls/request/request_template.ftl
@@ -32,7 +32,19 @@ func New${name}(${constructor.constructorParams}) *${name} {
 <#list withConstructors as const>
 func (${name?uncap_first} *${name}) With${const.name?cap_first}(${const.name?uncap_first} ${const.type}) *${name} {
     ${name?uncap_first}.${const.name?uncap_first} = ${const.name?uncap_first}
-    ${name?uncap_first}.queryParams.Set("${const.key}", ${const.name?uncap_first})
+    ${name?uncap_first}.queryParams.Set("${const.key}", ${const.assignment})
+    return ${name?uncap_first}
+}
+</#list>
+
+<#list nullableWithConstructors as const>
+func (${name?uncap_first} *${name}) With${const.name?cap_first}(${const.name?uncap_first} ${const.type}) *${name} {
+    ${name?uncap_first}.${const.name?uncap_first} = ${const.name?uncap_first}
+    if ${const.name?uncap_first} != nil {
+        ${name?uncap_first}.queryParams.Set("${const.key}", ${const.assignment})
+    } else {
+        ${name?uncap_first}.queryParams.Set("${const.key}", "")
+    }
     return ${name?uncap_first}
 }
 </#list>

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTests.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTests.java
@@ -31,9 +31,7 @@ import java.io.IOException;
 
 import static com.spectralogic.ds3autogen.utils.ConverterUtil.hasContent;
 import static com.spectralogic.ds3autogen.utils.ConverterUtil.isEmpty;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-
 import static org.mockito.Mockito.mock;
 
 public class GoFunctionalTests {
@@ -101,4 +99,36 @@ public class GoFunctionalTests {
         CODE_LOGGER.logFile(client, FileTypeToLog.CLIENT);
         assertTrue(hasContent(client));
     }
+
+    @Test
+    public void requestWithResourceInPath() throws IOException, TemplateModelException {
+        final String requestName = "DeleteBucketAclSpectraS3Request";
+        final FileUtils fileUtils = mock(FileUtils.class);
+        final GoTestGeneratedCode codeGenerator = new GoTestGeneratedCode(fileUtils, requestName);
+
+        codeGenerator.generateCode(fileUtils, "/input/requestWithResourceInPath.xml");
+
+        // Verify Request file was generated
+        final String requestCode = codeGenerator.getRequestCode();
+        CODE_LOGGER.logFile(requestCode, FileTypeToLog.REQUEST);
+        assertTrue(hasContent(requestCode));
+        //TODO add test for properly included resource
+
+        // Verify Response file was generated
+        final String responseCode = codeGenerator.getResponseCode();
+        CODE_LOGGER.logFile(responseCode, FileTypeToLog.RESPONSE);
+        assertTrue(hasContent(responseCode));
+
+        // Verify response payload type file was not generated
+        final String typeCode = codeGenerator.getTypeCode();
+        CODE_LOGGER.logFile(typeCode, FileTypeToLog.MODEL);
+        assertTrue(isEmpty(typeCode));
+
+        // Verify that the client code was generated
+        final String client = codeGenerator.getClientCode(HttpVerb.GET);
+        CODE_LOGGER.logFile(client, FileTypeToLog.CLIENT);
+        assertTrue(hasContent(client));
+    }
+
+    //TODO add more tests for simple request generation
 }

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTests.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTests.java
@@ -17,7 +17,7 @@ package com.spectralogic.ds3autogen.go;
 
 import com.spectralogic.ds3autogen.api.FileUtils;
 import com.spectralogic.ds3autogen.api.models.enums.HttpVerb;
-import com.spectralogic.ds3autogen.go.utils.GoTestGeneratedCode;
+import com.spectralogic.ds3autogen.go.utils.GoTestCodeUtil;
 import com.spectralogic.ds3autogen.testutil.logging.FileTypeToLog;
 import com.spectralogic.ds3autogen.testutil.logging.GeneratedCodeLogger;
 import freemarker.template.TemplateModelException;
@@ -37,7 +37,7 @@ import static org.mockito.Mockito.mock;
 public class GoFunctionalTests {
 
     private final static Logger LOG = LoggerFactory.getLogger(GoFunctionalTests.class);
-    private final static GeneratedCodeLogger CODE_LOGGER = new GeneratedCodeLogger(FileTypeToLog.ALL, LOG);
+    private final static GeneratedCodeLogger CODE_LOGGER = new GeneratedCodeLogger(FileTypeToLog.REQUEST, LOG);
 
     @Rule
     public TemporaryFolder tempFolder = new TemporaryFolder();
@@ -46,7 +46,7 @@ public class GoFunctionalTests {
     public void simpleRequestNoPayload() throws IOException, TemplateModelException {
         final String requestName = "GetObjectRequest";
         final FileUtils fileUtils = mock(FileUtils.class);
-        final GoTestGeneratedCode codeGenerator = new GoTestGeneratedCode(fileUtils, requestName);
+        final GoTestCodeUtil codeGenerator = new GoTestCodeUtil(fileUtils, requestName);
 
         codeGenerator.generateCode(fileUtils, "/input/simpleRequestNoPayload.xml");
 
@@ -75,7 +75,7 @@ public class GoFunctionalTests {
     public void simpleRequestWithPayload() throws IOException, TemplateModelException {
         final String requestName = "SimpleWithPayloadRequest";
         final FileUtils fileUtils = mock(FileUtils.class);
-        final GoTestGeneratedCode codeGenerator = new GoTestGeneratedCode(fileUtils, requestName, "Bucket");
+        final GoTestCodeUtil codeGenerator = new GoTestCodeUtil(fileUtils, requestName, "Bucket");
 
         codeGenerator.generateCode(fileUtils, "/input/simpleRequestWithPayload.xml");
 
@@ -104,7 +104,7 @@ public class GoFunctionalTests {
     public void requestWithResourceInPath() throws IOException, TemplateModelException {
         final String requestName = "DeleteBucketAclSpectraS3Request";
         final FileUtils fileUtils = mock(FileUtils.class);
-        final GoTestGeneratedCode codeGenerator = new GoTestGeneratedCode(fileUtils, requestName);
+        final GoTestCodeUtil codeGenerator = new GoTestCodeUtil(fileUtils, requestName);
 
         codeGenerator.generateCode(fileUtils, "/input/requestWithResourceInPath.xml");
 
@@ -112,7 +112,9 @@ public class GoFunctionalTests {
         final String requestCode = codeGenerator.getRequestCode();
         CODE_LOGGER.logFile(requestCode, FileTypeToLog.REQUEST);
         assertTrue(hasContent(requestCode));
-        //TODO add test for properly included resource
+
+        assertTrue(requestCode.contains("func NewDeleteBucketAclSpectraS3Request(bucketAcl string) *DeleteBucketAclSpectraS3Request {"));
+        assertTrue(requestCode.contains("return \"/_rest_/bucket_acl/\" + deleteBucketAclSpectraS3Request.bucketAcl"));
 
         // Verify Response file was generated
         final String responseCode = codeGenerator.getResponseCode();
@@ -129,6 +131,4 @@ public class GoFunctionalTests {
         CODE_LOGGER.logFile(client, FileTypeToLog.CLIENT);
         assertTrue(hasContent(client));
     }
-
-    //TODO add more tests for simple request generation
 }

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/request/BaseRequestGenerator_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/request/BaseRequestGenerator_Test.java
@@ -116,7 +116,10 @@ public class BaseRequestGenerator_Test {
         final ImmutableList<Arguments> result = generator.toConstructorParamsList(testRequest);
 
         assertThat(result.size(), is(expectedArgs.size()));
-        expectedArgs.forEach(expected -> assertThat(result, hasItem(expected)));
+        for (int i = 0; i < result.size(); i++) {
+            assertThat(result.get(i).getName(), is(expectedArgs.get(i).getName()));
+            assertThat(result.get(i).getType(), is(expectedArgs.get(i).getType()));
+        }
     }
 
     @Test
@@ -152,7 +155,10 @@ public class BaseRequestGenerator_Test {
         final ImmutableList<Arguments> result = generator.toStructParams(testRequest);
 
         assertThat(result.size(), is(expectedArgs.size()));
-        expectedArgs.forEach(expected -> assertThat(result, hasItem(expected)));
+        for (int i = 0; i < result.size(); i++) {
+            assertThat(result.get(i).getName(), is(expectedArgs.get(i).getName()));
+            assertThat(result.get(i).getType(), is(expectedArgs.get(i).getType()));
+        }
     }
 
     @Test

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/request/BaseRequestGenerator_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/request/BaseRequestGenerator_Test.java
@@ -1,0 +1,206 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.go.generators.request;
+
+import com.google.common.collect.ImmutableList;
+import com.spectralogic.ds3autogen.api.models.Arguments;
+import com.spectralogic.ds3autogen.api.models.apispec.Ds3Param;
+import com.spectralogic.ds3autogen.api.models.apispec.Ds3Request;
+import com.spectralogic.ds3autogen.api.models.enums.*;
+import com.spectralogic.ds3autogen.go.models.request.*;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class BaseRequestGenerator_Test {
+
+    private final BaseRequestGenerator generator = new BaseRequestGenerator();
+
+    private final Ds3Request testRequest =
+            new Ds3Request("com.test.TestRequest",
+            HttpVerb.DELETE,
+            Classification.amazons3,
+            Requirement.REQUIRED,
+            Requirement.REQUIRED,
+            Action.BULK_DELETE,
+            Resource.ACTIVE_JOB,
+            ResourceType.SINGLETON,
+            Operation.CANCEL_EJECT,
+            true,
+            ImmutableList.of(),
+            ImmutableList.of( //optional query params
+                    new Ds3Param("IntOptParam", "int", false),
+                    new Ds3Param("IntegerOptParam", "java.lang.Integer", true),
+                    new Ds3Param("StringOptParam", "java.lang.String", false)
+            ),
+            ImmutableList.of( //required query params
+                    new Ds3Param("IntReqParam", "int", false),
+                    new Ds3Param("StringReqParam", "java.lang.String", false),
+                    new Ds3Param("VoidReqParam", "void", false)
+            ));
+
+    private final String expectedConstructorParams = "bucketName string, objectName string, activeJobId string, intReqParam int, stringReqParam string";
+
+    private final ImmutableList<VariableInterface> expectedQueryParams = ImmutableList.of(
+            new Variable("operation", "\"cancel_eject\""),
+            new Variable("int_req_param", "strconv.Itoa(intReqParam)"),
+            new Variable("string_req_param", "stringReqParam"),
+            new Variable("void_req_param", "\"\"")
+    );
+
+    private final ImmutableList<VariableInterface> expectedStructAssignments = ImmutableList.of(
+            new SimpleVariable("bucketName"),
+            new SimpleVariable("objectName"),
+            new SimpleVariable("intReqParam"),
+            new SimpleVariable("stringReqParam"),
+            new SimpleVariable("activeJobId")
+    );
+
+    @Test
+    public void toStructAssignmentParams_Test() {
+        final ImmutableList<VariableInterface> result = generator.toStructAssignmentParams(testRequest);
+        assertThat(result.size(), is(expectedStructAssignments.size()));
+        expectedStructAssignments.forEach(expected -> assertThat(result, hasItem(expected)));
+    }
+
+    @Test
+    public void toQueryParamsList_NullListWithOperation_Test() {
+        final Variable expected = new Variable("operation", "\"allocate\"");
+
+        final ImmutableList<VariableInterface> result = generator.toQueryParamsList(null, Operation.ALLOCATE);
+        assertThat(result.size(), is(1));
+        assertThat(result.get(0), is(expected));
+    }
+
+    @Test
+    public void toQueryParamsList_EmptyListWithoutOperation_Test() {
+        final ImmutableList<VariableInterface> result = generator.toQueryParamsList(ImmutableList.of(), null);
+        assertThat(result.size(), is(0));
+    }
+
+    @Test
+    public void toQueryParamsList_FullContent_Test() {
+        final ImmutableList<VariableInterface> result = generator.toQueryParamsList(
+                testRequest.getRequiredQueryParams(),
+                testRequest.getOperation());
+
+        assertThat(result.size(), is(expectedQueryParams.size()));
+        expectedQueryParams.forEach(expected -> assertThat(result, hasItem(expected)));
+    }
+
+    @Test
+    public void toConstructorParamsList_Test() {
+        final ImmutableList<Arguments> expectedArgs = ImmutableList.of(
+                new Arguments("string", "bucketName"),
+                new Arguments("string", "objectName"),
+                new Arguments("string", "activeJobId"),
+                new Arguments("int", "intReqParam"),
+                new Arguments("string", "stringReqParam")
+        );
+
+        final ImmutableList<Arguments> result = generator.toConstructorParamsList(testRequest);
+
+        assertThat(result.size(), is(expectedArgs.size()));
+        expectedArgs.forEach(expected -> assertThat(result, hasItem(expected)));
+    }
+
+    @Test
+    public void toConstructorParams_Test() {
+        final String result = generator.toConstructorParams(testRequest);
+        assertThat(result, is(expectedConstructorParams));
+    }
+
+    @Test
+    public void toConstructor_Test() {
+        final Constructor result = generator.toConstructor(testRequest);
+
+        assertThat(result.getConstructorParams(), is(expectedConstructorParams));
+        assertThat(result.getQueryParams().size(), is(expectedQueryParams.size()));
+        expectedQueryParams.forEach(expected -> assertThat(result.getQueryParams(), hasItem(expected)));
+        assertThat(result.getStructParams().size(), is(expectedStructAssignments.size()));
+        expectedStructAssignments.forEach(expected -> assertThat(result.getStructParams(), hasItem(expected)));
+    }
+
+    @Test
+    public void toStructParams_Test() {
+        final ImmutableList<Arguments> expectedArgs = ImmutableList.of(
+                new Arguments("string", "bucketName"),
+                new Arguments("string", "objectName"),
+                new Arguments("string", "activeJobId"),
+                new Arguments("*int", "integerOptParam"),
+                new Arguments("int", "intOptParam"),
+                new Arguments("int", "intReqParam"),
+                new Arguments("string", "stringOptParam"),
+                new Arguments("string", "stringReqParam")
+        );
+
+        final ImmutableList<Arguments> result = generator.toStructParams(testRequest);
+
+        assertThat(result.size(), is(expectedArgs.size()));
+        expectedArgs.forEach(expected -> assertThat(result, hasItem(expected)));
+    }
+
+    @Test
+    public void toWithConstructors_NullList_Test() {
+        final ImmutableList<WithConstructor> result = generator.toWithConstructors(null);
+        assertThat(result.size(), is(0));
+    }
+
+    @Test
+    public void toWithConstructors_EmptyList_Test() {
+        final ImmutableList<WithConstructor> result = generator.toWithConstructors(ImmutableList.of());
+        assertThat(result.size(), is(0));
+    }
+
+    @Test
+    public void toWithConstructors_FullList_Test() {
+        final ImmutableList<WithConstructor> expectedConst = ImmutableList.of(
+                new WithConstructor("IntOptParam", "int", "int_opt_param", "strconv.Itoa(intOptParam)"),
+                new WithConstructor("StringOptParam", "string", "string_opt_param", "stringOptParam")
+        );
+
+        final ImmutableList<WithConstructor> result = generator.toWithConstructors(testRequest.getOptionalQueryParams());
+        assertThat(result.size(), is(expectedConst.size()));
+
+        expectedConst.forEach(expected -> assertThat(result, hasItem(expected)));
+    }
+
+    @Test
+    public void toNullableWithConstructors_NullList_Test() {
+        final ImmutableList<WithConstructor> result = generator.toNullableWithConstructors(null);
+        assertThat(result.size(), is(0));
+    }
+
+    @Test
+    public void toNullableWithConstructors_EmptyList_Test() {
+        final ImmutableList<WithConstructor> result = generator.toNullableWithConstructors(ImmutableList.of());
+        assertThat(result.size(), is(0));
+    }
+
+    @Test
+    public void toNullableWithConstructors_FullList_Test() {
+        final ImmutableList<WithConstructor> expectedConst = ImmutableList.of(
+                new WithConstructor("IntegerOptParam", "*int", "integer_opt_param", "strconv.Itoa(*integerOptParam)")
+        );
+
+        final ImmutableList<WithConstructor> result = generator.toNullableWithConstructors(testRequest.getOptionalQueryParams());
+        assertThat(result.size(), is(expectedConst.size()));
+
+        expectedConst.forEach(expected -> assertThat(result, hasItem(expected)));
+    }
+}

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/request/RequestGeneratorUtil_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/request/RequestGeneratorUtil_Test.java
@@ -1,0 +1,349 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.go.generators.request;
+
+import com.google.common.collect.ImmutableList;
+import com.spectralogic.ds3autogen.api.models.Arguments;
+import com.spectralogic.ds3autogen.api.models.apispec.Ds3Param;
+import com.spectralogic.ds3autogen.api.models.apispec.Ds3Request;
+import com.spectralogic.ds3autogen.api.models.enums.*;
+import com.spectralogic.ds3autogen.go.models.request.SimpleVariable;
+import com.spectralogic.ds3autogen.go.models.request.Variable;
+import org.junit.Test;
+
+import static com.spectralogic.ds3autogen.go.generators.request.RequestGeneratorUtilKt.*;
+import static com.spectralogic.ds3autogen.testutil.Ds3ModelFixtures.*;
+import static com.spectralogic.ds3autogen.utils.Helper.uncapFirst;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertThat;
+
+public class RequestGeneratorUtil_Test {
+
+    @Test
+    public void removeVoidParams_NullList_Test() {
+        final ImmutableList<Ds3Param> result = removeVoidDs3Params(null);
+        assertThat(result.size(), is(0));
+    }
+
+    @Test
+    public void removeVoidParams_EmptyList_Test() {
+        final ImmutableList<Ds3Param> result = removeVoidDs3Params(ImmutableList.of());
+        assertThat(result.size(), is(0));
+    }
+
+    @Test
+    public void removeVoidParams_FullList_Test() {
+        final ImmutableList<Ds3Param> params = ImmutableList.of(
+                new Ds3Param("Param1", "Type1", false),
+                new Ds3Param("Param2", "void", false),
+                new Ds3Param("Param3", "int", false),
+                new Ds3Param("Param4", "VOID", false)
+        );
+        final ImmutableList<Ds3Param> result = removeVoidDs3Params(params);
+        assertThat(result.size(), is(2));
+
+        result.forEach(param -> assertThat(param.getType(), not("void")));
+    }
+
+    @Test
+    public void toGoArgumentsList_NullList_Test() {
+        final ImmutableList<Arguments> result = toGoArgumentsList(null);
+        assertThat(result.size(), is(0));
+    }
+
+    @Test
+    public void toGoArgumentsList_EmptyList_Test() {
+        final ImmutableList<Arguments> result = toGoArgumentsList(ImmutableList.of());
+        assertThat(result.size(), is(0));
+    }
+
+    @Test
+    public void toGoArgumentsList_FullList_Test() {
+        final ImmutableList<String> expectedTypes = ImmutableList.of("", "*int", "float64", "string");
+
+        final ImmutableList<Ds3Param> params = ImmutableList.of(
+                new Ds3Param("Param1", "void", false),
+                new Ds3Param("Param2", "java.lang.Integer", true),
+                new Ds3Param("Param3", "double", false),
+                new Ds3Param("Param4", "java.util.UUID", false)
+        );
+
+        final ImmutableList<Arguments> result = toGoArgumentsList(params);
+        assertThat(result.size(), is(4));
+
+        for (int i = 0; i < result.size(); i++) {
+            assertThat(result.get(i).getType(), is(expectedTypes.get(i)));
+        }
+    }
+
+    @Test
+    public void toGoArgument_Test() {
+        final ImmutableList<String> expectedTypes = ImmutableList.of("", "*int", "float64", "string");
+
+        final ImmutableList<Ds3Param> params = ImmutableList.of(
+                new Ds3Param("Param1", "void", false),
+                new Ds3Param("Param2", "java.lang.Integer", true),
+                new Ds3Param("Param3", "double", false),
+                new Ds3Param("Param4", "java.util.UUID", false)
+        );
+
+        for (int i = 0; i < params.size(); i++) {
+            final Arguments result = toGoArgument(params.get(i));
+            assertThat(result.getName(), is(uncapFirst(params.get(i).getName())));
+            assertThat(result.getType(), is(expectedTypes.get(i)));
+        }
+    }
+
+    @Test
+    public void toFunctionInput_EmptyList_Test() {
+        final String result = toFunctionInput(ImmutableList.of());
+        assertThat(result, is(""));
+    }
+
+    @Test
+    public void toFunctionInput_FullList_Test() {
+        final String expected = "bucketName string, objectName string, a int, b float64";
+
+        final ImmutableList<Arguments> args = ImmutableList.of(
+                new Arguments("float64", "b"),
+                new Arguments("int", "a"),
+                new Arguments("string", "ObjectName"),
+                new Arguments("string", "BucketName")
+        );
+
+        final String result = toFunctionInput(args);
+        assertThat(result, is(expected));
+    }
+
+    @Test (expected = IllegalArgumentException.class)
+    public void getHttpVerb_Exception_Test() {
+        getHttpVerb(null);
+    }
+
+    @Test
+    public void getHttpVerb_Test() {
+        assertThat(getHttpVerb(HttpVerb.DELETE), is(HttpVerb.DELETE));
+        assertThat(getHttpVerb(HttpVerb.GET), is(HttpVerb.GET));
+        assertThat(getHttpVerb(HttpVerb.HEAD), is(HttpVerb.HEAD));
+        assertThat(getHttpVerb(HttpVerb.POST), is(HttpVerb.POST));
+        assertThat(getHttpVerb(HttpVerb.PUT), is(HttpVerb.PUT));
+    }
+
+    @Test
+    public void ttoQueryParamVarList_NullList_Test() {
+        final ImmutableList<Variable> result = toQueryParamVarList(null);
+        assertThat(result.size(), is(0));
+    }
+
+    @Test
+    public void toQueryParamVarList_EmptyList_Test() {
+        final ImmutableList<Variable> result = toQueryParamVarList(ImmutableList.of());
+        assertThat(result.size(), is(0));
+    }
+
+    @Test
+    public void toQueryParamVarList_FullList_Test() {
+        final ImmutableList<Variable> expected = ImmutableList.of(
+                new Variable("param_one", "strconv.Itoa(paramOne)"),
+                new Variable("param_two", "strconv.FormatFloat(paramTwo, 'f', -1, 64)"),
+                new Variable("param_three", "paramThree"),
+                new Variable("param_four", "\"\"")
+        );
+
+        final ImmutableList<Ds3Param> params = ImmutableList.of(
+                new Ds3Param("ParamOne", "int", false),
+                new Ds3Param("ParamTwo", "float64", false),
+                new Ds3Param("ParamThree", "string", false),
+                new Ds3Param("ParamFour", "void", false)
+        );
+
+        final ImmutableList<Variable> result = toQueryParamVarList(params);
+        assertThat(result.size(), is(4));
+
+        for (int i = 0; i < result.size(); i++) {
+            assertThat(result.get(i), is(expected.get(i)));
+        }
+    }
+
+    @Test
+    public void toQueryParamVar_Test() {
+        final ImmutableList<Variable> expected = ImmutableList.of(
+                new Variable("param_one", "strconv.Itoa(paramOne)"),
+                new Variable("param_two", "strconv.FormatFloat(paramTwo, 'f', -1, 64)"),
+                new Variable("param_three", "paramThree"),
+                new Variable("param_four", "\"\"")
+        );
+
+        final ImmutableList<Ds3Param> params = ImmutableList.of(
+                new Ds3Param("ParamOne", "int", false),
+                new Ds3Param("ParamTwo", "float64", false),
+                new Ds3Param("ParamThree", "string", false),
+                new Ds3Param("ParamFour", "void", false)
+        );
+
+        assertThat(expected.size(), is(params.size()));
+        for (int i = 0; i < params.size(); i++) {
+            final Variable result = toQueryParamVar(params.get(i));
+            assertThat(result, is(expected.get(i)));
+        }
+    }
+
+    @Test
+    public void goVarToString_Test() {
+        assertThat(goVarToString("Arg", ""), is("\"\""));
+        assertThat(goVarToString("Arg", "int"), is("strconv.Itoa(Arg)"));
+        assertThat(goVarToString("Arg", "*int"), is("strconv.Itoa(*Arg)"));
+        assertThat(goVarToString("Arg", "bool"), is("strconv.FormatBool(Arg)"));
+        assertThat(goVarToString("Arg", "*bool"), is("strconv.FormatBool(*Arg)"));
+        assertThat(goVarToString("Arg", "int64"), is("strconv.FormatInt(Arg, 10)"));
+        assertThat(goVarToString("Arg", "*int64"), is("strconv.FormatInt(*Arg, 10)"));
+        assertThat(goVarToString("Arg", "float64"), is("strconv.FormatFloat(Arg, 'f', -1, 64)"));
+        assertThat(goVarToString("Arg", "*float64"), is("strconv.FormatFloat(*Arg, 'f', -1, 64)"));
+        assertThat(goVarToString("Arg", "string"), is("Arg"));
+        assertThat(goVarToString("Arg", "CustomType"), is("Arg.String()"));
+    }
+
+    @Test
+    public void toSimpleVariables_NullList_Test() {
+        final ImmutableList<SimpleVariable> result = toSimpleVariables(null);
+        assertThat(result.size(), is(0));
+    }
+
+    @Test
+    public void toSimpleVariables_EmptyList_Test() {
+        final ImmutableList<SimpleVariable> result = toSimpleVariables(ImmutableList.of());
+        assertThat(result.size(), is(0));
+    }
+
+    @Test
+    public void toSimpleVariables_FullList_Test() {
+        final ImmutableList<SimpleVariable> expected = ImmutableList.of(
+                new SimpleVariable("paramOne"),
+                new SimpleVariable("paramTwo"),
+                new SimpleVariable("paramThree")
+        );
+
+        final ImmutableList<Ds3Param> params = ImmutableList.of(
+                new Ds3Param("ParamOne", "string", false),
+                new Ds3Param("ParamTwo", "string", true),
+                new Ds3Param("ParamThree", "string", false)
+        );
+
+        final ImmutableList<SimpleVariable> result = toSimpleVariables(params);
+        assertThat(result.size(), is(3));
+
+        for (int i = 0; i < result.size(); i++) {
+            assertThat(result.get(i), is(expected.get(i)));
+        }
+    }
+
+    @Test
+    public void toRequestPath_Test() {
+        //Spectra requests
+        assertThat(toRequestPath(getRequestDeleteNotification()),
+                is("\"/_rest_/job_created_notification_registration/\" + deleteJobCreatedNotificationRegistrationRequestHandler.notificationId"));
+        assertThat(toRequestPath(getRequestCreateNotification()),
+                is("\"/_rest_/job_created_notification_registration\""));
+        assertThat(toRequestPath(getRequestGetNotification()),
+                is("\"/_rest_/job_completed_notification_registration/\" + getJobCompletedNotificationRegistrationRequestHandler.notificationId"));
+        assertThat(toRequestPath(getRequestVerifyPhysicalPlacement()),
+                is("\"/_rest_/bucket/\" + verifyPhysicalPlacementForObjectsRequestHandler.bucketName"));
+        assertThat(toRequestPath(getRequestBulkGet()),
+                is("\"/_rest_/bucket/\" + createGetJobRequestHandler.bucketName"));
+        assertThat(toRequestPath(getRequestBulkPut()),
+                is("\"/_rest_/bucket/\" + createPutJobRequestHandler.bucketName"));
+        assertThat(toRequestPath(getRequestSpectraS3GetObject()),
+                is("\"/_rest_/object/\" + getObjectRequestHandler.objectName"));
+        assertThat(toRequestPath(getRequestGetJob()),
+                is("\"/_rest_/job/\" + getJobRequestHandler.jobId"));
+
+        //Amazon requests
+        assertThat(toRequestPath(getRequestMultiFileDelete()),
+                is("\"/\" + deleteObjectsRequestHandler.bucketName"));
+        assertThat(toRequestPath(getRequestCreateObject()),
+                is("\"/\" + createObjectRequestHandler.bucketName + \"/\" + createObjectRequestHandler.objectName"));
+        assertThat(toRequestPath(getRequestAmazonS3GetObject()),
+                is("\"/\" + getObjectRequestHandler.bucketName + \"/\" + getObjectRequestHandler.objectName"));
+    }
+
+    @Test (expected = IllegalArgumentException.class)
+    public void toRequestPath_Exception_Test() {
+        final Ds3Request request = new Ds3Request(
+                "Test",
+                HttpVerb.GET,
+                Classification.spectrainternal,
+                Requirement.NOT_ALLOWED,
+                Requirement.NOT_ALLOWED,
+                Action.BULK_DELETE,
+                Resource.ACTIVE_JOB,
+                ResourceType.NON_SINGLETON,
+                Operation.ALLOCATE,
+                false,
+                ImmutableList.of(),
+                ImmutableList.of(),
+                ImmutableList.of());
+
+        toRequestPath(request);
+    }
+
+    @Test
+    public void getAmazonS3RequestPath_Test() {
+        //Amazon requests
+        assertThat(getAmazonS3RequestPath(getRequestMultiFileDelete()),
+                is("\"/\" + deleteObjectsRequestHandler.bucketName"));
+        assertThat(getAmazonS3RequestPath(getRequestCreateObject()),
+                is("\"/\" + createObjectRequestHandler.bucketName + \"/\" + createObjectRequestHandler.objectName"));
+        assertThat(getAmazonS3RequestPath(getRequestAmazonS3GetObject()),
+                is("\"/\" + getObjectRequestHandler.bucketName + \"/\" + getObjectRequestHandler.objectName"));
+
+        //Spectra requests
+        assertThat(getAmazonS3RequestPath(getRequestDeleteNotification()), is(""));
+        assertThat(getAmazonS3RequestPath(getRequestCreateNotification()), is(""));
+        assertThat(getAmazonS3RequestPath(getRequestGetNotification()), is(""));
+        assertThat(getAmazonS3RequestPath(getRequestVerifyPhysicalPlacement()), is(""));
+        assertThat(getAmazonS3RequestPath(getRequestBulkGet()), is(""));
+        assertThat(getAmazonS3RequestPath(getRequestBulkPut()), is(""));
+        assertThat(getAmazonS3RequestPath(getRequestSpectraS3GetObject()), is(""));
+        assertThat(getAmazonS3RequestPath(getRequestGetJob()), is(""));
+    }
+
+    @Test
+    public void getSpectraDs3RequestPath_Test() {
+        //Spectra requests
+        assertThat(getSpectraDs3RequestPath(getRequestDeleteNotification()),
+                is("\"/_rest_/job_created_notification_registration/\" + deleteJobCreatedNotificationRegistrationRequestHandler.notificationId"));
+        assertThat(getSpectraDs3RequestPath(getRequestCreateNotification()),
+                is("\"/_rest_/job_created_notification_registration\""));
+        assertThat(getSpectraDs3RequestPath(getRequestGetNotification()),
+                is("\"/_rest_/job_completed_notification_registration/\" + getJobCompletedNotificationRegistrationRequestHandler.notificationId"));
+        assertThat(getSpectraDs3RequestPath(getRequestVerifyPhysicalPlacement()),
+                is("\"/_rest_/bucket/\" + verifyPhysicalPlacementForObjectsRequestHandler.bucketName"));
+        assertThat(getSpectraDs3RequestPath(getRequestBulkGet()),
+                is("\"/_rest_/bucket/\" + createGetJobRequestHandler.bucketName"));
+        assertThat(getSpectraDs3RequestPath(getRequestBulkPut()),
+                is("\"/_rest_/bucket/\" + createPutJobRequestHandler.bucketName"));
+        assertThat(getSpectraDs3RequestPath(getRequestSpectraS3GetObject()),
+                is("\"/_rest_/object/\" + getObjectRequestHandler.objectName"));
+        assertThat(getSpectraDs3RequestPath(getRequestGetJob()),
+                is("\"/_rest_/job/\" + getJobRequestHandler.jobId"));
+
+        //Amazon requests
+        assertThat(getSpectraDs3RequestPath(getRequestMultiFileDelete()), is(""));
+        assertThat(getSpectraDs3RequestPath(getRequestCreateObject()), is(""));
+        assertThat(getSpectraDs3RequestPath(getRequestAmazonS3GetObject()), is(""));
+    }
+}

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/utils/GoTestCodeUtil.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/utils/GoTestCodeUtil.java
@@ -37,9 +37,9 @@ import java.util.Map;
 import static org.mockito.Mockito.when;
 
 /**
- * Used to generate Go code for a single command. Used in functional testing.
+ * Used to generate and capture Go code for a single command. Used in functional testing.
  */
-public class GoTestGeneratedCode {
+public class GoTestCodeUtil {
 
     final static String BASE_PATH = "./ds3/";
     final static String COMMAND_PATH = BASE_PATH + "models/";
@@ -57,7 +57,7 @@ public class GoTestGeneratedCode {
     /**
      * Constructor for generating Go files for a command with NO response payload
      */
-    public GoTestGeneratedCode(
+    public GoTestCodeUtil(
             final FileUtils fileUtils,
             final String requestName) throws IOException {
         this.requestOutputStream = setupOutputStream(fileUtils, COMMAND_PATH + requestName + ".go");
@@ -68,7 +68,7 @@ public class GoTestGeneratedCode {
     /**
      * Constructor for generating Go files for a command with a response payload
      */
-    public GoTestGeneratedCode(
+    public GoTestCodeUtil(
             final FileUtils fileUtils,
             final String requestName,
             final String responseType) throws IOException {
@@ -106,7 +106,7 @@ public class GoTestGeneratedCode {
      */
     public void generateCode(final FileUtils fileUtils, final String inputFileName) throws IOException, TemplateModelException {
         final Ds3SpecParser parser = new Ds3SpecParserImpl();
-        final Ds3ApiSpec spec = parser.getSpec(GoTestGeneratedCode.class.getResourceAsStream(inputFileName));
+        final Ds3ApiSpec spec = parser.getSpec(GoTestCodeUtil.class.getResourceAsStream(inputFileName));
         final CodeGenerator codeGenerator = new GoCodeGenerator();
         final Ds3DocSpec docSpec = new Ds3DocSpecEmptyImpl();
 

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/utils/GoTypeUtil_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/utils/GoTypeUtil_Test.java
@@ -1,0 +1,80 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.go.utils;
+import org.junit.Test;
+
+import static com.spectralogic.ds3autogen.go.utils.GoTypeUtilKt.toGoType;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class GoTypeUtil_Test {
+
+    @Test
+    public void toGoType_Test() {
+        assertThat(toGoType("void"), is(""));
+        assertThat(toGoType("Void"), is(""));
+        assertThat(toGoType("boolean"), is("bool"));
+        assertThat(toGoType("java.lang.Boolean"), is("bool"));
+        assertThat(toGoType("Integer"), is("int"));
+        assertThat(toGoType("int"), is("int"));
+        assertThat(toGoType("java.lang.Double"), is("float64"));
+        assertThat(toGoType("double"), is("float64"));
+        assertThat(toGoType("java.lang.Long"), is("int64"));
+        assertThat(toGoType("long"), is("int64"));
+        assertThat(toGoType("java.lang.String"), is("string"));
+        assertThat(toGoType("string"), is("string"));
+        assertThat(toGoType("java.util.UUID"), is("string"));
+        assertThat(toGoType("ChecksumType"), is("ChecksumType"));
+        assertThat(toGoType("OtherType"), is("OtherType"));
+    }
+
+    @Test
+    public void toGoType_Nullable_Test() {
+        // Not nullable
+        assertThat(toGoType("void", false), is(""));
+        assertThat(toGoType("Void", false), is(""));
+        assertThat(toGoType("boolean", false), is("bool"));
+        assertThat(toGoType("java.lang.Boolean", false), is("bool"));
+        assertThat(toGoType("Integer", false), is("int"));
+        assertThat(toGoType("int", false), is("int"));
+        assertThat(toGoType("java.lang.Double", false), is("float64"));
+        assertThat(toGoType("double", false), is("float64"));
+        assertThat(toGoType("java.lang.Long", false), is("int64"));
+        assertThat(toGoType("long", false), is("int64"));
+        assertThat(toGoType("java.lang.String", false), is("string"));
+        assertThat(toGoType("string", false), is("string"));
+        assertThat(toGoType("java.util.UUID", false), is("string"));
+        assertThat(toGoType("ChecksumType", false), is("ChecksumType"));
+        assertThat(toGoType("OtherType", false), is("OtherType"));
+
+        // Nullable
+        assertThat(toGoType("void", true), is(""));
+        assertThat(toGoType("Void", true), is(""));
+        assertThat(toGoType("boolean", true), is("*bool"));
+        assertThat(toGoType("java.lang.Boolean", true), is("*bool"));
+        assertThat(toGoType("Integer", true), is("*int"));
+        assertThat(toGoType("int", true), is("*int"));
+        assertThat(toGoType("java.lang.Double", true), is("*float64"));
+        assertThat(toGoType("double", true), is("*float64"));
+        assertThat(toGoType("java.lang.Long", true), is("*int64"));
+        assertThat(toGoType("long", true), is("*int64"));
+        assertThat(toGoType("java.lang.String", true), is("*string"));
+        assertThat(toGoType("string", true), is("*string"));
+        assertThat(toGoType("java.util.UUID", true), is("*string"));
+        assertThat(toGoType("ChecksumType", true), is("*ChecksumType"));
+        assertThat(toGoType("OtherType", true), is("*OtherType"));
+    }
+}

--- a/ds3-autogen-go/src/test/resources/input/requestWithResourceInPath.xml
+++ b/ds3-autogen-go/src/test/resources/input/requestWithResourceInPath.xml
@@ -1,0 +1,27 @@
+<Data>
+    <Contract>
+        <RequestHandlers>
+            <RequestHandler Classification="spectrads3" Name="com.spectralogic.s3.server.handler.reqhandler.spectrads3.acl.DeleteBucketAclRequestHandler">
+                <Request Action="DELETE" HttpVerb="DELETE" IncludeIdInPath="true" Resource="BUCKET_ACL" ResourceType="NON_SINGLETON">
+                    <OptionalQueryParams/>
+                    <RequiredQueryParams/>
+                </Request>
+                <ResponseCodes>
+                    <ResponseCode>
+                        <Code>204</Code>
+                        <ResponseTypes>
+                            <ResponseType Type="null"/>
+                        </ResponseTypes>
+                    </ResponseCode>
+                    <ResponseCode>
+                        <Code>403</Code>
+                        <ResponseTypes>
+                            <ResponseType Type="com.spectralogic.s3.server.domain.HttpErrorResultApiBean"/>
+                        </ResponseTypes>
+                    </ResponseCode>
+                </ResponseCodes>
+                <Version>1.0500995E51CDDBCFFC70327F12F2428F</Version>
+            </RequestHandler>
+        </RequestHandlers>
+    </Contract>
+</Data>

--- a/ds3-autogen-go/src/test/resources/input/simpleRequestWithPayload.xml
+++ b/ds3-autogen-go/src/test/resources/input/simpleRequestWithPayload.xml
@@ -2,10 +2,12 @@
     <Contract>
         <RequestHandlers>
             <RequestHandler Classification="amazons3" Name="com.spectralogic.s3.server.handler.reqhandler.SimpleWithPayloadRequestHandler">
-                <Request BucketRequirement="REQUIRED" HttpVerb="DELETE" ObjectRequirement="REQUIRED">
-                    <OptionalQueryParams/>
+                <Request BucketRequirement="REQUIRED" HttpVerb="DELETE" Operation="START_BULK_GET" ObjectRequirement="REQUIRED">
+                    <OptionalQueryParams>
+                        <Param Name="OptionalPlaceHolder" Type="java.lang.Integer"/>
+                    </OptionalQueryParams>
                     <RequiredQueryParams>
-                        <Param Name="Placeholder" Type="com.spectralogic.s3.common.dao.domain.ds3.Bucket"/>
+                        <Param Name="PlaceHolder" Type="com.spectralogic.s3.common.dao.domain.ds3.Bucket"/>
                     </RequiredQueryParams>
                 </Request>
                 <ResponseCodes>

--- a/ds3-autogen-go/src/test/resources/input/simpleRequestWithPayload.xml
+++ b/ds3-autogen-go/src/test/resources/input/simpleRequestWithPayload.xml
@@ -7,6 +7,7 @@
                         <Param Name="OptionalPlaceHolder" Type="java.lang.Integer"/>
                     </OptionalQueryParams>
                     <RequiredQueryParams>
+                        <Param Name="VoidParam" Type="void"/>
                         <Param Name="PlaceHolder" Type="com.spectralogic.s3.common.dao.domain.ds3.Bucket"/>
                     </RequiredQueryParams>
                 </Request>


### PR DESCRIPTION
**Changes**
- Implemented `BaseRequestGenerator`
- Updated/created request models used in template
- Update request handler template