### PR TITLE
Special cased amazon Get Object request in Go

### DIFF
--- a/ds3-autogen-go/src/main/java/com/spectralogic/ds3autogen/go/GoCodeGenerator.java
+++ b/ds3-autogen-go/src/main/java/com/spectralogic/ds3autogen/go/GoCodeGenerator.java
@@ -130,6 +130,9 @@ public class GoCodeGenerator implements CodeGenerator {
      * specified {@link Ds3Request}
      */
     static RequestModelGenerator<?> getRequestGenerator(final Ds3Request ds3Request) {
+        if (isGetObjectAmazonS3Request(ds3Request)) {
+            return new GetObjectRequestGenerator();
+        }
         if (isBulkRequest(ds3Request) || isPhysicalPlacementRequest(ds3Request) || isEjectStorageDomainBlobsRequest(ds3Request)) {
             return new RequiredObjectsPayloadGenerator();
         }
@@ -149,6 +152,9 @@ public class GoCodeGenerator implements CodeGenerator {
      * Retrieves the appropriate template that will generate the Go request handler
      */
     private Template getRequestTemplate(final Ds3Request ds3Request) throws IOException {
+        if (isGetObjectAmazonS3Request(ds3Request)) {
+            return config.getTemplate("request/get_object_request.ftl");
+        }
         if (isBulkRequest(ds3Request)
                 || isPhysicalPlacementRequest(ds3Request)
                 || isEjectStorageDomainBlobsRequest(ds3Request)

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/request/BaseRequestGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/request/BaseRequestGenerator.kt
@@ -77,7 +77,23 @@ open class BaseRequestGenerator : RequestModelGenerator<Request>, RequestModelGe
         return toWithConstructors(optionalParams, true)
     }
 
+    /**
+     * Retrieves the list of parameters that make up the Go request struct
+     */
     override fun toStructParams(ds3Request: Ds3Request): ImmutableList<Arguments> {
+        val structParams = structParamsFromRequest(ds3Request)
+
+        // Sort the arguments
+        return structParams.stream()
+                .sorted(CustomArgumentComparator())
+                .collect(GuavaCollectors.immutableList())
+    }
+
+    /**
+     * Retrieves the list of parameters that make up the Go request struct
+     * from the Ds3Request
+     */
+    protected fun structParamsFromRequest(ds3Request: Ds3Request): ImmutableList<Arguments> {
         val builder: ImmutableList.Builder<Arguments> = ImmutableList.builder()
         if (ds3Request.bucketRequirement != null && ds3Request.bucketRequirement == Requirement.REQUIRED) {
             builder.add(Arguments("string", "bucketName"))
@@ -92,11 +108,7 @@ open class BaseRequestGenerator : RequestModelGenerator<Request>, RequestModelGe
 
         builder.addAll(toGoArgumentsList(removeVoidAndOperationDs3Params(ds3Request.requiredQueryParams)))
         builder.addAll(toGoArgumentsList(removeVoidDs3Params(ds3Request.optionalQueryParams)))
-
-        // Sort the arguments
-        return builder.build().stream()
-                .sorted(CustomArgumentComparator())
-                .collect(GuavaCollectors.immutableList())
+        return builder.build()
     }
 
     override fun toConstructor(ds3Request: Ds3Request): Constructor {
@@ -141,7 +153,18 @@ open class BaseRequestGenerator : RequestModelGenerator<Request>, RequestModelGe
         return builder.build()
     }
 
+    /**
+     * Retrieves the list of struct assignments that are performed within the
+     * Go request constructor
+     */
     override fun toStructAssignmentParams(ds3Request: Ds3Request): ImmutableList<VariableInterface> {
+        return structAssignmentParamsFromRequest(ds3Request)
+    }
+
+    /**
+     * Retrieves the list of struct assignments from the Ds3Request
+     */
+    protected fun structAssignmentParamsFromRequest(ds3Request: Ds3Request): ImmutableList<VariableInterface> {
         val builder: ImmutableList.Builder<VariableInterface> = ImmutableList.builder()
         if (ds3Request.bucketRequirement != null && ds3Request.bucketRequirement == Requirement.REQUIRED) {
             builder.add(SimpleVariable("bucketName"))

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/request/GetObjectRequestGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/request/GetObjectRequestGenerator.kt
@@ -1,0 +1,64 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.go.generators.request
+
+import com.google.common.collect.ImmutableList
+import com.spectralogic.ds3autogen.api.models.Arguments
+import com.spectralogic.ds3autogen.api.models.apispec.Ds3Request
+import com.spectralogic.ds3autogen.go.models.request.Variable
+import com.spectralogic.ds3autogen.go.models.request.VariableInterface
+import com.spectralogic.ds3autogen.utils.collections.GuavaCollectors
+import com.spectralogic.ds3autogen.utils.comparators.CustomArgumentComparator
+
+/**
+ * Request generator for Amazon Get Object command
+ */
+open class GetObjectRequestGenerator : BaseRequestGenerator() {
+
+    /**
+     * Retrieves the list of parameters that make up the Go request struct,
+     * including checksum and range headers which are not represented within
+     * the Ds3Request
+     */
+    override fun toStructParams(ds3Request: Ds3Request): ImmutableList<Arguments> {
+        val structParams = structParamsFromRequest(ds3Request)
+
+        val builder = ImmutableList.builder<Arguments>()
+        builder.addAll(structParams)
+        builder.add(Arguments("*rangeHeader", "rangeHeader"))
+        builder.add(Arguments("networking.Checksum", "checksum"))
+
+        // Sort the arguments
+        return builder.build().stream()
+                .sorted(CustomArgumentComparator())
+                .collect(GuavaCollectors.immutableList())
+    }
+
+    /**
+     * Retrieves the list of struct assignments that are performed within the
+     * Go request constructor, including checksum which is not represented within
+     * the Ds3Request
+     */
+    override fun toStructAssignmentParams(ds3Request: Ds3Request): ImmutableList<VariableInterface> {
+        val assignments = structAssignmentParamsFromRequest(ds3Request)
+
+        val builder = ImmutableList.builder<VariableInterface>()
+        builder.addAll(assignments)
+        builder.add(Variable("checksum", "networking.NewNoneChecksum()"))
+
+        return builder.build()
+    }
+}

--- a/ds3-autogen-go/src/main/resources/tmpls/go/request/get_object_request.ftl
+++ b/ds3-autogen-go/src/main/resources/tmpls/go/request/get_object_request.ftl
@@ -1,0 +1,35 @@
+<#include "../common/copyright.ftl" />
+
+package models
+
+import (
+    "fmt"
+    "net/url"
+    "net/http"
+    "ds3/networking"
+    "strconv"
+)
+
+type rangeHeader struct {
+    start, end int
+}
+
+<#include "request_body.ftl" />
+
+<#include "with_checksum.ftl" />
+
+<#include "stream_no_content.ftl" />
+
+func (${name?uncap_first} *${name}) WithRange(start, end int) *${name} {
+    ${name?uncap_first}.rangeHeader = &rangeHeader{start, end}
+    return ${name?uncap_first}
+}
+
+func (${name?uncap_first} *${name}) Header() *http.Header {
+    if ${name?uncap_first}.rangeHeader == nil {
+        return &http.Header{}
+    } else {
+        rng := fmt.Sprintf("bytes=%d-%d", ${name?uncap_first}.rangeHeader.start, ${name?uncap_first}.rangeHeader.end)
+        return &http.Header{ "Range": []string{ rng } }
+    }
+}

--- a/ds3-autogen-go/src/main/resources/tmpls/go/request/no_checksum.ftl
+++ b/ds3-autogen-go/src/main/resources/tmpls/go/request/no_checksum.ftl
@@ -1,0 +1,3 @@
+func (${name}) GetChecksum() networking.Checksum {
+    return networking.NewNoneChecksum()
+}

--- a/ds3-autogen-go/src/main/resources/tmpls/go/request/no_headers.ftl
+++ b/ds3-autogen-go/src/main/resources/tmpls/go/request/no_headers.ftl
@@ -1,0 +1,3 @@
+func (${name}) Header() *http.Header {
+    return &http.Header{}
+}

--- a/ds3-autogen-go/src/main/resources/tmpls/go/request/request_body.ftl
+++ b/ds3-autogen-go/src/main/resources/tmpls/go/request/request_body.ftl
@@ -1,13 +1,3 @@
-<#include "../common/copyright.ftl" />
-
-package models
-
-import (
-    "net/url"
-    "net/http"
-    "ds3/networking"
-)
-
 type ${name} struct {
     <#list structParams as param>
     ${param.name?uncap_first} ${param.type}
@@ -66,12 +56,4 @@ func (${name?uncap_first} *${name}) Path() string {
 
 func (${name?uncap_first} *${name}) QueryParams() *url.Values {
     return ${name?uncap_first}.queryParams
-}
-
-func (${name}) Header() *http.Header {
-    return &http.Header{}
-}
-
-func (${name}) GetChecksum() networking.Checksum {
-    return networking.NewNoneChecksum()
 }

--- a/ds3-autogen-go/src/main/resources/tmpls/go/request/request_header.ftl
+++ b/ds3-autogen-go/src/main/resources/tmpls/go/request/request_header.ftl
@@ -1,0 +1,9 @@
+<#include "../common/copyright.ftl" />
+
+package models
+
+import (
+    "net/url"
+    "net/http"
+    "ds3/networking"
+)

--- a/ds3-autogen-go/src/main/resources/tmpls/go/request/request_template.ftl
+++ b/ds3-autogen-go/src/main/resources/tmpls/go/request/request_template.ftl
@@ -1,5 +1,9 @@
-<#include "request_body.ftl">
+<#include "request_header.ftl" />
 
-func (${name}) GetContentStream() networking.ReaderWithSizeDecorator {
-    return nil
-}
+<#include "request_body.ftl" />
+
+<#include "no_checksum.ftl" />
+
+<#include "no_headers.ftl" />
+
+<#include "stream_no_content.ftl" />

--- a/ds3-autogen-go/src/main/resources/tmpls/go/request/request_with_stream.ftl
+++ b/ds3-autogen-go/src/main/resources/tmpls/go/request/request_with_stream.ftl
@@ -1,5 +1,9 @@
+<#include "request_header.ftl" />
+
 <#include "request_body.ftl">
 
-func (${name?uncap_first} *${name}) GetContentStream() networking.ReaderWithSizeDecorator {
-    return ${name?uncap_first}.content
-}
+<#include "no_checksum.ftl" />
+
+<#include "no_headers.ftl" />
+
+<#include "stream_with_content.ftl">

--- a/ds3-autogen-go/src/main/resources/tmpls/go/request/stream_no_content.ftl
+++ b/ds3-autogen-go/src/main/resources/tmpls/go/request/stream_no_content.ftl
@@ -1,0 +1,3 @@
+func (${name}) GetContentStream() networking.ReaderWithSizeDecorator {
+    return nil
+}

--- a/ds3-autogen-go/src/main/resources/tmpls/go/request/stream_with_content.ftl
+++ b/ds3-autogen-go/src/main/resources/tmpls/go/request/stream_with_content.ftl
@@ -1,0 +1,3 @@
+func (${name?uncap_first} *${name}) GetContentStream() networking.ReaderWithSizeDecorator {
+    return ${name?uncap_first}.content
+}

--- a/ds3-autogen-go/src/main/resources/tmpls/go/request/with_checksum.ftl
+++ b/ds3-autogen-go/src/main/resources/tmpls/go/request/with_checksum.ftl
@@ -1,0 +1,9 @@
+func (${name?uncap_first} *${name}) WithChecksum(contentHash string, checksumType networking.ChecksumType) *${name} {
+    ${name?uncap_first}.checksum.ContentHash = contentHash
+    ${name?uncap_first}.checksum.Type = checksumType
+    return ${name?uncap_first}
+}
+
+func (${name?uncap_first} *${name}) GetChecksum() networking.Checksum {
+    return ${name?uncap_first}.checksum
+}

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoCodeGenerator_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoCodeGenerator_Test.java
@@ -15,11 +15,7 @@
 
 package com.spectralogic.ds3autogen.go;
 
-import com.spectralogic.ds3autogen.go.generators.request.BaseRequestGenerator;
-import com.spectralogic.ds3autogen.go.generators.request.MultipartUploadPayloadGenerator;
-import com.spectralogic.ds3autogen.go.generators.request.DeleteObjectsRequestGenerator;
-import com.spectralogic.ds3autogen.go.generators.request.RequiredObjectsPayloadGenerator;
-import com.spectralogic.ds3autogen.go.generators.request.StringRequestPayloadGenerator;
+import com.spectralogic.ds3autogen.go.generators.request.*;
 import com.spectralogic.ds3autogen.go.generators.response.BaseResponseGenerator;
 import com.spectralogic.ds3autogen.go.generators.response.NoResponseGenerator;
 import org.junit.Test;
@@ -34,6 +30,9 @@ public class GoCodeGenerator_Test {
 
     @Test
     public void getRequestGeneratorTest() {
+        // Amazon Get Object request
+        assertThat(getRequestGenerator(getRequestAmazonS3GetObject()), instanceOf(GetObjectRequestGenerator.class));
+
         // Requests with payloads List<Ds3Object>
         assertThat(getRequestGenerator(getRequestBulkGet()), instanceOf(RequiredObjectsPayloadGenerator.class));
         assertThat(getRequestGenerator(getRequestBulkPut()), instanceOf(RequiredObjectsPayloadGenerator.class));
@@ -62,7 +61,6 @@ public class GoCodeGenerator_Test {
         assertThat(getRequestGenerator(getRequestCreateNotification()), instanceOf(BaseRequestGenerator.class));
         assertThat(getRequestGenerator(getRequestGetNotification()), instanceOf(BaseRequestGenerator.class));
         assertThat(getRequestGenerator(getRequestDeleteNotification()), instanceOf(BaseRequestGenerator.class));
-        assertThat(getRequestGenerator(getRequestAmazonS3GetObject()), instanceOf(BaseRequestGenerator.class));
         assertThat(getRequestGenerator(getRequestMultiFileDelete()), instanceOf(BaseRequestGenerator.class));
         assertThat(getRequestGenerator(getCreateMultiPartUploadPart()), instanceOf(BaseRequestGenerator.class));
         assertThat(getRequestGenerator(getCompleteMultipartUploadRequest()), instanceOf(BaseRequestGenerator.class));

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/request/BaseRequestGenerator_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/request/BaseRequestGenerator_Test.java
@@ -81,6 +81,13 @@ public class BaseRequestGenerator_Test {
     }
 
     @Test
+    public void structAssignmentParamsFromRequest_Test() {
+        final ImmutableList<VariableInterface> result = generator.structAssignmentParamsFromRequest(testRequest);
+        assertThat(result.size(), is(expectedStructAssignments.size()));
+        expectedStructAssignments.forEach(expected -> assertThat(result, hasItem(expected)));
+    }
+
+    @Test
     public void toQueryParamsList_NullListWithOperation_Test() {
         final Variable expected = new Variable("operation", "\"allocate\"");
 
@@ -155,6 +162,29 @@ public class BaseRequestGenerator_Test {
         );
 
         final ImmutableList<Arguments> result = generator.toStructParams(testRequest);
+
+        assertThat(result.size(), is(expectedArgs.size()));
+        for (int i = 0; i < result.size(); i++) {
+            assertThat(result.get(i).getName(), is(expectedArgs.get(i).getName()));
+            assertThat(result.get(i).getType(), is(expectedArgs.get(i).getType()));
+        }
+    }
+
+    @Test
+    public void structParamsFromRequest_Test() {
+        // Not sorted
+        final ImmutableList<Arguments> expectedArgs = ImmutableList.of(
+                new Arguments("string", "bucketName"),
+                new Arguments("string", "objectName"),
+                new Arguments("string", "activeJobId"),
+                new Arguments("int", "intReqParam"),
+                new Arguments("string", "stringReqParam"),
+                new Arguments("int", "intOptParam"),
+                new Arguments("*int", "integerOptParam"),
+                new Arguments("string", "stringOptParam")
+        );
+
+        final ImmutableList<Arguments> result = generator.structParamsFromRequest(testRequest);
 
         assertThat(result.size(), is(expectedArgs.size()));
         for (int i = 0; i < result.size(); i++) {

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/request/GetObjectRequestGenerator_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/request/GetObjectRequestGenerator_Test.java
@@ -1,0 +1,67 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.go.generators.request;
+
+import com.google.common.collect.ImmutableList;
+import com.spectralogic.ds3autogen.api.models.Arguments;
+import com.spectralogic.ds3autogen.go.models.request.SimpleVariable;
+import com.spectralogic.ds3autogen.go.models.request.Variable;
+import com.spectralogic.ds3autogen.go.models.request.VariableInterface;
+import org.junit.Test;
+
+import static com.spectralogic.ds3autogen.testutil.Ds3ModelFixtures.getRequestAmazonS3GetObject;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class GetObjectRequestGenerator_Test {
+
+    private final GetObjectRequestGenerator generator = new GetObjectRequestGenerator();
+
+    @Test
+    public void toStructParams_Test() {
+        final ImmutableList<Arguments> expectedArgs = ImmutableList.of(
+                new Arguments("string", "bucketName"),
+                new Arguments("string", "objectName"),
+                new Arguments("networking.Checksum", "checksum"),
+                new Arguments("string", "job"),
+                new Arguments("int64", "offset"),
+                new Arguments("*rangeHeader", "rangeHeader")
+        );
+
+        final ImmutableList<Arguments> result = generator.toStructParams(getRequestAmazonS3GetObject());
+
+        assertThat(result.size(), is(expectedArgs.size()));
+        for (int i = 0; i < result.size(); i++) {
+            assertThat(result.get(i).getName(), is(expectedArgs.get(i).getName()));
+            assertThat(result.get(i).getType(), is(expectedArgs.get(i).getType()));
+        }
+    }
+
+    @Test
+    public void toStructAssignmentParams_Test() {
+        final ImmutableList<VariableInterface> expectedVars = ImmutableList.of(
+                new SimpleVariable("bucketName"),
+                new SimpleVariable("objectName"),
+                new Variable("checksum", "networking.NewNoneChecksum()")
+        );
+
+        final ImmutableList<VariableInterface> result = generator.toStructAssignmentParams(getRequestAmazonS3GetObject());
+
+        assertThat(result.size(), is(expectedVars.size()));
+        expectedVars.forEach(expected -> assertThat(result, hasItem(expected)));
+    }
+}

--- a/ds3-autogen-go/src/test/resources/input/getObject.xml
+++ b/ds3-autogen-go/src/test/resources/input/getObject.xml
@@ -1,0 +1,48 @@
+<Data>
+    <Contract>
+        <RequestHandlers>
+            <RequestHandler Classification="amazons3" Name="com.spectralogic.s3.server.handler.reqhandler.amazons3.GetObjectRequestHandler">
+                <Request BucketRequirement="REQUIRED" HttpVerb="GET" IncludeIdInPath="false" ObjectRequirement="REQUIRED">
+                    <OptionalQueryParams>
+                        <Param Name="Job" Type="java.util.UUID"/>
+                        <Param Name="Offset" Type="long"/>
+                    </OptionalQueryParams>
+                    <RequiredQueryParams/>
+                </Request>
+                <ResponseCodes>
+                    <ResponseCode>
+                        <Code>200</Code>
+                        <ResponseTypes>
+                            <ResponseType Type="null"/>
+                        </ResponseTypes>
+                    </ResponseCode>
+                    <ResponseCode>
+                        <Code>206</Code>
+                        <ResponseTypes>
+                            <ResponseType Type="null"/>
+                        </ResponseTypes>
+                    </ResponseCode>
+                    <ResponseCode>
+                        <Code>307</Code>
+                        <ResponseTypes>
+                            <ResponseType Type="com.spectralogic.s3.server.domain.HttpErrorResultApiBean"/>
+                        </ResponseTypes>
+                    </ResponseCode>
+                    <ResponseCode>
+                        <Code>400</Code>
+                        <ResponseTypes>
+                            <ResponseType Type="com.spectralogic.s3.server.domain.HttpErrorResultApiBean"/>
+                        </ResponseTypes>
+                    </ResponseCode>
+                    <ResponseCode>
+                        <Code>503</Code>
+                        <ResponseTypes>
+                            <ResponseType Type="com.spectralogic.s3.server.domain.HttpErrorResultApiBean"/>
+                        </ResponseTypes>
+                    </ResponseCode>
+                </ResponseCodes>
+                <Version>1.F50E6F8DEFB864FE89D9385A71A6C25A</Version>
+            </RequestHandler>
+        </RequestHandlers>
+    </Contract>
+</Data>


### PR DESCRIPTION
**Changes**
- Created template and request generator for Get Object command
- Pulled some logic out of overloaded functions in `BaseRequestGenerator` for re-usability
- Separated request template logic into multiple new templates for re-usability

Generated Code:
```
package models

import (
    "fmt"
    "net/url"
    "net/http"
    "ds3/networking"
    "strconv"
)

type rangeHeader struct {
    start, end int
}

type GetObjectRequest struct {
    bucketName string
    objectName string
    checksum networking.Checksum
    job string
    offset int64
    rangeHeader *rangeHeader
    queryParams *url.Values
}

func NewGetObjectRequest(bucketName string, objectName string) *GetObjectRequest {
    queryParams := &url.Values{}

    return &GetObjectRequest{
        bucketName: bucketName,
        objectName: objectName,
        checksum: networking.NewNoneChecksum(),
        queryParams: queryParams,
    }
}

func (getObjectRequest *GetObjectRequest) WithJob(job string) *GetObjectRequest {
    getObjectRequest.job = job
    getObjectRequest.queryParams.Set("job", job)
    return getObjectRequest
}
func (getObjectRequest *GetObjectRequest) WithOffset(offset int64) *GetObjectRequest {
    getObjectRequest.offset = offset
    getObjectRequest.queryParams.Set("offset", strconv.FormatInt(offset, 10))
    return getObjectRequest
}



func (GetObjectRequest) Verb() networking.HttpVerb {
    return networking.GET
}

func (getObjectRequest *GetObjectRequest) Path() string {
    return "/" + getObjectRequest.bucketName + "/" + getObjectRequest.objectName
}

func (getObjectRequest *GetObjectRequest) QueryParams() *url.Values {
    return getObjectRequest.queryParams
}

func (getObjectRequest *GetObjectRequest) WithChecksum(contentHash string, checksumType networking.ChecksumType) *GetObjectRequest {
    getObjectRequest.checksum.ContentHash = contentHash
    getObjectRequest.checksum.Type = checksumType
    return getObjectRequest
}

func (getObjectRequest *GetObjectRequest) GetChecksum() networking.Checksum {
    return getObjectRequest.checksum
}

func (GetObjectRequest) GetContentStream() networking.ReaderWithSizeDecorator {
    return nil
}

func (getObjectRequest *GetObjectRequest) WithRange(start, end int) *GetObjectRequest {
    getObjectRequest.rangeHeader = &rangeHeader{start, end}
    return getObjectRequest
}

func (getObjectRequest *GetObjectRequest) Header() *http.Header {
    if getObjectRequest.rangeHeader == nil {
        return &http.Header{}
    } else {
        rng := fmt.Sprintf("bytes=%d-%d", getObjectRequest.rangeHeader.start, getObjectRequest.rangeHeader.end)
        return &http.Header{ "Range": []string{ rng } }
    }
}
```