### PR TITLE
Fixed error in converting a string pointer into a string

### DIFF
--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/request/RequestGeneratorUtil.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/request/RequestGeneratorUtil.kt
@@ -152,6 +152,7 @@ fun goVarToString(name: String, goType: String): String {
         "*bool" -> return "strconv.FormatBool(*$name)"
         "*int64" -> return "strconv.FormatInt(*$name, 10)"
         "*float64" -> return "strconv.FormatFloat(*$name, 'f', -1, 64)"
+        "*string" -> return "*$name"
         else -> return name + ".String()"
     }
 }

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/request/RequestGeneratorUtil_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/request/RequestGeneratorUtil_Test.java
@@ -249,6 +249,7 @@ public class RequestGeneratorUtil_Test {
         assertThat(goVarToString("Arg", "float64"), is("strconv.FormatFloat(Arg, 'f', -1, 64)"));
         assertThat(goVarToString("Arg", "*float64"), is("strconv.FormatFloat(*Arg, 'f', -1, 64)"));
         assertThat(goVarToString("Arg", "string"), is("Arg"));
+        assertThat(goVarToString("Arg", "*string"), is("*Arg"));
         assertThat(goVarToString("Arg", "CustomType"), is("Arg.String()"));
     }
 


### PR DESCRIPTION
Fixed bug where a string pointer was not being dereferenced properly when accessing string value in Go generated code

Old: `strPtr.String()`
New: `*strPtr`