### PR TITLE
Go generation of requests with string payloads

### DIFF
--- a/ds3-autogen-go/src/main/java/com/spectralogic/ds3autogen/go/GoCodeGenerator.java
+++ b/ds3-autogen-go/src/main/java/com/spectralogic/ds3autogen/go/GoCodeGenerator.java
@@ -29,6 +29,7 @@ import com.spectralogic.ds3autogen.go.generators.client.ClientModelGenerator;
 import com.spectralogic.ds3autogen.go.generators.request.BaseRequestGenerator;
 import com.spectralogic.ds3autogen.go.generators.request.RequiredObjectsPayloadGenerator;
 import com.spectralogic.ds3autogen.go.generators.request.RequestModelGenerator;
+import com.spectralogic.ds3autogen.go.generators.request.StringRequestPayloadGenerator;
 import com.spectralogic.ds3autogen.go.generators.response.BaseResponseGenerator;
 import com.spectralogic.ds3autogen.go.generators.response.ResponseModelGenerator;
 import com.spectralogic.ds3autogen.go.generators.type.BaseTypeGenerator;
@@ -126,9 +127,12 @@ public class GoCodeGenerator implements CodeGenerator {
      * Retrieves the generator used to create the Go request handler for the
      * specified {@link Ds3Request}
      */
-    protected static RequestModelGenerator<?> getRequestGenerator(final Ds3Request ds3Request) {
+    static RequestModelGenerator<?> getRequestGenerator(final Ds3Request ds3Request) {
         if (isBulkRequest(ds3Request) || isPhysicalPlacementRequest(ds3Request) || isEjectStorageDomainBlobsRequest(ds3Request)) {
             return new RequiredObjectsPayloadGenerator();
+        }
+        if (hasStringRequestPayload(ds3Request)) {
+            return new StringRequestPayloadGenerator();
         }
         return new BaseRequestGenerator();
     }
@@ -137,7 +141,10 @@ public class GoCodeGenerator implements CodeGenerator {
      * Retrieves the appropriate template that will generate the Go request handler
      */
     private Template getRequestTemplate(final Ds3Request ds3Request) throws IOException {
-        if (isBulkRequest(ds3Request) || isPhysicalPlacementRequest(ds3Request) || isEjectStorageDomainBlobsRequest(ds3Request)) {
+        if (isBulkRequest(ds3Request)
+                || isPhysicalPlacementRequest(ds3Request)
+                || isEjectStorageDomainBlobsRequest(ds3Request)
+                || hasStringRequestPayload(ds3Request)) {
             return config.getTemplate("request/request_with_stream.ftl");
         }
         return config.getTemplate("request/request_template.ftl");

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/request/RequestPayloadGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/request/RequestPayloadGenerator.kt
@@ -38,7 +38,7 @@ abstract class RequestPayloadGenerator : BaseRequestGenerator() {
      * including contents which contains the request payload in the generated code.
      */
     override fun toStructParams(ds3Request: Ds3Request): ImmutableList<Arguments> {
-        val builder: ImmutableList.Builder<Arguments> = ImmutableList.builder()
+        val builder = ImmutableList.builder<Arguments>()
         if (ds3Request.bucketRequirement != null && ds3Request.bucketRequirement == Requirement.REQUIRED) {
             builder.add(Arguments("string", "bucketName"))
         }
@@ -46,7 +46,7 @@ abstract class RequestPayloadGenerator : BaseRequestGenerator() {
             builder.add(Arguments("string", "objectName"))
         }
         if (RequestConverterUtil.isResourceAnArg(ds3Request.resource, ds3Request.includeInPath)) {
-            val resourceArg: Arguments = RequestConverterUtil.getArgFromResource(ds3Request.resource)
+            val resourceArg = RequestConverterUtil.getArgFromResource(ds3Request.resource)
             builder.add(Arguments(toGoType(resourceArg.type), Helper.uncapFirst(resourceArg.name)))
         }
 
@@ -64,7 +64,7 @@ abstract class RequestPayloadGenerator : BaseRequestGenerator() {
      * Creates the list of constructor parameters, including a list of Ds3Objects.
      */
     override fun toConstructorParamsList(ds3Request: Ds3Request): ImmutableList<Arguments> {
-        val builder: ImmutableList.Builder<Arguments> = ImmutableList.builder()
+        val builder = ImmutableList.builder<Arguments>()
         if (ds3Request.bucketRequirement != null && ds3Request.bucketRequirement == Requirement.REQUIRED) {
             builder.add(Arguments("string", "bucketName"))
         }
@@ -72,7 +72,7 @@ abstract class RequestPayloadGenerator : BaseRequestGenerator() {
             builder.add(Arguments("string", "objectName"))
         }
         if (RequestConverterUtil.isResourceAnArg(ds3Request.resource, ds3Request.includeInPath)) {
-            val resourceArg: Arguments = RequestConverterUtil.getArgFromResource(ds3Request.resource)
+            val resourceArg = RequestConverterUtil.getArgFromResource(ds3Request.resource)
             builder.add(Arguments(toGoType(resourceArg.type), Helper.uncapFirst(resourceArg.name)))
         }
 
@@ -87,7 +87,7 @@ abstract class RequestPayloadGenerator : BaseRequestGenerator() {
      * into a stream before being assigned to the content variable.
      */
     override fun toStructAssignmentParams(ds3Request: Ds3Request): ImmutableList<VariableInterface> {
-        val builder: ImmutableList.Builder<VariableInterface> = ImmutableList.builder()
+        val builder = ImmutableList.builder<VariableInterface>()
         if (ds3Request.bucketRequirement != null && ds3Request.bucketRequirement == Requirement.REQUIRED) {
             builder.add(SimpleVariable("bucketName"))
         }
@@ -95,7 +95,7 @@ abstract class RequestPayloadGenerator : BaseRequestGenerator() {
             builder.add(SimpleVariable("objectName"))
         }
         if (RequestConverterUtil.isResourceAnArg(ds3Request.resource, ds3Request.includeInPath)) {
-            val resourceArg: Arguments = RequestConverterUtil.getArgFromResource(ds3Request.resource)
+            val resourceArg = RequestConverterUtil.getArgFromResource(ds3Request.resource)
             builder.add(SimpleVariable(Helper.uncapFirst(resourceArg.name)))
         }
 

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/request/RequestPayloadGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/request/RequestPayloadGenerator.kt
@@ -1,0 +1,117 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.go.generators.request
+
+import com.google.common.collect.ImmutableList
+import com.spectralogic.ds3autogen.api.models.Arguments
+import com.spectralogic.ds3autogen.api.models.apispec.Ds3Request
+import com.spectralogic.ds3autogen.api.models.enums.Requirement
+import com.spectralogic.ds3autogen.go.models.request.SimpleVariable
+import com.spectralogic.ds3autogen.go.models.request.Variable
+import com.spectralogic.ds3autogen.go.models.request.VariableInterface
+import com.spectralogic.ds3autogen.go.utils.toGoType
+import com.spectralogic.ds3autogen.utils.Helper
+import com.spectralogic.ds3autogen.utils.RequestConverterUtil
+import com.spectralogic.ds3autogen.utils.collections.GuavaCollectors
+import com.spectralogic.ds3autogen.utils.comparators.CustomArgumentComparator
+
+/**
+ * Abstract generator for requests with payloads
+ */
+abstract class RequestPayloadGenerator : BaseRequestGenerator() {
+
+    /**
+     * Creates the list of arguments that composes the request handler struct,
+     * including contents which contains the request payload in the generated code.
+     */
+    override fun toStructParams(ds3Request: Ds3Request): ImmutableList<Arguments> {
+        val builder: ImmutableList.Builder<Arguments> = ImmutableList.builder()
+        if (ds3Request.bucketRequirement != null && ds3Request.bucketRequirement == Requirement.REQUIRED) {
+            builder.add(Arguments("string", "bucketName"))
+        }
+        if (ds3Request.objectRequirement != null && ds3Request.objectRequirement == Requirement.REQUIRED) {
+            builder.add(Arguments("string", "objectName"))
+        }
+        if (RequestConverterUtil.isResourceAnArg(ds3Request.resource, ds3Request.includeInPath)) {
+            val resourceArg: Arguments = RequestConverterUtil.getArgFromResource(ds3Request.resource)
+            builder.add(Arguments(toGoType(resourceArg.type), Helper.uncapFirst(resourceArg.name)))
+        }
+
+        builder.addAll(toGoArgumentsList(removeVoidAndOperationDs3Params(ds3Request.requiredQueryParams)))
+        builder.addAll(toGoArgumentsList(removeVoidDs3Params(ds3Request.optionalQueryParams)))
+        builder.add(Arguments("networking.ReaderWithSizeDecorator", "content"))
+
+        // Sort the arguments
+        return builder.build().stream()
+                .sorted(CustomArgumentComparator())
+                .collect(GuavaCollectors.immutableList())
+    }
+
+    /**
+     * Creates the list of constructor parameters, including a list of Ds3Objects.
+     */
+    override fun toConstructorParamsList(ds3Request: Ds3Request): ImmutableList<Arguments> {
+        val builder: ImmutableList.Builder<Arguments> = ImmutableList.builder()
+        if (ds3Request.bucketRequirement != null && ds3Request.bucketRequirement == Requirement.REQUIRED) {
+            builder.add(Arguments("string", "bucketName"))
+        }
+        if (ds3Request.objectRequirement != null && ds3Request.objectRequirement == Requirement.REQUIRED) {
+            builder.add(Arguments("string", "objectName"))
+        }
+        if (RequestConverterUtil.isResourceAnArg(ds3Request.resource, ds3Request.includeInPath)) {
+            val resourceArg: Arguments = RequestConverterUtil.getArgFromResource(ds3Request.resource)
+            builder.add(Arguments(toGoType(resourceArg.type), Helper.uncapFirst(resourceArg.name)))
+        }
+
+        builder.addAll(toGoArgumentsList(removeVoidAndOperationDs3Params(ds3Request.requiredQueryParams)))
+        builder.add(getPayloadConstructorArg())
+        return builder.build()
+    }
+
+    /**
+     * Creates the list of variables that are assigned to the request handler struct
+     * within the constructor. In the generated code, the Ds3Object list is converted
+     * into a stream before being assigned to the content variable.
+     */
+    override fun toStructAssignmentParams(ds3Request: Ds3Request): ImmutableList<VariableInterface> {
+        val builder: ImmutableList.Builder<VariableInterface> = ImmutableList.builder()
+        if (ds3Request.bucketRequirement != null && ds3Request.bucketRequirement == Requirement.REQUIRED) {
+            builder.add(SimpleVariable("bucketName"))
+        }
+        if (ds3Request.objectRequirement != null && ds3Request.objectRequirement == Requirement.REQUIRED) {
+            builder.add(SimpleVariable("objectName"))
+        }
+        if (RequestConverterUtil.isResourceAnArg(ds3Request.resource, ds3Request.includeInPath)) {
+            val resourceArg: Arguments = RequestConverterUtil.getArgFromResource(ds3Request.resource)
+            builder.add(SimpleVariable(Helper.uncapFirst(resourceArg.name)))
+        }
+
+        builder.addAll(toSimpleVariables(removeVoidAndOperationDs3Params(ds3Request.requiredQueryParams)))
+        builder.add(getStructAssignmentVariable())
+
+        return builder.build()
+    }
+
+    /**
+     * Retrieves the parameter representing the request payload passed into the constructor
+     */
+    abstract fun getPayloadConstructorArg(): Arguments
+
+    /**
+     * Retrieves the variable that holds the struct assignment for the request payload type
+     */
+    abstract fun getStructAssignmentVariable(): Variable
+}

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/request/StringRequestPayloadGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/request/StringRequestPayloadGenerator.kt
@@ -19,22 +19,23 @@ import com.spectralogic.ds3autogen.api.models.Arguments
 import com.spectralogic.ds3autogen.go.models.request.Variable
 
 /**
- * Go generator for request handlers that have a Ds3Object list request payload
- * that is not specified in the contract
+ * The Go generator for request handlers that have a string request payload
+ * that is not specified within the contract
  */
-class RequiredObjectsPayloadGenerator : RequestPayloadGenerator() {
+class StringRequestPayloadGenerator : RequestPayloadGenerator() {
 
     /**
-     * Retrieves the Ds3Object list request payload
+     * Retrieves the string request payload
      */
     override fun getPayloadConstructorArg(): Arguments {
-        return Arguments("[]Ds3Object", "objects")
+        return Arguments("string", "requestPayload")
     }
 
     /**
-     * Retrieves the struct assignment for the Ds3Object list request payload
+     * Retrieves the struct assignment for the string request payload
      */
     override fun getStructAssignmentVariable(): Variable {
-        return Variable("content", "buildDs3ObjectListStream(objects)")
+        return Variable("content", "buildStreamFromString(requestPayload)")
     }
+
 }

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoCodeGenerator_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoCodeGenerator_Test.java
@@ -17,6 +17,7 @@ package com.spectralogic.ds3autogen.go;
 
 import com.spectralogic.ds3autogen.go.generators.request.BaseRequestGenerator;
 import com.spectralogic.ds3autogen.go.generators.request.RequiredObjectsPayloadGenerator;
+import com.spectralogic.ds3autogen.go.generators.request.StringRequestPayloadGenerator;
 import org.junit.Test;
 
 import static com.spectralogic.ds3autogen.testutil.Ds3ModelFixtures.*;
@@ -38,6 +39,10 @@ public class GoCodeGenerator_Test {
         assertThat(getRequestGenerator(createVerifyJobRequest()), instanceOf(RequiredObjectsPayloadGenerator.class));
         assertThat(getRequestGenerator(getPhysicalPlacementForObjects()), instanceOf(RequiredObjectsPayloadGenerator.class));
         assertThat(getRequestGenerator(verifyPhysicalPlacementForObjectsWithFullDetails()), instanceOf(RequiredObjectsPayloadGenerator.class));
+
+        //Requests with string payloads
+        assertThat(getRequestGenerator(getGetBlobPersistence()), instanceOf(StringRequestPayloadGenerator.class));
+        assertThat(getRequestGenerator(getReplicatePutJob()), instanceOf(StringRequestPayloadGenerator.class));
 
         // Non-special cased requests
         assertThat(getRequestGenerator(getGetBlobPersistence()), instanceOf(BaseRequestGenerator.class));

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTests.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTests.java
@@ -137,6 +137,7 @@ public class GoFunctionalTests {
 
     @Test
     public void verifyPhysicalPlacement() throws IOException, TemplateModelException {
+        // Test for request with payload of Ds3Object list
         final String requestName = "VerifyPhysicalPlacementForObjectsSpectraS3Request";
         final FileUtils fileUtils = mock(FileUtils.class);
         final GoTestCodeUtil codeGenerator = new GoTestCodeUtil(fileUtils, requestName);
@@ -149,6 +150,39 @@ public class GoFunctionalTests {
         assertTrue(hasContent(requestCode));
         assertTrue(requestCode.contains("content networking.ReaderWithSizeDecorator")); //content is in request struct
         assertTrue(requestCode.contains("content: buildDs3ObjectListStream(objects),")); //content is assigned a stream
+        assertTrue(returnsStream(requestName, requestCode));
+
+        // Verify Response file was generated
+        final String responseCode = codeGenerator.getResponseCode();
+        CODE_LOGGER.logFile(responseCode, FileTypeToLog.RESPONSE);
+        assertTrue(hasContent(responseCode));
+
+        // Verify response payload type file was not generated
+        final String typeCode = codeGenerator.getTypeCode();
+        CODE_LOGGER.logFile(typeCode, FileTypeToLog.MODEL);
+        assertTrue(isEmpty(typeCode));
+
+        // Verify that the client code was generated
+        final String client = codeGenerator.getClientCode(HttpVerb.GET);
+        CODE_LOGGER.logFile(client, FileTypeToLog.CLIENT);
+        assertTrue(hasContent(client));
+    }
+
+    @Test
+    public void replicatePutJob() throws IOException, TemplateModelException {
+        // Test for request with string payload
+        final String requestName = "ReplicatePutJobSpectraS3Request";
+        final FileUtils fileUtils = mock(FileUtils.class);
+        final GoTestCodeUtil codeGenerator = new GoTestCodeUtil(fileUtils, requestName);
+
+        codeGenerator.generateCode(fileUtils, "/input/replicatePutJob.xml");
+
+        // Verify Request file was generated
+        final String requestCode = codeGenerator.getRequestCode();
+        CODE_LOGGER.logFile(requestCode, FileTypeToLog.REQUEST);
+        assertTrue(hasContent(requestCode));
+        assertTrue(requestCode.contains("content networking.ReaderWithSizeDecorator")); //content is in request struct
+        assertTrue(requestCode.contains("content: buildStreamFromString(requestPayload),")); //content is assigned a stream
         assertTrue(returnsStream(requestName, requestCode));
 
         // Verify Response file was generated

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/request/RequiredObjectsPayloadGenerator_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/request/RequiredObjectsPayloadGenerator_Test.java
@@ -78,4 +78,18 @@ public class RequiredObjectsPayloadGenerator_Test {
             assertThat(result.get(i).getType(), is(expected.get(i).getType()));
         }
     }
+
+    @Test
+    public void getPayloadConstructorArgTest() {
+        final Arguments result = generator.getPayloadConstructorArg();
+        assertThat(result.getName(), is("objects"));
+        assertThat(result.getType(), is("[]Ds3Object"));
+    }
+
+    @Test
+    public void getStructAssignmentVariableTest() {
+        final Variable result = generator.getStructAssignmentVariable();
+        assertThat(result.getName(), is("content"));
+        assertThat(result.getAssignment(), is("buildDs3ObjectListStream(objects)"));
+    }
 }

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/request/StringRequestPayloadGenerator_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/request/StringRequestPayloadGenerator_Test.java
@@ -1,0 +1,42 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.go.generators.request;
+
+import com.spectralogic.ds3autogen.api.models.Arguments;
+import com.spectralogic.ds3autogen.go.models.request.Variable;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class StringRequestPayloadGenerator_Test {
+
+    private final StringRequestPayloadGenerator generator = new StringRequestPayloadGenerator();
+
+    @Test
+    public void getPayloadConstructorArgTest() {
+        final Arguments result = generator.getPayloadConstructorArg();
+        assertThat(result.getName(), is("requestPayload"));
+        assertThat(result.getType(), is("string"));
+    }
+
+    @Test
+    public void getStructAssignmentVariableTest() {
+        final Variable result = generator.getStructAssignmentVariable();
+        assertThat(result.getName(), is("content"));
+        assertThat(result.getAssignment(), is("buildStreamFromString(requestPayload)"));
+    }
+}

--- a/ds3-autogen-go/src/test/resources/input/replicatePutJob.xml
+++ b/ds3-autogen-go/src/test/resources/input/replicatePutJob.xml
@@ -1,0 +1,32 @@
+<Data>
+    <Contract>
+        <RequestHandlers>
+            <RequestHandler Classification="spectrads3" Name="com.spectralogic.s3.server.handler.reqhandler.spectrads3.job.ReplicatePutJobRequestHandler">
+                <Request Action="MODIFY" HttpVerb="PUT" IncludeIdInPath="true" Operation="START_BULK_PUT" Resource="BUCKET" ResourceType="NON_SINGLETON">
+                    <OptionalQueryParams>
+                        <Param Name="Priority" Type="com.spectralogic.s3.common.dao.domain.ds3.BlobStoreTaskPriority"/>
+                    </OptionalQueryParams>
+                    <RequiredQueryParams>
+                        <Param Name="Operation" Type="com.spectralogic.s3.server.request.rest.RestOperationType"/>
+                        <Param Name="Replicate" Type="void"/>
+                    </RequiredQueryParams>
+                </Request>
+                <ResponseCodes>
+                    <ResponseCode>
+                        <Code>200</Code>
+                        <ResponseTypes>
+                            <ResponseType Type="com.spectralogic.s3.server.domain.JobWithChunksApiBean"/>
+                        </ResponseTypes>
+                    </ResponseCode>
+                    <ResponseCode>
+                        <Code>204</Code>
+                        <ResponseTypes>
+                            <ResponseType Type="null"/>
+                        </ResponseTypes>
+                    </ResponseCode>
+                </ResponseCodes>
+                <Version>1.6F544A6CED02468AF923384632138561</Version>
+            </RequestHandler>
+        </RequestHandlers>
+    </Contract>
+</Data>


### PR DESCRIPTION
**Changes**
- Created Go request generator for commands with request payloads of type `string`
- Moved request payload logic from `RequiredObjectsPayloadGenerator` into abstract `RequestPayloadGenerator` for code reusability