### PR TITLE
Changed Go enum-to-string to log error rather than return error

### DIFF
--- a/ds3-autogen-go/src/main/resources/tmpls/go/type/enum_type.ftl
+++ b/ds3-autogen-go/src/main/resources/tmpls/go/type/enum_type.ftl
@@ -6,6 +6,7 @@ import (
     "errors"
     "fmt"
     "bytes"
+    "log"
 )
 
 type ${name} Enum
@@ -24,17 +25,18 @@ func (${name?uncap_first} *${name}) UnmarshalText(text []byte) error {
         </#list>
         default:
             *${name?uncap_first} = UNDEFINED
-            return errors.New(fmt.Sprintf("Cannot marshal %s into ${name}", str))
+            return errors.New(fmt.Sprintf("Cannot marshal '%s' into ${name}", str))
     }
     return nil
 }
 
-func (${name?uncap_first} ${name}) String() (string, error) {
+func (${name?uncap_first} ${name}) String() string {
     switch ${name?uncap_first} {
         <#list enumConstants as const>
-        case ${enumPrefix}${const}: return "${const}", nil
+        case ${enumPrefix}${const}: return "${const}"
         </#list>
-        case UNDEFINED: return "UNDEFINED", nil
-        default: return "", errors.New(fmt.Sprintf("Invalid ${name} represented by: %d", ${name?uncap_first}))
+        default:
+            log.Printf("Error: invalid ${name} represented by '%d'", ${name?uncap_first})
+            return ""
     }
 }

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTypeTests.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTypeTests.java
@@ -63,10 +63,10 @@ public class GoFunctionalTypeTests {
         assertTrue(typeCode.contains("case \"NORMAL\": *databasePhysicalSpaceState = DATABASE_PHYSICAL_SPACE_STATE_NORMAL"));
 
         // Test conversion to string
-        assertTrue(typeCode.contains("case DATABASE_PHYSICAL_SPACE_STATE_CRITICAL: return \"CRITICAL\", nil"));
-        assertTrue(typeCode.contains("case DATABASE_PHYSICAL_SPACE_STATE_LOW: return \"LOW\", nil"));
-        assertTrue(typeCode.contains("case DATABASE_PHYSICAL_SPACE_STATE_NEAR_LOW: return \"NEAR_LOW\", nil"));
-        assertTrue(typeCode.contains("case DATABASE_PHYSICAL_SPACE_STATE_NORMAL: return \"NORMAL\", nil"));
+        assertTrue(typeCode.contains("case DATABASE_PHYSICAL_SPACE_STATE_CRITICAL: return \"CRITICAL\""));
+        assertTrue(typeCode.contains("case DATABASE_PHYSICAL_SPACE_STATE_LOW: return \"LOW\""));
+        assertTrue(typeCode.contains("case DATABASE_PHYSICAL_SPACE_STATE_NEAR_LOW: return \"NEAR_LOW\""));
+        assertTrue(typeCode.contains("case DATABASE_PHYSICAL_SPACE_STATE_NORMAL: return \"NORMAL\""));
     }
 
     @Test


### PR DESCRIPTION
Example enum generated code: 
```
package models

import (
    "errors"
    "fmt"
    "bytes"
    "log"
)

type Priority Enum

const (
    PRIORITY_CRITICAL Priority = 1 + iota
    PRIORITY_URGENT Priority = 1 + iota
    PRIORITY_HIGH Priority = 1 + iota
    PRIORITY_NORMAL Priority = 1 + iota
    PRIORITY_LOW Priority = 1 + iota
    PRIORITY_BACKGROUND Priority = 1 + iota
)

func (priority *Priority) UnmarshalText(text []byte) error {
    var str string = string(bytes.ToUpper(text))
    switch str {
        case "CRITICAL": *priority = PRIORITY_CRITICAL
        case "URGENT": *priority = PRIORITY_URGENT
        case "HIGH": *priority = PRIORITY_HIGH
        case "NORMAL": *priority = PRIORITY_NORMAL
        case "LOW": *priority = PRIORITY_LOW
        case "BACKGROUND": *priority = PRIORITY_BACKGROUND
        default:
            *priority = UNDEFINED
            return errors.New(fmt.Sprintf("Cannot marshal '%s' into Priority", str))
    }
    return nil
}

func (priority Priority) String() string {
    switch priority {
        case PRIORITY_CRITICAL: return "CRITICAL"
        case PRIORITY_URGENT: return "URGENT"
        case PRIORITY_HIGH: return "HIGH"
        case PRIORITY_NORMAL: return "NORMAL"
        case PRIORITY_LOW: return "LOW"
        case PRIORITY_BACKGROUND: return "BACKGROUND"
        default:
            log.Printf("Error: invalid Priority represented by '%d'", priority)
            return ""
    }
}
```