### PR TITLE
Fixed notification resource generation in Go request handlers

### DIFF
--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/request/BaseRequestGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/request/BaseRequestGenerator.kt
@@ -128,8 +128,8 @@ open class BaseRequestGenerator : RequestModelGenerator<Request>, RequestModelGe
         if (ds3Request.objectRequirement != null && ds3Request.objectRequirement == Requirement.REQUIRED) {
             builder.add(Arguments("string", "objectName"))
         }
-        if (isGoResourceAnArg(ds3Request.resource, ds3Request.includeInPath)) {
-            val resourceArg: Arguments = getGoArgFromResource(ds3Request.resource)
+        if (ds3Request.isGoResourceAnArg()) {
+            val resourceArg: Arguments = ds3Request.getGoArgFromResource()
             builder.add(Arguments(toGoType(resourceArg.type), uncapFirst(resourceArg.name)))
         }
 
@@ -168,8 +168,8 @@ open class BaseRequestGenerator : RequestModelGenerator<Request>, RequestModelGe
         if (ds3Request.objectRequirement != null && ds3Request.objectRequirement == Requirement.REQUIRED) {
             builder.add(SimpleVariable("objectName"))
         }
-        if (isGoResourceAnArg(ds3Request.resource, ds3Request.includeInPath)) {
-            val resourceArg: Arguments = getGoArgFromResource(ds3Request.resource)
+        if (ds3Request.isGoResourceAnArg()) {
+            val resourceArg: Arguments = ds3Request.getGoArgFromResource()
             builder.add(SimpleVariable(uncapFirst(resourceArg.name)))
         }
 

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/request/BaseRequestGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/request/BaseRequestGenerator.kt
@@ -27,7 +27,6 @@ import com.spectralogic.ds3autogen.utils.ConverterUtil.isEmpty
 import com.spectralogic.ds3autogen.utils.Helper
 import com.spectralogic.ds3autogen.utils.Helper.uncapFirst
 import com.spectralogic.ds3autogen.utils.NormalizingContractNamesUtil
-import com.spectralogic.ds3autogen.utils.RequestConverterUtil
 import com.spectralogic.ds3autogen.utils.collections.GuavaCollectors
 import com.spectralogic.ds3autogen.utils.comparators.CustomArgumentComparator
 
@@ -95,18 +94,7 @@ open class BaseRequestGenerator : RequestModelGenerator<Request>, RequestModelGe
      */
     protected fun structParamsFromRequest(ds3Request: Ds3Request): ImmutableList<Arguments> {
         val builder: ImmutableList.Builder<Arguments> = ImmutableList.builder()
-        if (ds3Request.bucketRequirement != null && ds3Request.bucketRequirement == Requirement.REQUIRED) {
-            builder.add(Arguments("string", "bucketName"))
-        }
-        if (ds3Request.objectRequirement != null && ds3Request.objectRequirement == Requirement.REQUIRED) {
-            builder.add(Arguments("string", "objectName"))
-        }
-        if (RequestConverterUtil.isResourceAnArg(ds3Request.resource, ds3Request.includeInPath)) {
-            val resourceArg: Arguments = RequestConverterUtil.getArgFromResource(ds3Request.resource)
-            builder.add(Arguments(toGoType(resourceArg.type), uncapFirst(resourceArg.name)))
-        }
-
-        builder.addAll(toGoArgumentsList(removeVoidAndOperationDs3Params(ds3Request.requiredQueryParams)))
+        builder.addAll(paramsListFromRequest(ds3Request))
         builder.addAll(toGoArgumentsList(removeVoidDs3Params(ds3Request.optionalQueryParams)))
         return builder.build()
     }
@@ -125,6 +113,14 @@ open class BaseRequestGenerator : RequestModelGenerator<Request>, RequestModelGe
     }
 
     override fun toConstructorParamsList(ds3Request: Ds3Request): ImmutableList<Arguments> {
+        return paramsListFromRequest(ds3Request)
+    }
+
+    /**
+     * Retrieves constructor param list from the Ds3Request. This is reused by special-cased
+     * generators to fetch always-present constructor params.
+     */
+    fun paramsListFromRequest(ds3Request: Ds3Request): ImmutableList<Arguments> {
         val builder: ImmutableList.Builder<Arguments> = ImmutableList.builder()
         if (ds3Request.bucketRequirement != null && ds3Request.bucketRequirement == Requirement.REQUIRED) {
             builder.add(Arguments("string", "bucketName"))
@@ -132,8 +128,8 @@ open class BaseRequestGenerator : RequestModelGenerator<Request>, RequestModelGe
         if (ds3Request.objectRequirement != null && ds3Request.objectRequirement == Requirement.REQUIRED) {
             builder.add(Arguments("string", "objectName"))
         }
-        if (RequestConverterUtil.isResourceAnArg(ds3Request.resource, ds3Request.includeInPath)) {
-            val resourceArg: Arguments = RequestConverterUtil.getArgFromResource(ds3Request.resource)
+        if (isGoResourceAnArg(ds3Request.resource, ds3Request.includeInPath)) {
+            val resourceArg: Arguments = getGoArgFromResource(ds3Request.resource)
             builder.add(Arguments(toGoType(resourceArg.type), uncapFirst(resourceArg.name)))
         }
 
@@ -172,8 +168,8 @@ open class BaseRequestGenerator : RequestModelGenerator<Request>, RequestModelGe
         if (ds3Request.objectRequirement != null && ds3Request.objectRequirement == Requirement.REQUIRED) {
             builder.add(SimpleVariable("objectName"))
         }
-        if (RequestConverterUtil.isResourceAnArg(ds3Request.resource, ds3Request.includeInPath)) {
-            val resourceArg: Arguments = RequestConverterUtil.getArgFromResource(ds3Request.resource)
+        if (isGoResourceAnArg(ds3Request.resource, ds3Request.includeInPath)) {
+            val resourceArg: Arguments = getGoArgFromResource(ds3Request.resource)
             builder.add(SimpleVariable(uncapFirst(resourceArg.name)))
         }
 

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/request/RequestGeneratorUtil.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/request/RequestGeneratorUtil.kt
@@ -22,6 +22,7 @@ import com.spectralogic.ds3autogen.api.models.apispec.Ds3Request
 import com.spectralogic.ds3autogen.api.models.enums.Classification
 import com.spectralogic.ds3autogen.api.models.enums.HttpVerb
 import com.spectralogic.ds3autogen.api.models.enums.Requirement
+import com.spectralogic.ds3autogen.api.models.enums.Resource
 import com.spectralogic.ds3autogen.go.models.request.SimpleVariable
 import com.spectralogic.ds3autogen.go.models.request.Variable
 import com.spectralogic.ds3autogen.go.models.request.WithConstructor
@@ -36,6 +37,7 @@ import com.spectralogic.ds3autogen.utils.Helper.camelToUnderscore
 import com.spectralogic.ds3autogen.utils.Helper.uncapFirst
 import com.spectralogic.ds3autogen.utils.NormalizingContractNamesUtil.removePath
 import com.spectralogic.ds3autogen.utils.RequestConverterUtil.*
+
 import com.spectralogic.ds3autogen.utils.collections.GuavaCollectors
 import com.spectralogic.ds3autogen.utils.comparators.CustomArgumentComparator
 import com.spectralogic.ds3autogen.utils.models.NotificationType
@@ -229,8 +231,8 @@ fun getSpectraDs3RequestPath(ds3Request: Ds3Request): String {
         builder.append("/\"").append(" + ").append(requestRef).append(".notificationId")
     } else if (hasBucketNameInPath(ds3Request)) {
         builder.append("/\"").append(" + ").append(requestRef).append(".bucketName")
-    } else if (isResourceAnArg(ds3Request.resource, ds3Request.includeInPath)) {
-        val resourceArg = getArgFromResource(ds3Request.resource)
+    } else if (isGoResourceAnArg(ds3Request.resource, ds3Request.includeInPath)) {
+        val resourceArg = getGoArgFromResource(ds3Request.resource)
         builder.append("/\"").append(" + ").append(uncapFirst(requestRef))
                 .append(".").append(uncapFirst(resourceArg.name))
     } else {
@@ -265,4 +267,34 @@ fun toWithConstructor(ds3Param: Ds3Param): WithConstructor {
             goType,
             camelToUnderscore(ds3Param.name),
             goVarToString(uncapFirst(goName), goType))
+}
+
+/**
+ * Determines if a Ds3Request's Resource describes a required argument or not.
+ */
+fun isGoResourceAnArg(
+        resource: Resource?,
+        includeIdInPath: Boolean): Boolean {
+    return resource != null && includeIdInPath
+}
+
+/**
+ * Creates an argument from a resource. Notification resource args are simplified to notificationId.
+ * If the resource does not describe a valid argument, such as a singleton, an error is thrown.
+ * @param resource A Ds3Request's Resource
+ */
+fun getGoArgFromResource(resource: Resource?): Arguments {
+    if (isResourceSingleton(resource)) {
+        throw IllegalArgumentException("Cannot create an argument from a singleton resource: " + resource.toString())
+    }
+    if (isResourceNotification(resource)) {
+        return Arguments("String", "notificationId")
+    }
+    if (isResourceNamed(resource)) {
+        return Arguments("String", Helper.underscoreToCamel(resource.toString()) + "Name")
+    }
+    if (isResourceId(resource)) {
+        return Arguments("UUID", Helper.underscoreToCamel(resource.toString()) + "Id")
+    }
+    return Arguments("String", Helper.underscoreToCamel(resource.toString()))
 }

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/request/RequestGeneratorUtil.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/request/RequestGeneratorUtil.kt
@@ -22,7 +22,6 @@ import com.spectralogic.ds3autogen.api.models.apispec.Ds3Request
 import com.spectralogic.ds3autogen.api.models.enums.Classification
 import com.spectralogic.ds3autogen.api.models.enums.HttpVerb
 import com.spectralogic.ds3autogen.api.models.enums.Requirement
-import com.spectralogic.ds3autogen.api.models.enums.Resource
 import com.spectralogic.ds3autogen.go.models.request.SimpleVariable
 import com.spectralogic.ds3autogen.go.models.request.Variable
 import com.spectralogic.ds3autogen.go.models.request.WithConstructor
@@ -37,7 +36,6 @@ import com.spectralogic.ds3autogen.utils.Helper.camelToUnderscore
 import com.spectralogic.ds3autogen.utils.Helper.uncapFirst
 import com.spectralogic.ds3autogen.utils.NormalizingContractNamesUtil.removePath
 import com.spectralogic.ds3autogen.utils.RequestConverterUtil.*
-
 import com.spectralogic.ds3autogen.utils.collections.GuavaCollectors
 import com.spectralogic.ds3autogen.utils.comparators.CustomArgumentComparator
 import com.spectralogic.ds3autogen.utils.models.NotificationType
@@ -231,8 +229,8 @@ fun getSpectraDs3RequestPath(ds3Request: Ds3Request): String {
         builder.append("/\"").append(" + ").append(requestRef).append(".notificationId")
     } else if (hasBucketNameInPath(ds3Request)) {
         builder.append("/\"").append(" + ").append(requestRef).append(".bucketName")
-    } else if (isGoResourceAnArg(ds3Request.resource, ds3Request.includeInPath)) {
-        val resourceArg = getGoArgFromResource(ds3Request.resource)
+    } else if (ds3Request.isGoResourceAnArg()) {
+        val resourceArg = ds3Request.getGoArgFromResource()
         builder.append("/\"").append(" + ").append(uncapFirst(requestRef))
                 .append(".").append(uncapFirst(resourceArg.name))
     } else {
@@ -272,29 +270,26 @@ fun toWithConstructor(ds3Param: Ds3Param): WithConstructor {
 /**
  * Determines if a Ds3Request's Resource describes a required argument or not.
  */
-fun isGoResourceAnArg(
-        resource: Resource?,
-        includeIdInPath: Boolean): Boolean {
-    return resource != null && includeIdInPath
+fun Ds3Request.isGoResourceAnArg(): Boolean {
+    return this.resource != null && this.includeInPath
 }
 
 /**
  * Creates an argument from a resource. Notification resource args are simplified to notificationId.
  * If the resource does not describe a valid argument, such as a singleton, an error is thrown.
- * @param resource A Ds3Request's Resource
  */
-fun getGoArgFromResource(resource: Resource?): Arguments {
-    if (isResourceSingleton(resource)) {
-        throw IllegalArgumentException("Cannot create an argument from a singleton resource: " + resource.toString())
+fun Ds3Request.getGoArgFromResource(): Arguments {
+    if (isResourceSingleton(this.resource)) {
+        throw IllegalArgumentException("Cannot create an argument from a singleton resource: " + this.resource.toString())
     }
-    if (isResourceNotification(resource)) {
+    if (isResourceNotification(this.resource)) {
         return Arguments("String", "notificationId")
     }
-    if (isResourceNamed(resource)) {
-        return Arguments("String", Helper.underscoreToCamel(resource.toString()) + "Name")
+    if (isResourceNamed(this.resource)) {
+        return Arguments("String", Helper.underscoreToCamel(this.resource.toString()) + "Name")
     }
-    if (isResourceId(resource)) {
-        return Arguments("UUID", Helper.underscoreToCamel(resource.toString()) + "Id")
+    if (isResourceId(this.resource)) {
+        return Arguments("UUID", Helper.underscoreToCamel(this.resource.toString()) + "Id")
     }
-    return Arguments("String", Helper.underscoreToCamel(resource.toString()))
+    return Arguments("String", Helper.underscoreToCamel(this.resource.toString()))
 }

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/request/RequestGeneratorUtil.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/request/RequestGeneratorUtil.kt
@@ -271,7 +271,7 @@ fun toWithConstructor(ds3Param: Ds3Param): WithConstructor {
  * Determines if a Ds3Request's Resource describes a required argument or not.
  */
 fun Ds3Request.isGoResourceAnArg(): Boolean {
-    return this.resource != null && this.includeInPath
+    return resource != null && includeInPath
 }
 
 /**
@@ -279,17 +279,17 @@ fun Ds3Request.isGoResourceAnArg(): Boolean {
  * If the resource does not describe a valid argument, such as a singleton, an error is thrown.
  */
 fun Ds3Request.getGoArgFromResource(): Arguments {
-    if (isResourceSingleton(this.resource)) {
-        throw IllegalArgumentException("Cannot create an argument from a singleton resource: " + this.resource.toString())
+    if (isResourceSingleton(resource)) {
+        throw IllegalArgumentException("Cannot create an argument from a singleton resource: " + resource.toString())
     }
-    if (isResourceNotification(this.resource)) {
+    if (isResourceNotification(resource)) {
         return Arguments("String", "notificationId")
     }
-    if (isResourceNamed(this.resource)) {
-        return Arguments("String", Helper.underscoreToCamel(this.resource.toString()) + "Name")
+    if (isResourceNamed(resource)) {
+        return Arguments("String", Helper.underscoreToCamel(resource.toString()) + "Name")
     }
-    if (isResourceId(this.resource)) {
-        return Arguments("UUID", Helper.underscoreToCamel(this.resource.toString()) + "Id")
+    if (isResourceId(resource)) {
+        return Arguments("UUID", Helper.underscoreToCamel(resource.toString()) + "Id")
     }
-    return Arguments("String", Helper.underscoreToCamel(this.resource.toString()))
+    return Arguments("String", Helper.underscoreToCamel(resource.toString()))
 }

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/request/RequestPayloadGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/request/RequestPayloadGenerator.kt
@@ -18,13 +18,8 @@ package com.spectralogic.ds3autogen.go.generators.request
 import com.google.common.collect.ImmutableList
 import com.spectralogic.ds3autogen.api.models.Arguments
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3Request
-import com.spectralogic.ds3autogen.api.models.enums.Requirement
-import com.spectralogic.ds3autogen.go.models.request.SimpleVariable
 import com.spectralogic.ds3autogen.go.models.request.Variable
 import com.spectralogic.ds3autogen.go.models.request.VariableInterface
-import com.spectralogic.ds3autogen.go.utils.toGoType
-import com.spectralogic.ds3autogen.utils.Helper
-import com.spectralogic.ds3autogen.utils.RequestConverterUtil
 import com.spectralogic.ds3autogen.utils.collections.GuavaCollectors
 import com.spectralogic.ds3autogen.utils.comparators.CustomArgumentComparator
 
@@ -39,19 +34,7 @@ abstract class RequestPayloadGenerator : BaseRequestGenerator() {
      */
     override fun toStructParams(ds3Request: Ds3Request): ImmutableList<Arguments> {
         val builder = ImmutableList.builder<Arguments>()
-        if (ds3Request.bucketRequirement != null && ds3Request.bucketRequirement == Requirement.REQUIRED) {
-            builder.add(Arguments("string", "bucketName"))
-        }
-        if (ds3Request.objectRequirement != null && ds3Request.objectRequirement == Requirement.REQUIRED) {
-            builder.add(Arguments("string", "objectName"))
-        }
-        if (RequestConverterUtil.isResourceAnArg(ds3Request.resource, ds3Request.includeInPath)) {
-            val resourceArg = RequestConverterUtil.getArgFromResource(ds3Request.resource)
-            builder.add(Arguments(toGoType(resourceArg.type), Helper.uncapFirst(resourceArg.name)))
-        }
-
-        builder.addAll(toGoArgumentsList(removeVoidAndOperationDs3Params(ds3Request.requiredQueryParams)))
-        builder.addAll(toGoArgumentsList(removeVoidDs3Params(ds3Request.optionalQueryParams)))
+        builder.addAll(structParamsFromRequest(ds3Request))
         builder.add(Arguments("networking.ReaderWithSizeDecorator", "content"))
 
         // Sort the arguments
@@ -65,18 +48,7 @@ abstract class RequestPayloadGenerator : BaseRequestGenerator() {
      */
     override fun toConstructorParamsList(ds3Request: Ds3Request): ImmutableList<Arguments> {
         val builder = ImmutableList.builder<Arguments>()
-        if (ds3Request.bucketRequirement != null && ds3Request.bucketRequirement == Requirement.REQUIRED) {
-            builder.add(Arguments("string", "bucketName"))
-        }
-        if (ds3Request.objectRequirement != null && ds3Request.objectRequirement == Requirement.REQUIRED) {
-            builder.add(Arguments("string", "objectName"))
-        }
-        if (RequestConverterUtil.isResourceAnArg(ds3Request.resource, ds3Request.includeInPath)) {
-            val resourceArg = RequestConverterUtil.getArgFromResource(ds3Request.resource)
-            builder.add(Arguments(toGoType(resourceArg.type), Helper.uncapFirst(resourceArg.name)))
-        }
-
-        builder.addAll(toGoArgumentsList(removeVoidAndOperationDs3Params(ds3Request.requiredQueryParams)))
+        builder.addAll(paramsListFromRequest(ds3Request))
         builder.add(getPayloadConstructorArg())
         return builder.build()
     }
@@ -88,18 +60,7 @@ abstract class RequestPayloadGenerator : BaseRequestGenerator() {
      */
     override fun toStructAssignmentParams(ds3Request: Ds3Request): ImmutableList<VariableInterface> {
         val builder = ImmutableList.builder<VariableInterface>()
-        if (ds3Request.bucketRequirement != null && ds3Request.bucketRequirement == Requirement.REQUIRED) {
-            builder.add(SimpleVariable("bucketName"))
-        }
-        if (ds3Request.objectRequirement != null && ds3Request.objectRequirement == Requirement.REQUIRED) {
-            builder.add(SimpleVariable("objectName"))
-        }
-        if (RequestConverterUtil.isResourceAnArg(ds3Request.resource, ds3Request.includeInPath)) {
-            val resourceArg = RequestConverterUtil.getArgFromResource(ds3Request.resource)
-            builder.add(SimpleVariable(Helper.uncapFirst(resourceArg.name)))
-        }
-
-        builder.addAll(toSimpleVariables(removeVoidAndOperationDs3Params(ds3Request.requiredQueryParams)))
+        builder.addAll(structAssignmentParamsFromRequest(ds3Request))
         builder.add(getStructAssignmentVariable())
 
         return builder.build()

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTests.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTests.java
@@ -37,7 +37,7 @@ import static org.mockito.Mockito.mock;
 public class GoFunctionalTests {
 
     private final static Logger LOG = LoggerFactory.getLogger(GoFunctionalTests.class);
-    private final static GeneratedCodeLogger CODE_LOGGER = new GeneratedCodeLogger(FileTypeToLog.RESPONSE, LOG);
+    private final static GeneratedCodeLogger CODE_LOGGER = new GeneratedCodeLogger(FileTypeToLog.REQUEST, LOG);
 
     @Test
     public void simpleRequestNoPayload() throws IOException, TemplateModelException {
@@ -543,6 +543,60 @@ public class GoFunctionalTests {
         assertTrue(hasContent(client));
 
         assertTrue(client.contains("func (client *Client) PutAzureDataReplicationRuleSpectraS3(request *models.PutAzureDataReplicationRuleSpectraS3Request) (*models.PutAzureDataReplicationRuleSpectraS3Response, error) {"));
+        assertTrue(client.contains("networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.netLayer), client.clientPolicy.maxRetries)"));
+        assertTrue(client.contains("response, requestErr := networkRetryDecorator.Invoke(request)"));
+    }
+
+    @Test
+    public void deleteJobCreatedNotificationRegistration() throws IOException, TemplateModelException {
+        // This tests correct generation of notificationId required parameter from resource
+        final String requestName = "DeleteJobCreatedNotificationRegistrationSpectraS3Request";
+        final FileUtils fileUtils = mock(FileUtils.class);
+        final GoTestCodeUtil codeGenerator = new GoTestCodeUtil(fileUtils, requestName);
+
+        codeGenerator.generateCode(fileUtils, "/input/deleteJobCreatedNotificationRegistration.xml");
+
+        // Verify Request file was generated
+        final String requestCode = codeGenerator.getRequestCode();
+        CODE_LOGGER.logFile(requestCode, FileTypeToLog.REQUEST);
+        assertTrue(hasContent(requestCode));
+
+        // test request imports
+        assertTrue(requestCode.contains("\"net/url\""));
+        assertTrue(requestCode.contains("\"net/http\""));
+        assertTrue(requestCode.contains("\"ds3/networking\""));
+
+        // test request struct
+        assertTrue(requestCode.contains("notificationId string"));
+        assertTrue(requestCode.contains("queryParams *url.Values"));
+
+        // test constructor
+        assertTrue(requestCode.contains("func NewDeleteJobCreatedNotificationRegistrationSpectraS3Request(notificationId string) *DeleteJobCreatedNotificationRegistrationSpectraS3Request {"));
+        assertTrue(requestCode.contains("notificationId: notificationId,"));
+
+        // test path
+        assertTrue(requestCode.contains("return \"/_rest_/job_created_notification_registration/\" + deleteJobCreatedNotificationRegistrationSpectraS3Request.notificationId"));
+
+        // Verify Response file was generated
+        final String responseCode = codeGenerator.getResponseCode();
+        CODE_LOGGER.logFile(responseCode, FileTypeToLog.RESPONSE);
+        assertTrue(hasContent(responseCode));
+
+        assertTrue(responseCode.contains("func NewDeleteJobCreatedNotificationRegistrationSpectraS3Response(webResponse networking.WebResponse) (*DeleteJobCreatedNotificationRegistrationSpectraS3Response, error) {"));
+        assertTrue(responseCode.contains("expectedStatusCodes := []int { 204 }"));
+        assertTrue(responseCode.contains("return &DeleteJobCreatedNotificationRegistrationSpectraS3Response{}, nil"));
+
+        // Verify response payload type file was not generated
+        final String typeCode = codeGenerator.getTypeCode();
+        CODE_LOGGER.logFile(typeCode, FileTypeToLog.MODEL);
+        assertTrue(isEmpty(typeCode));
+
+        // Verify that the client code was generated
+        final String client = codeGenerator.getClientCode(HttpVerb.DELETE);
+        CODE_LOGGER.logFile(client, FileTypeToLog.CLIENT);
+        assertTrue(hasContent(client));
+
+        assertTrue(client.contains("func (client *Client) DeleteJobCreatedNotificationRegistrationSpectraS3(request *models.DeleteJobCreatedNotificationRegistrationSpectraS3Request) (*models.DeleteJobCreatedNotificationRegistrationSpectraS3Response, error) {"));
         assertTrue(client.contains("networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.netLayer), client.clientPolicy.maxRetries)"));
         assertTrue(client.contains("response, requestErr := networkRetryDecorator.Invoke(request)"));
     }

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/request/BaseRequestGenerator_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/request/BaseRequestGenerator_Test.java
@@ -132,6 +132,25 @@ public class BaseRequestGenerator_Test {
     }
 
     @Test
+    public void paramsListFromRequest_Test() {
+        final ImmutableList<Arguments> expectedArgs = ImmutableList.of(
+                new Arguments("string", "bucketName"),
+                new Arguments("string", "objectName"),
+                new Arguments("string", "activeJobId"),
+                new Arguments("int", "intReqParam"),
+                new Arguments("string", "stringReqParam")
+        );
+
+        final ImmutableList<Arguments> result = generator.paramsListFromRequest(testRequest);
+
+        assertThat(result.size(), is(expectedArgs.size()));
+        for (int i = 0; i < result.size(); i++) {
+            assertThat(result.get(i).getName(), is(expectedArgs.get(i).getName()));
+            assertThat(result.get(i).getType(), is(expectedArgs.get(i).getType()));
+        }
+    }
+
+    @Test
     public void toConstructorParams_Test() {
         final String result = generator.toConstructorParams(testRequest);
         assertThat(result, is(expectedConstructorParams));

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/request/RequestGeneratorUtil_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/request/RequestGeneratorUtil_Test.java
@@ -28,7 +28,9 @@ import org.junit.Test;
 import static com.spectralogic.ds3autogen.go.generators.request.RequestGeneratorUtilKt.*;
 import static com.spectralogic.ds3autogen.testutil.Ds3ModelFixtures.*;
 import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 public class RequestGeneratorUtil_Test {
 
@@ -461,5 +463,43 @@ public class RequestGeneratorUtil_Test {
 
         assertThat(params.size(), is(expected.size()));
         params.forEach(param -> assertThat(expected, hasItem(toWithConstructor(param))));
+    }
+
+    @Test (expected = IllegalArgumentException.class)
+    public void getGoArgFromResource_ExceptionTest() {
+        getGoArgFromResource(Resource.CAPACITY_SUMMARY);
+    }
+
+    @Test
+    public void getGoArgFromResource_Test() {
+        final ImmutableList<Arguments> expectedArgs = ImmutableList.of(
+                new Arguments("String", "notificationId"),
+                new Arguments("String", "bucketId"),
+                new Arguments("UUID", "jobId"),
+                new Arguments("String", "activeJob")
+        );
+
+        final ImmutableList<Resource> resources = ImmutableList.of(
+                Resource.DS3_TARGET_FAILURE_NOTIFICATION_REGISTRATION,
+                Resource.BUCKET,
+                Resource.JOB,
+                Resource.ACTIVE_JOB
+        );
+
+        assertThat(resources.size(), is(expectedArgs.size()));
+        for (int i = 0; i > resources.size(); i++) {
+            final Arguments result = getGoArgFromResource(resources.get(i));
+            assertThat(result.getName(), is(expectedArgs.get(i).getName()));
+            assertThat(result.getType(), is(expectedArgs.get(i).getType()));
+        }
+    }
+
+    @Test
+    public void isGoResourceAnArg_Test() {
+        assertFalse(isGoResourceAnArg(null, true));
+        assertFalse(isGoResourceAnArg(null, false));
+        assertFalse(isGoResourceAnArg(Resource.ACTIVE_JOB, false));
+
+        assertTrue(isGoResourceAnArg(Resource.ACTIVE_JOB, true));
     }
 }

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/request/RequestGeneratorUtil_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/request/RequestGeneratorUtil_Test.java
@@ -34,6 +34,23 @@ import static org.junit.Assert.assertTrue;
 
 public class RequestGeneratorUtil_Test {
 
+    private static Ds3Request createTestRequest(final Resource resource, final boolean includeInPath) {
+        return new Ds3Request(
+                "com.test.TestRequest",
+                null,
+                Classification.amazons3,
+                null,
+                null,
+                null,
+                resource,
+                null,
+                null,
+                includeInPath,
+                null,
+                null,
+                null);
+    }
+
     @Test
     public void removeVoidParams_NullList_Test() {
         final ImmutableList<Ds3Param> result = removeVoidDs3Params(null);
@@ -467,7 +484,7 @@ public class RequestGeneratorUtil_Test {
 
     @Test (expected = IllegalArgumentException.class)
     public void getGoArgFromResource_ExceptionTest() {
-        getGoArgFromResource(Resource.CAPACITY_SUMMARY);
+        getGoArgFromResource(createTestRequest(Resource.CAPACITY_SUMMARY, true));
     }
 
     @Test
@@ -479,16 +496,16 @@ public class RequestGeneratorUtil_Test {
                 new Arguments("String", "activeJob")
         );
 
-        final ImmutableList<Resource> resources = ImmutableList.of(
-                Resource.DS3_TARGET_FAILURE_NOTIFICATION_REGISTRATION,
-                Resource.BUCKET,
-                Resource.JOB,
-                Resource.ACTIVE_JOB
+        final ImmutableList<Ds3Request> requests = ImmutableList.of(
+                createTestRequest(Resource.DS3_TARGET_FAILURE_NOTIFICATION_REGISTRATION, true),
+                createTestRequest(Resource.BUCKET, true),
+                createTestRequest(Resource.JOB, true),
+                createTestRequest(Resource.ACTIVE_JOB, true)
         );
 
-        assertThat(resources.size(), is(expectedArgs.size()));
-        for (int i = 0; i > resources.size(); i++) {
-            final Arguments result = getGoArgFromResource(resources.get(i));
+        assertThat(requests.size(), is(expectedArgs.size()));
+        for (int i = 0; i > requests.size(); i++) {
+            final Arguments result = getGoArgFromResource(requests.get(i));
             assertThat(result.getName(), is(expectedArgs.get(i).getName()));
             assertThat(result.getType(), is(expectedArgs.get(i).getType()));
         }
@@ -496,10 +513,10 @@ public class RequestGeneratorUtil_Test {
 
     @Test
     public void isGoResourceAnArg_Test() {
-        assertFalse(isGoResourceAnArg(null, true));
-        assertFalse(isGoResourceAnArg(null, false));
-        assertFalse(isGoResourceAnArg(Resource.ACTIVE_JOB, false));
+        assertFalse(isGoResourceAnArg(createTestRequest(null, true)));
+        assertFalse(isGoResourceAnArg(createTestRequest(null, false)));
+        assertFalse(isGoResourceAnArg(createTestRequest(Resource.ACTIVE_JOB, false)));
 
-        assertTrue(isGoResourceAnArg(Resource.ACTIVE_JOB, true));
+        assertTrue(isGoResourceAnArg(createTestRequest(Resource.ACTIVE_JOB, true)));
     }
 }

--- a/ds3-autogen-go/src/test/resources/input/deleteJobCreatedNotificationRegistration.xml
+++ b/ds3-autogen-go/src/test/resources/input/deleteJobCreatedNotificationRegistration.xml
@@ -1,0 +1,21 @@
+<Data>
+    <Contract>
+        <RequestHandlers>
+            <RequestHandler Classification="spectrads3" Name="com.spectralogic.s3.server.handler.reqhandler.spectrads3.notification.DeleteJobCreatedNotificationRegistrationRequestHandler">
+                <Request Action="DELETE" HttpVerb="DELETE" IncludeIdInPath="true" Resource="JOB_CREATED_NOTIFICATION_REGISTRATION" ResourceType="NON_SINGLETON">
+                    <OptionalQueryParams/>
+                    <RequiredQueryParams/>
+                </Request>
+                <ResponseCodes>
+                    <ResponseCode>
+                        <Code>204</Code>
+                        <ResponseTypes>
+                            <ResponseType Type="null"/>
+                        </ResponseTypes>
+                    </ResponseCode>
+                </ResponseCodes>
+                <Version>1.BF2D067D7C365D5CD381837F5376FBCC</Version>
+            </RequestHandler>
+        </RequestHandlers>
+    </Contract>
+</Data>

--- a/ds3-autogen-utils/src/main/java/com/spectralogic/ds3autogen/utils/RequestConverterUtil.java
+++ b/ds3-autogen-utils/src/main/java/com/spectralogic/ds3autogen/utils/RequestConverterUtil.java
@@ -131,7 +131,7 @@ public final class RequestConverterUtil {
      * name should be name spaced to include "Name". For example, Resource.BUCKET
      * describes an argument whose name should be "BucketName" with type String.
      */
-    private static boolean isResourceNamed(final Resource resource) {
+    public static boolean isResourceNamed(final Resource resource) {
         switch (resource) {
             case BUCKET:
             case OBJECT:
@@ -188,7 +188,7 @@ public final class RequestConverterUtil {
     /**
      * Converts all void Ds3Params into a list of Arguments, excluding the Operations param
      */
-    public static ImmutableList<Arguments> getVoidArgsFromParamList(final ImmutableList<Ds3Param> paramList) {
+    static ImmutableList<Arguments> getVoidArgsFromParamList(final ImmutableList<Ds3Param> paramList) {
         if(isEmpty(paramList)) {
             return ImmutableList.of();
         }
@@ -227,7 +227,7 @@ public final class RequestConverterUtil {
     /**
      * Converts a Ds3Param into an argument
      */
-    public static Arguments toArgument(final Ds3Param ds3Param) {
+    static Arguments toArgument(final Ds3Param ds3Param) {
         final String paramType = ds3Param.getType().substring(ds3Param.getType().lastIndexOf(".") + 1);
         return new Arguments(paramType, ds3Param.getName());
     }


### PR DESCRIPTION
The generation of notification requests was not correctly generating notification IDs when required. This is caused by some incorrect assumptions in autogen utils which all modules use. For the Go implementation of notification request handlers, a new "Go" version of the utilities was created to convert any notification type resource that is included-in-path into the argument `notificationId`.  Updating the autogen util may be done at a later time, but will have cascading effects on multiple modules.

**Changes**
- Fixed generation of notification request handlers with a `notificationId`
- Refactored some redundant code within request generators to maximize code reuse.
