### PR TITLE
Special cased PutMultiPartUpload request

### DIFF
--- a/ds3-autogen-go/src/main/java/com/spectralogic/ds3autogen/go/GoCodeGenerator.java
+++ b/ds3-autogen-go/src/main/java/com/spectralogic/ds3autogen/go/GoCodeGenerator.java
@@ -133,6 +133,9 @@ public class GoCodeGenerator implements CodeGenerator {
         if (isGetObjectAmazonS3Request(ds3Request)) {
             return new GetObjectRequestGenerator();
         }
+        if (isCreateMultiPartUploadPartRequest(ds3Request)) {
+            return new ReaderRequestPayloadGenerator();
+        }
         if (isBulkRequest(ds3Request) || isPhysicalPlacementRequest(ds3Request) || isEjectStorageDomainBlobsRequest(ds3Request)) {
             return new RequiredObjectsPayloadGenerator();
         }
@@ -140,7 +143,7 @@ public class GoCodeGenerator implements CodeGenerator {
             return new StringRequestPayloadGenerator();
         }
         if (isCompleteMultiPartUploadRequest(ds3Request)) {
-            return new MultipartUploadPayloadGenerator();
+            return new PartsRequestPayloadGenerator();
         }
         if (isMultiFileDeleteRequest(ds3Request)) {
             return new DeleteObjectsRequestGenerator();
@@ -156,6 +159,7 @@ public class GoCodeGenerator implements CodeGenerator {
             return config.getTemplate("request/get_object_request.ftl");
         }
         if (isBulkRequest(ds3Request)
+                || isCreateMultiPartUploadPartRequest(ds3Request)
                 || isPhysicalPlacementRequest(ds3Request)
                 || isEjectStorageDomainBlobsRequest(ds3Request)
                 || hasStringRequestPayload(ds3Request)

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/request/PartsRequestPayloadGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/request/PartsRequestPayloadGenerator.kt
@@ -1,0 +1,41 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.go.generators.request
+
+import com.spectralogic.ds3autogen.api.models.Arguments
+import com.spectralogic.ds3autogen.go.models.request.Variable
+
+/**
+ * The Go generator for request handlers that have a CompleteMultipartUpload
+ * request payload not specified within the contract.
+ */
+
+class PartsRequestPayloadGenerator : RequestPayloadGenerator() {
+
+    /**
+     * Retrieves the CompleteMultipartUpload request payload
+     */
+    override fun getPayloadConstructorArg(): Arguments {
+        return Arguments("[]Part", "parts")
+    }
+
+    /**
+     * Retrieves the struct assignment for the CompleteMultipartUpload request payload
+     */
+    override fun getStructAssignmentVariable(): Variable {
+        return Variable("content", "buildPartsListStream(parts)")
+    }
+}

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/request/ReaderRequestPayloadGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/request/ReaderRequestPayloadGenerator.kt
@@ -19,23 +19,23 @@ import com.spectralogic.ds3autogen.api.models.Arguments
 import com.spectralogic.ds3autogen.go.models.request.Variable
 
 /**
- * The Go generator for request handlers that have a CompleteMultipartUpload
- * request payload not specified within the contract.
+ * Creates requests that have a payload of type ReaderWithSizeDecorator
  */
+class ReaderRequestPayloadGenerator : RequestPayloadGenerator() {
 
-class MultipartUploadPayloadGenerator : RequestPayloadGenerator() {
-
+    //TODO test
     /**
-     * Retrieves the CompleteMultipartUpload request payload
+     * Retrieves the ReaderWithSizeDecorator request payload
      */
     override fun getPayloadConstructorArg(): Arguments {
-        return Arguments("[]Part", "parts")
+        return Arguments("networking.ReaderWithSizeDecorator", "content")
     }
 
+    //TODO test
     /**
-     * Retrieves the struct assignment for the CompleteMultipartUpload request payload
+     * Retrieves the struct assignment for the ReaderWithSizeDecorator request payload
      */
     override fun getStructAssignmentVariable(): Variable {
-        return Variable("content", "buildPartsListStream(parts)")
+        return Variable("content", "content")
     }
 }

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoCodeGenerator_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoCodeGenerator_Test.java
@@ -30,6 +30,10 @@ public class GoCodeGenerator_Test {
 
     @Test
     public void getRequestGeneratorTest() {
+
+        // Request with ReaderWithSizeDecorator payload
+        assertThat(getRequestGenerator(getCreateMultiPartUploadPart()), instanceOf(ReaderRequestPayloadGenerator.class));
+
         // Amazon Get Object request
         assertThat(getRequestGenerator(getRequestAmazonS3GetObject()), instanceOf(GetObjectRequestGenerator.class));
 
@@ -50,7 +54,7 @@ public class GoCodeGenerator_Test {
         assertThat(getRequestGenerator(getReplicatePutJob()), instanceOf(StringRequestPayloadGenerator.class));
 
         // Request with CompleteMultipartUpload request payload
-        assertThat(getRequestGenerator(getCompleteMultipartUploadRequest()), instanceOf(MultipartUploadPayloadGenerator.class));
+        assertThat(getRequestGenerator(getCompleteMultipartUploadRequest()), instanceOf(PartsRequestPayloadGenerator.class));
 
         // Non-special cased requests
         assertThat(getRequestGenerator(getGetBlobPersistence()), instanceOf(BaseRequestGenerator.class));
@@ -62,8 +66,6 @@ public class GoCodeGenerator_Test {
         assertThat(getRequestGenerator(getRequestGetNotification()), instanceOf(BaseRequestGenerator.class));
         assertThat(getRequestGenerator(getRequestDeleteNotification()), instanceOf(BaseRequestGenerator.class));
         assertThat(getRequestGenerator(getRequestMultiFileDelete()), instanceOf(BaseRequestGenerator.class));
-        assertThat(getRequestGenerator(getCreateMultiPartUploadPart()), instanceOf(BaseRequestGenerator.class));
-        assertThat(getRequestGenerator(getCompleteMultipartUploadRequest()), instanceOf(BaseRequestGenerator.class));
         assertThat(getRequestGenerator(getBucketRequest()), instanceOf(BaseRequestGenerator.class));
     }
 

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTests.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTests.java
@@ -610,4 +610,70 @@ public class GoFunctionalTests {
         assertTrue(client.contains("networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.netLayer), client.clientPolicy.maxRetries)"));
         assertTrue(client.contains("response, requestErr := networkRetryDecorator.Invoke(request)"));
     }
+
+    @Test
+    public void putMultiPartUploadPart() throws IOException, TemplateModelException {
+        // This tests correct generation of request with ReaderWithSizeDecorator payload
+        final String requestName = "PutMultiPartUploadPartRequest";
+        final FileUtils fileUtils = mock(FileUtils.class);
+        final GoTestCodeUtil codeGenerator = new GoTestCodeUtil(fileUtils, requestName);
+
+        codeGenerator.generateCode(fileUtils, "/input/putMultiPartUploadPart.xml");
+
+        // Verify Request file was generated
+        final String requestCode = codeGenerator.getRequestCode();
+        CODE_LOGGER.logFile(requestCode, FileTypeToLog.REQUEST);
+        assertTrue(hasContent(requestCode));
+
+        // test request imports
+        assertTrue(requestCode.contains("\"strconv\""));
+        assertTrue(requestCode.contains("\"net/url\""));
+        assertTrue(requestCode.contains("\"net/http\""));
+        assertTrue(requestCode.contains("\"ds3/networking\""));
+
+        // test request struct
+        assertTrue(requestCode.contains("bucketName string"));
+        assertTrue(requestCode.contains("objectName string"));
+        assertTrue(requestCode.contains("partNumber int"));
+        assertTrue(requestCode.contains("uploadId string"));
+        assertTrue(requestCode.contains("content networking.ReaderWithSizeDecorator"));
+
+        // test constructor
+        assertTrue(requestCode.contains("func NewPutMultiPartUploadPartRequest(bucketName string, objectName string, content networking.ReaderWithSizeDecorator, partNumber int, uploadId string) *PutMultiPartUploadPartRequest {"));
+        assertTrue(requestCode.contains("bucketName: bucketName,"));
+        assertTrue(requestCode.contains("objectName: objectName,"));
+        assertTrue(requestCode.contains("partNumber: partNumber,"));
+        assertTrue(requestCode.contains("uploadId: uploadId,"));
+        assertTrue(requestCode.contains("content: content,"));
+
+        // test path
+        assertTrue(requestCode.contains("return \"/\" + putMultiPartUploadPartRequest.bucketName + \"/\" + putMultiPartUploadPartRequest.objectName"));
+
+        // test content stream
+        assertTrue(requestCode.contains("func (putMultiPartUploadPartRequest *PutMultiPartUploadPartRequest) GetContentStream() networking.ReaderWithSizeDecorator {"));
+        assertTrue(requestCode.contains("return putMultiPartUploadPartRequest.content"));
+
+        // Verify Response file was generated
+        final String responseCode = codeGenerator.getResponseCode();
+        CODE_LOGGER.logFile(responseCode, FileTypeToLog.RESPONSE);
+        assertTrue(hasContent(responseCode));
+
+        assertTrue(responseCode.contains("func NewPutMultiPartUploadPartResponse(webResponse networking.WebResponse) (*PutMultiPartUploadPartResponse, error) {"));
+        assertTrue(responseCode.contains("expectedStatusCodes := []int { 200 }"));
+        assertTrue(responseCode.contains("return &PutMultiPartUploadPartResponse{}, nil"));
+
+        // Verify response payload type file was not generated
+        final String typeCode = codeGenerator.getTypeCode();
+        CODE_LOGGER.logFile(typeCode, FileTypeToLog.MODEL);
+        assertTrue(isEmpty(typeCode));
+
+        // Verify that the client code was generated
+        final String client = codeGenerator.getClientCode(HttpVerb.PUT);
+        CODE_LOGGER.logFile(client, FileTypeToLog.CLIENT);
+        assertTrue(hasContent(client));
+
+        assertTrue(client.contains("func (client *Client) PutMultiPartUploadPart(request *models.PutMultiPartUploadPartRequest) (*models.PutMultiPartUploadPartResponse, error) {"));
+        assertTrue(client.contains("networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.netLayer), client.clientPolicy.maxRetries)"));
+        assertTrue(client.contains("response, requestErr := networkRetryDecorator.Invoke(request)"));
+    }
 }

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/request/ReaderRequestPayloadGenerator_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/request/ReaderRequestPayloadGenerator_Test.java
@@ -22,21 +22,21 @@ import org.junit.Test;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
-public class MultipartUploadPayloadGenerator_Test {
+public class ReaderRequestPayloadGenerator_Test {
 
-    private final PartsRequestPayloadGenerator generator = new PartsRequestPayloadGenerator();
+    private final ReaderRequestPayloadGenerator generator = new ReaderRequestPayloadGenerator();
 
     @Test
     public void getPayloadConstructorArgTest() {
         final Arguments result = generator.getPayloadConstructorArg();
-        assertThat(result.getName(), is("parts"));
-        assertThat(result.getType(), is("[]Part"));
+        assertThat(result.getName(), is("content"));
+        assertThat(result.getType(), is("networking.ReaderWithSizeDecorator"));
     }
 
     @Test
     public void getStructAssignmentVariableTest() {
         final Variable result = generator.getStructAssignmentVariable();
         assertThat(result.getName(), is("content"));
-        assertThat(result.getAssignment(), is("buildPartsListStream(parts)"));
+        assertThat(result.getAssignment(), is("content"));
     }
 }

--- a/ds3-autogen-go/src/test/resources/input/putMultiPartUploadPart.xml
+++ b/ds3-autogen-go/src/test/resources/input/putMultiPartUploadPart.xml
@@ -1,0 +1,45 @@
+<!--
+  ~ *******************************************************************************
+  ~   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+  ~   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+  ~   this file except in compliance with the License. A copy of the License is located at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~   or in the "license" file accompanying this file.
+  ~   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+  ~   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+  ~   specific language governing permissions and limitations under the License.
+  ~ *****************************************************************************
+  -->
+
+<Data>
+    <Contract>
+        <RequestHandlers>
+            <RequestHandler Classification="amazons3" Name="com.spectralogic.s3.server.handler.reqhandler.amazons3.CreateMultiPartUploadPartRequestHandler">
+                <Request BucketRequirement="REQUIRED" HttpVerb="PUT" IncludeIdInPath="false" ObjectRequirement="REQUIRED">
+                    <OptionalQueryParams/>
+                    <RequiredQueryParams>
+                        <Param Name="PartNumber" Type="int"/>
+                        <Param Name="UploadId" Type="java.util.UUID"/>
+                    </RequiredQueryParams>
+                </Request>
+                <ResponseCodes>
+                    <ResponseCode>
+                        <Code>200</Code>
+                        <ResponseTypes>
+                            <ResponseType Type="null"/>
+                        </ResponseTypes>
+                    </ResponseCode>
+                    <ResponseCode>
+                        <Code>404</Code>
+                        <ResponseTypes>
+                            <ResponseType Type="com.spectralogic.s3.server.domain.HttpErrorResultApiBean"/>
+                        </ResponseTypes>
+                    </ResponseCode>
+                </ResponseCodes>
+                <Version>1.013CF864155A896718908128F7C31E1E</Version>
+            </RequestHandler>
+        </RequestHandlers>
+    </Contract>
+</Data>


### PR DESCRIPTION
**Changes**
- Renamed `MultipartUploadPayloadGenerator` -> `PartsRequestPayloadGenerator` to remove confusion regarding the different special casing for `CreateMultiPartUploadRequest` and `CompleteMultiPartUploadRequest`
- Created `ReaderRequestPayloadGenerator` to special case PutMultiPartUpload request which has a request payload of type `ReaderWithSizeDecorator`