### PR TITLE
Name spaced enum values with type names

### DIFF
--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/type/BaseTypeGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/type/BaseTypeGenerator.kt
@@ -15,6 +15,7 @@
 
 package com.spectralogic.ds3autogen.go.generators.type
 
+import com.google.common.base.CaseFormat
 import com.google.common.collect.ImmutableList
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3Element
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3EnumConstant
@@ -31,10 +32,18 @@ open class BaseTypeGenerator : TypeModelGenerator<Type>, TypeModelGeneratorUtil 
 
     override fun generate(ds3Type: Ds3Type): Type {
         val name = NormalizingContractNamesUtil.removePath(ds3Type.name)
+        val enumPrefix = toEnumPrefix(name)
         val enumConstants = toEnumConstantsList(ds3Type.enumConstants)
         val structElements = toStructElementsList(ds3Type.elements)
 
-        return Type(name, enumConstants, structElements)
+        return Type(name, enumPrefix, enumConstants, structElements)
+    }
+
+    /**
+     * Converts the type name into the uppercase prefix used to namespace enum values
+     */
+    fun toEnumPrefix(name: String): String {
+        return CaseFormat.UPPER_CAMEL.to(CaseFormat.UPPER_UNDERSCORE, name) + "_"
     }
 
     /**

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/models/type/Type.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/models/type/Type.kt
@@ -19,5 +19,6 @@ import com.google.common.collect.ImmutableList
 
 data class Type(
         val name: String,
+        val enumPrefix: String,
         val enumConstants: ImmutableList<String>,
         val structElements: ImmutableList<StructElement>)

--- a/ds3-autogen-go/src/main/resources/tmpls/go/type/enum_type.ftl
+++ b/ds3-autogen-go/src/main/resources/tmpls/go/type/enum_type.ftl
@@ -2,11 +2,17 @@
 
 package models
 
+import (
+    "errors"
+    "fmt"
+    "bytes"
+)
+
 type ${name} Enum
 
 const (
     <#list enumConstants as const>
-    ${const} ${name} = 1 + iota
+    ${enumPrefix}${const} ${name} = 1 + iota
     </#list>
 )
 
@@ -14,10 +20,10 @@ func (${name?uncap_first} *${name}) UnmarshalText(text []byte) error {
     var str string = string(bytes.ToUpper(text))
     switch str {
         <#list enumConstants as const>
-        case "${const}": *${name?uncap_first} = ${const}
+        case "${const}": *${name?uncap_first} = ${enumPrefix}${const}
         </#list>
         default:
-            *${name?uncap_first} = NONE
+            *${name?uncap_first} = UNDEFINED
             return errors.New(fmt.Sprintf("Cannot marshal %s into ${name}", str))
     }
     return nil
@@ -26,9 +32,9 @@ func (${name?uncap_first} *${name}) UnmarshalText(text []byte) error {
 func (${name?uncap_first} ${name}) String() (string, error) {
     switch ${name?uncap_first} {
         <#list enumConstants as const>
-        case ${const}: return "${const}", nil
+        case ${enumPrefix}${const}: return "${const}", nil
         </#list>
-        case NONE: return "NONE", nil
+        case UNDEFINED: return "UNDEFINED", nil
         default: return "", errors.New(fmt.Sprintf("Invalid ${name} represented by: %d", ${name?uncap_first}))
     }
 }

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTypeTests.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTypeTests.java
@@ -50,10 +50,23 @@ public class GoFunctionalTypeTests {
         CODE_LOGGER.logFile(typeCode, FileTypeToLog.MODEL);
         assertTrue(hasContent(typeCode));
 
-        assertTrue(typeCode.contains("CRITICAL DatabasePhysicalSpaceState = 1 + iota"));
-        assertTrue(typeCode.contains("LOW DatabasePhysicalSpaceState = 1 + iota"));
-        assertTrue(typeCode.contains("NEAR_LOW DatabasePhysicalSpaceState = 1 + iota"));
-        assertTrue(typeCode.contains("NORMAL DatabasePhysicalSpaceState = 1 + iota"));
+        // Test const definitions
+        assertTrue(typeCode.contains("DATABASE_PHYSICAL_SPACE_STATE_CRITICAL DatabasePhysicalSpaceState = 1 + iota"));
+        assertTrue(typeCode.contains("DATABASE_PHYSICAL_SPACE_STATE_LOW DatabasePhysicalSpaceState = 1 + iota"));
+        assertTrue(typeCode.contains("DATABASE_PHYSICAL_SPACE_STATE_NEAR_LOW DatabasePhysicalSpaceState = 1 + iota"));
+        assertTrue(typeCode.contains("DATABASE_PHYSICAL_SPACE_STATE_NORMAL DatabasePhysicalSpaceState = 1 + iota"));
+
+        // Test un-marshaling
+        assertTrue(typeCode.contains("case \"CRITICAL\": *databasePhysicalSpaceState = DATABASE_PHYSICAL_SPACE_STATE_CRITICAL"));
+        assertTrue(typeCode.contains("case \"LOW\": *databasePhysicalSpaceState = DATABASE_PHYSICAL_SPACE_STATE_LOW"));
+        assertTrue(typeCode.contains("case \"NEAR_LOW\": *databasePhysicalSpaceState = DATABASE_PHYSICAL_SPACE_STATE_NEAR_LOW"));
+        assertTrue(typeCode.contains("case \"NORMAL\": *databasePhysicalSpaceState = DATABASE_PHYSICAL_SPACE_STATE_NORMAL"));
+
+        // Test conversion to string
+        assertTrue(typeCode.contains("case DATABASE_PHYSICAL_SPACE_STATE_CRITICAL: return \"CRITICAL\", nil"));
+        assertTrue(typeCode.contains("case DATABASE_PHYSICAL_SPACE_STATE_LOW: return \"LOW\", nil"));
+        assertTrue(typeCode.contains("case DATABASE_PHYSICAL_SPACE_STATE_NEAR_LOW: return \"NEAR_LOW\", nil"));
+        assertTrue(typeCode.contains("case DATABASE_PHYSICAL_SPACE_STATE_NORMAL: return \"NORMAL\", nil"));
     }
 
     @Test

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/type/BaseTypeGenerator_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/type/BaseTypeGenerator_Test.java
@@ -138,4 +138,10 @@ public class BaseTypeGenerator_Test {
 
         expectedElements.forEach(expected -> assertThat(result, hasItem(expected)));
     }
+
+    @Test
+    public void toEnumPrefix_Test() {
+        assertThat(generator.toEnumPrefix("testLowerCamelName"), is("TEST_LOWER_CAMEL_NAME_"));
+        assertThat(generator.toEnumPrefix("TestUpperCamelName"), is("TEST_UPPER_CAMEL_NAME_"));
+    }
 }


### PR DESCRIPTION
Generated enums have name collisions. This name spaces the enum values with the type name as a prefix.

Example code of generated enum:

```
package models

import (
    "errors"
    "fmt"
    "bytes"
)

type DatabasePhysicalSpaceState Enum

const (
    DATABASE_PHYSICAL_SPACE_STATE_CRITICAL DatabasePhysicalSpaceState = 1 + iota
    DATABASE_PHYSICAL_SPACE_STATE_LOW DatabasePhysicalSpaceState = 1 + iota
    DATABASE_PHYSICAL_SPACE_STATE_NEAR_LOW DatabasePhysicalSpaceState = 1 + iota
    DATABASE_PHYSICAL_SPACE_STATE_NORMAL DatabasePhysicalSpaceState = 1 + iota
)

func (databasePhysicalSpaceState *DatabasePhysicalSpaceState) UnmarshalText(text []byte) error {
    var str string = string(bytes.ToUpper(text))
    switch str {
        case "CRITICAL": *databasePhysicalSpaceState = DATABASE_PHYSICAL_SPACE_STATE_CRITICAL
        case "LOW": *databasePhysicalSpaceState = DATABASE_PHYSICAL_SPACE_STATE_LOW
        case "NEAR_LOW": *databasePhysicalSpaceState = DATABASE_PHYSICAL_SPACE_STATE_NEAR_LOW
        case "NORMAL": *databasePhysicalSpaceState = DATABASE_PHYSICAL_SPACE_STATE_NORMAL
        default:
            *databasePhysicalSpaceState = UNDEFINED
            return errors.New(fmt.Sprintf("Cannot marshal %s into DatabasePhysicalSpaceState", str))
    }
    return nil
}

func (databasePhysicalSpaceState DatabasePhysicalSpaceState) String() (string, error) {
    switch databasePhysicalSpaceState {
        case DATABASE_PHYSICAL_SPACE_STATE_CRITICAL: return "CRITICAL", nil
        case DATABASE_PHYSICAL_SPACE_STATE_LOW: return "LOW", nil
        case DATABASE_PHYSICAL_SPACE_STATE_NEAR_LOW: return "NEAR_LOW", nil
        case DATABASE_PHYSICAL_SPACE_STATE_NORMAL: return "NORMAL", nil
        case UNDEFINED: return "UNDEFINED", nil
        default: return "", errors.New(fmt.Sprintf("Invalid DatabasePhysicalSpaceState represented by: %d", databasePhysicalSpaceState))
    }
}
```