### PR TITLE
Namespaced parameters called 'Type' to use spectra type names

### DIFF
--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/utils/GoNamingUtil.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/utils/GoNamingUtil.kt
@@ -1,0 +1,50 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.go.utils
+
+import com.spectralogic.ds3autogen.utils.ConverterUtil.hasContent
+import com.spectralogic.ds3autogen.utils.NormalizingContractNamesUtil.removePath
+
+/**
+ * Contains utils for naming elements to Go conventions and avoiding
+ * key word conflicts.
+ */
+
+
+/**
+ * Converts a parameter name into a Go compatible name. If the name
+ * is the Go keyword "Type", then the parameter is named after its
+ * type.
+ */
+fun toGoParamName(contractName: String, type: String): String {
+    return toGoParamName(contractName, type, "")
+}
+
+/**
+ * Converts a parameter name into a Go compatible name. If the name
+ * is the Go keyword "Type", then the parameter is named after its
+ * type. If the type is an array, then "List" is appended to the
+ * component type name.
+ */
+fun toGoParamName(contractName: String, type: String, componentType: String): String {
+    if (!contractName.equals("Type", ignoreCase = true)) {
+        return contractName
+    }
+    if (hasContent(componentType)) {
+        return removePath(componentType) + "List"
+    }
+    return removePath(type)
+}

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTests.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTests.java
@@ -37,7 +37,7 @@ import static org.mockito.Mockito.mock;
 public class GoFunctionalTests {
 
     private final static Logger LOG = LoggerFactory.getLogger(GoFunctionalTests.class);
-    private final static GeneratedCodeLogger CODE_LOGGER = new GeneratedCodeLogger(FileTypeToLog.REQUEST, LOG);
+    private final static GeneratedCodeLogger CODE_LOGGER = new GeneratedCodeLogger(FileTypeToLog.RESPONSE, LOG);
 
     @Test
     public void simpleRequestNoPayload() throws IOException, TemplateModelException {
@@ -417,6 +417,132 @@ public class GoFunctionalTests {
         CODE_LOGGER.logFile(client, FileTypeToLog.CLIENT);
         assertTrue(hasContent(client));
         assertTrue(client.contains("func (client *Client) GetObject(request *models.GetObjectRequest) (*models.GetObjectResponse, error) {"));
+        assertTrue(client.contains("networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.netLayer), client.clientPolicy.maxRetries)"));
+        assertTrue(client.contains("response, requestErr := networkRetryDecorator.Invoke(request)"));
+    }
+
+    @Test
+    public void getAzureDataReplicationRules() throws IOException, TemplateModelException {
+        // This tests generation of request with "type" optional parameter keyword conflict
+        final String requestName = "GetAzureDataReplicationRulesSpectraS3Request";
+        final FileUtils fileUtils = mock(FileUtils.class);
+        final GoTestCodeUtil codeGenerator = new GoTestCodeUtil(fileUtils, requestName);
+
+        codeGenerator.generateCode(fileUtils, "/input/getAzureDataReplicationRules.xml");
+
+        // Verify Request file was generated
+        final String requestCode = codeGenerator.getRequestCode();
+        CODE_LOGGER.logFile(requestCode, FileTypeToLog.REQUEST);
+        assertTrue(hasContent(requestCode));
+
+        // test request imports
+        assertTrue(requestCode.contains("\"net/url\""));
+        assertTrue(requestCode.contains("\"net/http\""));
+        assertTrue(requestCode.contains("\"ds3/networking\""));
+
+        // test request struct
+        assertTrue(requestCode.contains("dataPolicyId string"));
+        assertTrue(requestCode.contains("pageLength int"));
+        assertTrue(requestCode.contains("pageOffset int"));
+        assertTrue(requestCode.contains("pageStartMarker string"));
+        assertTrue(requestCode.contains("replicateDeletes bool"));
+        assertTrue(requestCode.contains("state DataPlacementRuleState"));
+        assertTrue(requestCode.contains("targetId string"));
+        assertTrue(requestCode.contains("dataReplicationRuleType DataReplicationRuleType"));
+
+        // test constructor and with-constructors
+        assertTrue(requestCode.contains("func (getAzureDataReplicationRulesSpectraS3Request *GetAzureDataReplicationRulesSpectraS3Request) WithDataPolicyId(dataPolicyId string) *GetAzureDataReplicationRulesSpectraS3Request {"));
+        assertTrue(requestCode.contains("func (getAzureDataReplicationRulesSpectraS3Request *GetAzureDataReplicationRulesSpectraS3Request) WithPageLength(pageLength int) *GetAzureDataReplicationRulesSpectraS3Request {"));
+        assertTrue(requestCode.contains("func (getAzureDataReplicationRulesSpectraS3Request *GetAzureDataReplicationRulesSpectraS3Request) WithPageOffset(pageOffset int) *GetAzureDataReplicationRulesSpectraS3Request {"));
+        assertTrue(requestCode.contains("func (getAzureDataReplicationRulesSpectraS3Request *GetAzureDataReplicationRulesSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetAzureDataReplicationRulesSpectraS3Request {"));
+        assertTrue(requestCode.contains("func (getAzureDataReplicationRulesSpectraS3Request *GetAzureDataReplicationRulesSpectraS3Request) WithReplicateDeletes(replicateDeletes bool) *GetAzureDataReplicationRulesSpectraS3Request {"));
+        assertTrue(requestCode.contains("func (getAzureDataReplicationRulesSpectraS3Request *GetAzureDataReplicationRulesSpectraS3Request) WithState(state DataPlacementRuleState) *GetAzureDataReplicationRulesSpectraS3Request {"));
+        assertTrue(requestCode.contains("func (getAzureDataReplicationRulesSpectraS3Request *GetAzureDataReplicationRulesSpectraS3Request) WithTargetId(targetId string) *GetAzureDataReplicationRulesSpectraS3Request {"));
+        assertTrue(requestCode.contains("func (getAzureDataReplicationRulesSpectraS3Request *GetAzureDataReplicationRulesSpectraS3Request) WithDataReplicationRuleType(dataReplicationRuleType DataReplicationRuleType) *GetAzureDataReplicationRulesSpectraS3Request {"));
+        assertTrue(requestCode.contains("func (getAzureDataReplicationRulesSpectraS3Request *GetAzureDataReplicationRulesSpectraS3Request) WithLastPage() *GetAzureDataReplicationRulesSpectraS3Request {"));
+
+        // Verify Response file was generated
+        final String responseCode = codeGenerator.getResponseCode();
+        CODE_LOGGER.logFile(responseCode, FileTypeToLog.RESPONSE);
+        assertTrue(hasContent(responseCode));
+
+        assertTrue(responseCode.contains("func NewGetAzureDataReplicationRulesSpectraS3Response(webResponse networking.WebResponse) (*GetAzureDataReplicationRulesSpectraS3Response, error) {"));
+        assertTrue(responseCode.contains("expectedStatusCodes := []int { 200 }"));
+        assertTrue(responseCode.contains("if err := readResponseBody(webResponse, &body); err != nil {"));
+        assertTrue(responseCode.contains("return &body, nil"));
+
+        // Verify response payload type file was not generated
+        final String typeCode = codeGenerator.getTypeCode();
+        CODE_LOGGER.logFile(typeCode, FileTypeToLog.MODEL);
+        assertTrue(isEmpty(typeCode));
+
+        // Verify that the client code was generated
+        final String client = codeGenerator.getClientCode(HttpVerb.GET);
+        CODE_LOGGER.logFile(client, FileTypeToLog.CLIENT);
+        assertTrue(hasContent(client));
+
+        assertTrue(client.contains("func (client *Client) GetAzureDataReplicationRulesSpectraS3(request *models.GetAzureDataReplicationRulesSpectraS3Request) (*models.GetAzureDataReplicationRulesSpectraS3Response, error) {"));
+        assertTrue(client.contains("networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.netLayer), client.clientPolicy.maxRetries)"));
+        assertTrue(client.contains("httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(&networkRetryDecorator, client.clientPolicy.maxRedirect)"));
+        assertTrue(client.contains("response, requestErr := httpRedirectDecorator.Invoke(request)"));
+    }
+
+    @Test
+    public void putAzureDataReplicationRule() throws IOException, TemplateModelException {
+        // This tests generation of request with "type" required parameter keyword conflict
+        final String requestName = "PutAzureDataReplicationRuleSpectraS3Request";
+        final FileUtils fileUtils = mock(FileUtils.class);
+        final GoTestCodeUtil codeGenerator = new GoTestCodeUtil(fileUtils, requestName);
+
+        codeGenerator.generateCode(fileUtils, "/input/putAzureDataReplicationRule.xml");
+
+        // Verify Request file was generated
+        final String requestCode = codeGenerator.getRequestCode();
+        CODE_LOGGER.logFile(requestCode, FileTypeToLog.REQUEST);
+        assertTrue(hasContent(requestCode));
+
+        // test request imports
+        assertTrue(requestCode.contains("\"net/url\""));
+        assertTrue(requestCode.contains("\"net/http\""));
+        assertTrue(requestCode.contains("\"ds3/networking\""));
+
+        // test request struct
+        assertTrue(requestCode.contains("dataPolicyId string"));
+        assertTrue(requestCode.contains("dataReplicationRuleType DataReplicationRuleType"));
+        assertTrue(requestCode.contains("maxBlobPartSizeInBytes int64"));
+        assertTrue(requestCode.contains("replicateDeletes bool"));
+        assertTrue(requestCode.contains("targetId string"));
+
+        // test constructor and
+        assertTrue(requestCode.contains("func NewPutAzureDataReplicationRuleSpectraS3Request(dataPolicyId string, dataReplicationRuleType DataReplicationRuleType, targetId string) *PutAzureDataReplicationRuleSpectraS3Request {"));
+        assertTrue(requestCode.contains("queryParams.Set(\"type\", dataReplicationRuleType.String())"));
+        assertTrue(requestCode.contains("dataReplicationRuleType: dataReplicationRuleType,"));
+
+        // test with-constructors
+        assertTrue(requestCode.contains("func (putAzureDataReplicationRuleSpectraS3Request *PutAzureDataReplicationRuleSpectraS3Request) WithMaxBlobPartSizeInBytes(maxBlobPartSizeInBytes int64) *PutAzureDataReplicationRuleSpectraS3Request {"));
+        assertTrue(requestCode.contains("func (putAzureDataReplicationRuleSpectraS3Request *PutAzureDataReplicationRuleSpectraS3Request) WithReplicateDeletes(replicateDeletes bool) *PutAzureDataReplicationRuleSpectraS3Request {"));
+
+        // Verify Response file was generated
+        final String responseCode = codeGenerator.getResponseCode();
+        CODE_LOGGER.logFile(responseCode, FileTypeToLog.RESPONSE);
+        assertTrue(hasContent(responseCode));
+
+        assertTrue(responseCode.contains("func NewPutAzureDataReplicationRuleSpectraS3Response(webResponse networking.WebResponse) (*PutAzureDataReplicationRuleSpectraS3Response, error) {"));
+        assertTrue(responseCode.contains("expectedStatusCodes := []int { 201 }"));
+        assertTrue(responseCode.contains("if err := readResponseBody(webResponse, &body); err != nil {"));
+        assertTrue(responseCode.contains("return &body, nil"));
+
+        // Verify response payload type file was not generated
+        final String typeCode = codeGenerator.getTypeCode();
+        CODE_LOGGER.logFile(typeCode, FileTypeToLog.MODEL);
+        assertTrue(isEmpty(typeCode));
+
+        // Verify that the client code was generated
+        final String client = codeGenerator.getClientCode(HttpVerb.POST);
+        CODE_LOGGER.logFile(client, FileTypeToLog.CLIENT);
+        assertTrue(hasContent(client));
+
+        assertTrue(client.contains("func (client *Client) PutAzureDataReplicationRuleSpectraS3(request *models.PutAzureDataReplicationRuleSpectraS3Request) (*models.PutAzureDataReplicationRuleSpectraS3Response, error) {"));
         assertTrue(client.contains("networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.netLayer), client.clientPolicy.maxRetries)"));
         assertTrue(client.contains("response, requestErr := networkRetryDecorator.Invoke(request)"));
     }

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/request/RequestGeneratorUtil_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/request/RequestGeneratorUtil_Test.java
@@ -27,10 +27,7 @@ import org.junit.Test;
 
 import static com.spectralogic.ds3autogen.go.generators.request.RequestGeneratorUtilKt.*;
 import static com.spectralogic.ds3autogen.testutil.Ds3ModelFixtures.*;
-import static com.spectralogic.ds3autogen.utils.Helper.uncapFirst;
-import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.assertThat;
 
 public class RequestGeneratorUtil_Test {
@@ -126,19 +123,27 @@ public class RequestGeneratorUtil_Test {
 
     @Test
     public void toGoArgument_Test() {
-        final ImmutableList<String> expectedTypes = ImmutableList.of("", "*int", "float64", "string");
+        final ImmutableList<Arguments> expectedArgs = ImmutableList.of(
+                new Arguments("", "param1"),
+                new Arguments("*int", "param2"),
+                new Arguments("float64", "param3"),
+                new Arguments("string", "param4"),
+                new Arguments("TestType", "testType")
+        );
 
         final ImmutableList<Ds3Param> params = ImmutableList.of(
                 new Ds3Param("Param1", "void", false),
                 new Ds3Param("Param2", "java.lang.Integer", true),
                 new Ds3Param("Param3", "double", false),
-                new Ds3Param("Param4", "java.util.UUID", false)
+                new Ds3Param("Param4", "java.util.UUID", false),
+                new Ds3Param("Type", "com.test.TestType", false)
         );
 
         for (int i = 0; i < params.size(); i++) {
             final Arguments result = toGoArgument(params.get(i));
-            assertThat(result.getName(), is(uncapFirst(params.get(i).getName())));
-            assertThat(result.getType(), is(expectedTypes.get(i)));
+            final Arguments expected = expectedArgs.get(i);
+            assertThat(result.getName(), is(expected.getName()));
+            assertThat(result.getType(), is(expected.getType()));
         }
     }
 
@@ -195,7 +200,8 @@ public class RequestGeneratorUtil_Test {
                 new Variable("param_one", "strconv.Itoa(paramOne)"),
                 new Variable("param_two", "strconv.FormatFloat(paramTwo, 'f', -1, 64)"),
                 new Variable("param_three", "paramThree"),
-                new Variable("param_four", "\"\"")
+                new Variable("param_four", "\"\""),
+                new Variable("type", "typeName.String()")
         );
 
         final ImmutableList<Ds3Param> params = ImmutableList.of(
@@ -203,7 +209,8 @@ public class RequestGeneratorUtil_Test {
                 new Ds3Param("ParamTwo", "float64", false),
                 new Ds3Param("ParamThree", "string", false),
                 new Ds3Param("ParamFour", "void", false),
-                new Ds3Param("Operation", "RestOperationType", false)
+                new Ds3Param("Operation", "RestOperationType", false),
+                new Ds3Param("Type", "com.test.TypeName", false)
         );
 
         final ImmutableList<Variable> result = toQueryParamVarList(params);
@@ -270,21 +277,20 @@ public class RequestGeneratorUtil_Test {
         final ImmutableList<SimpleVariable> expected = ImmutableList.of(
                 new SimpleVariable("paramOne"),
                 new SimpleVariable("paramTwo"),
-                new SimpleVariable("paramThree")
+                new SimpleVariable("paramThree"),
+                new SimpleVariable("typeName")
         );
 
         final ImmutableList<Ds3Param> params = ImmutableList.of(
                 new Ds3Param("ParamOne", "string", false),
                 new Ds3Param("ParamTwo", "string", true),
-                new Ds3Param("ParamThree", "string", false)
+                new Ds3Param("ParamThree", "string", false),
+                new Ds3Param("Type", "com.test.TypeName", false)
         );
 
         final ImmutableList<SimpleVariable> result = toSimpleVariables(params);
-        assertThat(result.size(), is(3));
-
-        for (int i = 0; i < result.size(); i++) {
-            assertThat(result.get(i), is(expected.get(i)));
-        }
+        assertThat(result.size(), is(expected.size()));
+        expected.forEach(expectedVar -> assertThat(result, hasItem(expectedVar)));
     }
 
     @Test
@@ -399,14 +405,16 @@ public class RequestGeneratorUtil_Test {
     public void toWithConstructors_NonNullableParams_Test() {
         final ImmutableList<WithConstructor> expected = ImmutableList.of(
                 new WithConstructor("ParamOne", "Type1", "param_one", "paramOne.String()"),
-                new WithConstructor("ParamThree", "int", "param_three", "strconv.Itoa(paramThree)")
+                new WithConstructor("ParamThree", "int", "param_three", "strconv.Itoa(paramThree)"),
+                new WithConstructor("TypeName", "TypeName", "type", "typeName.String()")
         );
 
         final ImmutableList<Ds3Param> params = ImmutableList.of(
                 new Ds3Param("ParamOne", "Type1", false),
                 new Ds3Param("ParamTwo", "void", false),
                 new Ds3Param("ParamThree", "int", false),
-                new Ds3Param("ParamFour", "VOID", false)
+                new Ds3Param("ParamFour", "VOID", false),
+                new Ds3Param("Type", "com.test.TypeName", false)
         );
 
         final ImmutableList<WithConstructor> result = toWithConstructors(params, false);
@@ -419,19 +427,39 @@ public class RequestGeneratorUtil_Test {
     public void toWithConstructors_NullableParams_Test() {
         final ImmutableList<WithConstructor> expected = ImmutableList.of(
                 new WithConstructor("ParamOne", "*Type1", "param_one", "paramOne.String()"),
-                new WithConstructor("ParamThree", "*int", "param_three", "strconv.Itoa(*paramThree)")
+                new WithConstructor("ParamThree", "*int", "param_three", "strconv.Itoa(*paramThree)"),
+                new WithConstructor("TypeName", "*TypeName", "type", "typeName.String()")
         );
 
         final ImmutableList<Ds3Param> params = ImmutableList.of(
                 new Ds3Param("ParamOne", "Type1", true),
                 new Ds3Param("ParamTwo", "void", true),
                 new Ds3Param("ParamThree", "int", true),
-                new Ds3Param("ParamFour", "VOID", true)
+                new Ds3Param("ParamFour", "VOID", true),
+                new Ds3Param("Type", "com.test.TypeName", true)
         );
 
         final ImmutableList<WithConstructor> result = toWithConstructors(params, true);
         assertThat(result.size(), is(expected.size()));
 
         expected.forEach(expectedConst -> assertThat(result, hasItem(expectedConst)));
+    }
+
+    @Test
+    public void toWithConstructor_Test() {
+        final ImmutableList<WithConstructor> expected = ImmutableList.of(
+                new WithConstructor("ParamOne", "Type1", "param_one", "paramOne.String()"),
+                new WithConstructor("ParamTwo", "int", "param_two", "strconv.Itoa(paramTwo)"),
+                new WithConstructor("TypeName", "TypeName", "type", "typeName.String()")
+        );
+
+        final ImmutableList<Ds3Param> params = ImmutableList.of(
+                new Ds3Param("ParamOne", "Type1", false),
+                new Ds3Param("ParamTwo", "int", false),
+                new Ds3Param("Type", "com.test.TypeName", false)
+        );
+
+        assertThat(params.size(), is(expected.size()));
+        params.forEach(param -> assertThat(expected, hasItem(toWithConstructor(param))));
     }
 }

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/utils/GoNamingUtil_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/utils/GoNamingUtil_Test.java
@@ -1,0 +1,39 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.go.utils;
+
+import org.junit.Test;
+
+import static com.spectralogic.ds3autogen.go.utils.GoNamingUtilKt.toGoParamName;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class GoNamingUtil_Test {
+
+    @Test
+    public void toGoParamName_TwoParam_Test() {
+        assertThat(toGoParamName("Name", "TypeName"), is("Name"));
+        assertThat(toGoParamName("Type", "TypeName"), is("TypeName"));
+        assertThat(toGoParamName("Type", "com.test.TypeName"), is("TypeName"));
+    }
+
+    @Test
+    public void toGoParamName_ThreeParam_Test() {
+        assertThat(toGoParamName("Name", "com.test.TypeName", ""), is("Name"));
+        assertThat(toGoParamName("Type", "com.test.TypeName", ""), is("TypeName"));
+        assertThat(toGoParamName("Type", "array", "com.test.ComponentType"), is("ComponentTypeList"));
+    }
+}

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/utils/GoTestCodeUtil.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/utils/GoTestCodeUtil.java
@@ -41,8 +41,8 @@ import static org.mockito.Mockito.when;
  */
 public class GoTestCodeUtil {
 
-    final static String BASE_PATH = "./ds3/";
-    final static String COMMAND_PATH = BASE_PATH + "models/";
+    private final static String BASE_PATH = "./ds3/";
+    private final static String COMMAND_PATH = BASE_PATH + "models/";
 
     private final ByteArrayOutputStream requestOutputStream;
     private final ByteArrayOutputStream responseOutputStream;

--- a/ds3-autogen-go/src/test/resources/input/getAzureDataReplicationRules.xml
+++ b/ds3-autogen-go/src/test/resources/input/getAzureDataReplicationRules.xml
@@ -1,0 +1,82 @@
+<Data>
+    <Contract>
+        <RequestHandlers>
+            <RequestHandler Classification="spectrads3" Name="com.spectralogic.s3.server.handler.reqhandler.spectrads3.datapolicy.GetAzureDataReplicationRulesRequestHandler">
+                <Request Action="LIST" HttpVerb="GET" IncludeIdInPath="false" Resource="AZURE_DATA_REPLICATION_RULE" ResourceType="NON_SINGLETON">
+                    <OptionalQueryParams>
+                        <Param Name="DataPolicyId" Type="java.util.UUID"/>
+                        <Param Name="LastPage" Type="void"/>
+                        <Param Name="PageLength" Type="int"/>
+                        <Param Name="PageOffset" Type="int"/>
+                        <Param Name="PageStartMarker" Type="java.util.UUID"/>
+                        <Param Name="ReplicateDeletes" Type="boolean"/>
+                        <Param Name="State" Type="com.spectralogic.s3.common.dao.domain.ds3.DataPlacementRuleState"/>
+                        <Param Name="TargetId" Type="java.util.UUID"/>
+                        <Param Name="Type" Type="com.spectralogic.s3.common.dao.domain.ds3.DataReplicationRuleType"/>
+                    </OptionalQueryParams>
+                    <RequiredQueryParams/>
+                </Request>
+                <ResponseCodes>
+                    <ResponseCode>
+                        <Code>200</Code>
+                        <ResponseTypes>
+                            <ResponseType ComponentType="com.spectralogic.s3.common.dao.domain.ds3.AzureDataReplicationRule" Type="array"/>
+                        </ResponseTypes>
+                    </ResponseCode>
+                </ResponseCodes>
+                <Version>1.760344CC17CCA3AAC0D1AEAAB22664BE</Version>
+            </RequestHandler>
+        </RequestHandlers>
+        <Types>
+            <Type Name="com.spectralogic.s3.common.dao.domain.ds3.AzureDataReplicationRule">
+                <Elements>
+                    <Element Name="DataPolicyId" Type="java.util.UUID">
+                        <Annotations>
+                            <Annotation Name="com.spectralogic.util.db.lang.References">
+                                <AnnotationElements>
+                                    <AnnotationElement Name="Value" Value="com.spectralogic.s3.common.dao.domain.ds3.DataPolicy" ValueType="java.lang.Class"/>
+                                </AnnotationElements>
+                            </Annotation>
+                        </Annotations>
+                    </Element>
+                    <Element Name="Id" Type="java.util.UUID">
+                        <Annotations/>
+                    </Element>
+                    <Element Name="MaxBlobPartSizeInBytes" Type="long">
+                        <Annotations>
+                            <Annotation Name="com.spectralogic.util.bean.lang.DefaultLongValue">
+                                <AnnotationElements>
+                                    <AnnotationElement Name="Value" Value="1073741824" ValueType="java.lang.Long"/>
+                                </AnnotationElements>
+                            </Annotation>
+                        </Annotations>
+                    </Element>
+                    <Element Name="ReplicateDeletes" Type="boolean">
+                        <Annotations>
+                            <Annotation Name="com.spectralogic.util.bean.lang.DefaultBooleanValue">
+                                <AnnotationElements>
+                                    <AnnotationElement Name="Value" Value="true" ValueType="java.lang.Boolean"/>
+                                </AnnotationElements>
+                            </Annotation>
+                        </Annotations>
+                    </Element>
+                    <Element Name="State" Type="com.spectralogic.s3.common.dao.domain.ds3.DataPlacementRuleState">
+                        <Annotations/>
+                    </Element>
+                    <Element Name="TargetId" Type="java.util.UUID">
+                        <Annotations>
+                            <Annotation Name="com.spectralogic.util.db.lang.References">
+                                <AnnotationElements>
+                                    <AnnotationElement Name="Value" Value="com.spectralogic.s3.common.dao.domain.target.AzureTarget" ValueType="java.lang.Class"/>
+                                </AnnotationElements>
+                            </Annotation>
+                        </Annotations>
+                    </Element>
+                    <Element Name="Type" Type="com.spectralogic.s3.common.dao.domain.ds3.DataReplicationRuleType">
+                        <Annotations/>
+                    </Element>
+                </Elements>
+            </Type>
+        </Types>
+    </Contract>
+</Data>

--- a/ds3-autogen-go/src/test/resources/input/putAzureDataReplicationRule.xml
+++ b/ds3-autogen-go/src/test/resources/input/putAzureDataReplicationRule.xml
@@ -1,0 +1,79 @@
+<Data>
+    <Contract>
+        <RequestHandlers>
+            <RequestHandler Classification="spectrads3" Name="com.spectralogic.s3.server.handler.reqhandler.spectrads3.datapolicy.CreateAzureDataReplicationRuleRequestHandler">
+                <Request Action="CREATE" HttpVerb="POST" IncludeIdInPath="false" Resource="AZURE_DATA_REPLICATION_RULE" ResourceType="NON_SINGLETON">
+                    <OptionalQueryParams>
+                        <Param Name="MaxBlobPartSizeInBytes" Type="long"/>
+                        <Param Name="ReplicateDeletes" Type="boolean"/>
+                    </OptionalQueryParams>
+                    <RequiredQueryParams>
+                        <Param Name="DataPolicyId" Type="java.util.UUID"/>
+                        <Param Name="TargetId" Type="java.util.UUID"/>
+                        <Param Name="Type" Type="com.spectralogic.s3.common.dao.domain.ds3.DataReplicationRuleType"/>
+                    </RequiredQueryParams>
+                </Request>
+                <ResponseCodes>
+                    <ResponseCode>
+                        <Code>201</Code>
+                        <ResponseTypes>
+                            <ResponseType Type="com.spectralogic.s3.common.dao.domain.ds3.AzureDataReplicationRule"/>
+                        </ResponseTypes>
+                    </ResponseCode>
+                </ResponseCodes>
+                <Version>1.15D63B0FD0C4257041795BA2235277C5</Version>
+            </RequestHandler>
+        </RequestHandlers>
+        <Types>
+            <Type Name="com.spectralogic.s3.common.dao.domain.ds3.AzureDataReplicationRule">
+                <Elements>
+                    <Element Name="DataPolicyId" Type="java.util.UUID">
+                        <Annotations>
+                            <Annotation Name="com.spectralogic.util.db.lang.References">
+                                <AnnotationElements>
+                                    <AnnotationElement Name="Value" Value="com.spectralogic.s3.common.dao.domain.ds3.DataPolicy" ValueType="java.lang.Class"/>
+                                </AnnotationElements>
+                            </Annotation>
+                        </Annotations>
+                    </Element>
+                    <Element Name="Id" Type="java.util.UUID">
+                        <Annotations/>
+                    </Element>
+                    <Element Name="MaxBlobPartSizeInBytes" Type="long">
+                        <Annotations>
+                            <Annotation Name="com.spectralogic.util.bean.lang.DefaultLongValue">
+                                <AnnotationElements>
+                                    <AnnotationElement Name="Value" Value="1073741824" ValueType="java.lang.Long"/>
+                                </AnnotationElements>
+                            </Annotation>
+                        </Annotations>
+                    </Element>
+                    <Element Name="ReplicateDeletes" Type="boolean">
+                        <Annotations>
+                            <Annotation Name="com.spectralogic.util.bean.lang.DefaultBooleanValue">
+                                <AnnotationElements>
+                                    <AnnotationElement Name="Value" Value="true" ValueType="java.lang.Boolean"/>
+                                </AnnotationElements>
+                            </Annotation>
+                        </Annotations>
+                    </Element>
+                    <Element Name="State" Type="com.spectralogic.s3.common.dao.domain.ds3.DataPlacementRuleState">
+                        <Annotations/>
+                    </Element>
+                    <Element Name="TargetId" Type="java.util.UUID">
+                        <Annotations>
+                            <Annotation Name="com.spectralogic.util.db.lang.References">
+                                <AnnotationElements>
+                                    <AnnotationElement Name="Value" Value="com.spectralogic.s3.common.dao.domain.target.AzureTarget" ValueType="java.lang.Class"/>
+                                </AnnotationElements>
+                            </Annotation>
+                        </Annotations>
+                    </Element>
+                    <Element Name="Type" Type="com.spectralogic.s3.common.dao.domain.ds3.DataReplicationRuleType">
+                        <Annotations/>
+                    </Element>
+                </Elements>
+            </Type>
+        </Types>
+    </Contract>
+</Data>


### PR DESCRIPTION
There was a conflict in generated request parameters of name `type` since this is a keyword in Go.  This creates a `toGoParamName` util which renames parameters `type` to use their classes.  Parameters that are lists are namespaced to include List in their name.

Example name changes:
`type PoolType` -> `poolType PoolType`
`type []PoolType` -> `poolTypeList []PoolType`