### PR TITLE
Special cased Go generation of Amazon Get Object response handler

### DIFF
--- a/ds3-autogen-go/src/main/java/com/spectralogic/ds3autogen/go/GoCodeGenerator.java
+++ b/ds3-autogen-go/src/main/java/com/spectralogic/ds3autogen/go/GoCodeGenerator.java
@@ -28,6 +28,7 @@ import com.spectralogic.ds3autogen.go.generators.client.BaseClientGenerator;
 import com.spectralogic.ds3autogen.go.generators.client.ClientModelGenerator;
 import com.spectralogic.ds3autogen.go.generators.request.*;
 import com.spectralogic.ds3autogen.go.generators.response.BaseResponseGenerator;
+import com.spectralogic.ds3autogen.go.generators.response.GetObjectResponseGenerator;
 import com.spectralogic.ds3autogen.go.generators.response.NoResponseGenerator;
 import com.spectralogic.ds3autogen.go.generators.response.ResponseModelGenerator;
 import com.spectralogic.ds3autogen.go.generators.type.BaseTypeGenerator;
@@ -202,6 +203,9 @@ public class GoCodeGenerator implements CodeGenerator {
      * specified {@link Ds3Request}
      */
     static ResponseModelGenerator<?> getResponseGenerator(final Ds3Request ds3Request) {
+        if (isGetObjectAmazonS3Request(ds3Request)) {
+            return new GetObjectResponseGenerator();
+        }
         if (!hasResponsePayload(ds3Request.getDs3ResponseCodes())) {
             return new NoResponseGenerator();
         }

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/request/ReaderRequestPayloadGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/request/ReaderRequestPayloadGenerator.kt
@@ -23,7 +23,6 @@ import com.spectralogic.ds3autogen.go.models.request.Variable
  */
 class ReaderRequestPayloadGenerator : RequestPayloadGenerator() {
 
-    //TODO test
     /**
      * Retrieves the ReaderWithSizeDecorator request payload
      */
@@ -31,7 +30,6 @@ class ReaderRequestPayloadGenerator : RequestPayloadGenerator() {
         return Arguments("networking.ReaderWithSizeDecorator", "content")
     }
 
-    //TODO test
     /**
      * Retrieves the struct assignment for the ReaderWithSizeDecorator request payload
      */

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/response/BaseResponseGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/response/BaseResponseGenerator.kt
@@ -17,6 +17,7 @@ package com.spectralogic.ds3autogen.go.generators.response
 
 import com.google.common.collect.ImmutableList
 import com.google.common.collect.ImmutableMap
+import com.google.common.collect.ImmutableSet
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3Request
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3ResponseCode
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3Type
@@ -41,8 +42,16 @@ open class BaseResponseGenerator : ResponseModelGenerator<Response>, ResponseMod
         val payloadStruct = toResponsePayloadStruct(ds3Request.ds3ResponseCodes, typeMap)
         val expectedCodes = toExpectedStatusCodes(ds3Request.ds3ResponseCodes)
         val responseCodes = toResponseCodeList(ds3Request.ds3ResponseCodes, name)
+        val imports = toImportSet()
 
-        return Response(name, payloadStruct, expectedCodes, responseCodes)
+        return Response(name, payloadStruct, expectedCodes, responseCodes, imports)
+    }
+    
+    /**
+     * The standard response has all of its imports specified within the template file
+     */
+    override fun toImportSet(): ImmutableSet<String> {
+        return ImmutableSet.of()
     }
 
     /**
@@ -62,7 +71,14 @@ open class BaseResponseGenerator : ResponseModelGenerator<Response>, ResponseMod
      * Converts a Ds3ResponseCode into a ResponseCode model which contains the Go
      * code for parsing the specified response.
      */
-    fun toResponseCode(ds3ResponseCode: Ds3ResponseCode, responseName: String): ResponseCode {
+    override fun toResponseCode(ds3ResponseCode: Ds3ResponseCode, responseName: String): ResponseCode {
+        return toStandardResponseCode(ds3ResponseCode, responseName)
+    }
+
+    /**
+     * Converts a Ds3ResponseCode into one of the standard ResponseCode configurations
+     */
+    fun toStandardResponseCode(ds3ResponseCode: Ds3ResponseCode, responseName: String): ResponseCode {
         if (isEmpty(ds3ResponseCode.ds3ResponseTypes)) {
             throw IllegalArgumentException("Ds3ResponseCode does not have any response types " + ds3ResponseCode.code)
         }

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/response/GetObjectResponseGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/response/GetObjectResponseGenerator.kt
@@ -13,7 +13,7 @@
  * ****************************************************************************
  */
 
-package com.spectralogic.ds3autogen.go.generators.response;
+package com.spectralogic.ds3autogen.go.generators.response
 
 import com.google.common.collect.ImmutableList
 import com.google.common.collect.ImmutableMap
@@ -22,22 +22,30 @@ import com.spectralogic.ds3autogen.api.models.apispec.Ds3ResponseCode
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3Type
 import com.spectralogic.ds3autogen.go.models.response.ResponseCode
 
-interface ResponseModelGeneratorUtil {
+/**
+ * Generates the Go Amazon Get Object response handler
+ */
+class GetObjectResponseGenerator : BaseResponseGenerator() {
+
+    override fun toImportSet(): ImmutableSet<String> {
+        return ImmutableSet.of("io")
+    }
 
     /**
-     * Retrieves the content of the response struct
+     * Retrieves the response payload struct content, which is an io.ReadCloser
      */
-    fun toResponsePayloadStruct(expectedResponseCodes: ImmutableList<Ds3ResponseCode>?, typeMap: ImmutableMap<String, Ds3Type>): String
+    override fun toResponsePayloadStruct(expectedResponseCodes: ImmutableList<Ds3ResponseCode>?, typeMap: ImmutableMap<String, Ds3Type>): String {
+        return "Content io.ReadCloser"
+    }
 
     /**
      * Converts a Ds3ResponseCode into a ResponseCode model which contains the Go
      * code for parsing the specified response.
      */
-    fun toResponseCode(ds3ResponseCode: Ds3ResponseCode, responseName: String): ResponseCode
-
-    /**
-     * Retrieves the list of imports that are not common to all responses
-     * i.e. not specified within the templates
-     */
-    fun toImportSet(): ImmutableSet<String>
+    override fun toResponseCode(ds3ResponseCode: Ds3ResponseCode, responseName: String): ResponseCode {
+        if (ds3ResponseCode.code == 200) {
+            return ResponseCode(ds3ResponseCode.code, "return &$responseName{ Content: webResponse.Body() }, nil")
+        }
+        return toStandardResponseCode(ds3ResponseCode, responseName)
+    }
 }

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/models/response/Response.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/models/response/Response.kt
@@ -16,9 +16,11 @@
 package com.spectralogic.ds3autogen.go.models.response
 
 import com.google.common.collect.ImmutableList
+import com.google.common.collect.ImmutableSet
 
 data class Response(
         val name: String,
         val payloadStruct: String, //The struct definition for the response payload including xml parsing when relevant
         val expectedCodes: String,
-        val responseCodes: ImmutableList<ResponseCode>)
+        val responseCodes: ImmutableList<ResponseCode>,
+        val imports: ImmutableSet<String>)

--- a/ds3-autogen-go/src/main/resources/tmpls/go/response/response_template.ftl
+++ b/ds3-autogen-go/src/main/resources/tmpls/go/response/response_template.ftl
@@ -4,6 +4,9 @@ package models
 
 import (
     "ds3/networking"
+    <#list imports as import>
+    "${import}"
+    </#list>
 )
 
 type ${name} struct {

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoCodeGenerator_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoCodeGenerator_Test.java
@@ -17,12 +17,14 @@ package com.spectralogic.ds3autogen.go;
 
 import com.spectralogic.ds3autogen.go.generators.request.*;
 import com.spectralogic.ds3autogen.go.generators.response.BaseResponseGenerator;
+import com.spectralogic.ds3autogen.go.generators.response.GetObjectResponseGenerator;
 import com.spectralogic.ds3autogen.go.generators.response.NoResponseGenerator;
 import org.junit.Test;
 
 import static com.spectralogic.ds3autogen.go.GoCodeGenerator.getRequestGenerator;
 import static com.spectralogic.ds3autogen.go.GoCodeGenerator.getResponseGenerator;
 import static com.spectralogic.ds3autogen.testutil.Ds3ModelFixtures.*;
+import static com.spectralogic.ds3autogen.testutil.Ds3ModelFixtures.getRequestCreateObject;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertThat;
 
@@ -73,6 +75,9 @@ public class GoCodeGenerator_Test {
 
     @Test
     public void getResponseGeneratorTest() {
+        // Amazon Get Object
+        assertThat(getResponseGenerator(getRequestAmazonS3GetObject()), instanceOf(GetObjectResponseGenerator.class));
+
         // Commands with no response payload
         assertThat(getResponseGenerator(getRequestDeleteNotification()), instanceOf(NoResponseGenerator.class));
         assertThat(getResponseGenerator(getHeadObjectRequest()), instanceOf(NoResponseGenerator.class));

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTests.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTests.java
@@ -37,11 +37,11 @@ import static org.mockito.Mockito.mock;
 public class GoFunctionalTests {
 
     private final static Logger LOG = LoggerFactory.getLogger(GoFunctionalTests.class);
-    private final static GeneratedCodeLogger CODE_LOGGER = new GeneratedCodeLogger(FileTypeToLog.REQUEST, LOG);
+    private final static GeneratedCodeLogger CODE_LOGGER = new GeneratedCodeLogger(FileTypeToLog.RESPONSE, LOG);
 
     @Test
     public void simpleRequestNoPayload() throws IOException, TemplateModelException {
-        final String requestName = "GetObjectRequest";
+        final String requestName = "SimpleNoPayloadRequest";
         final FileUtils fileUtils = mock(FileUtils.class);
         final GoTestCodeUtil codeGenerator = new GoTestCodeUtil(fileUtils, requestName);
 
@@ -56,9 +56,9 @@ public class GoFunctionalTests {
         final String responseCode = codeGenerator.getResponseCode();
         CODE_LOGGER.logFile(responseCode, FileTypeToLog.RESPONSE);
         assertTrue(hasContent(responseCode));
-        assertTrue(responseCode.contains("func NewGetObjectResponse(webResponse networking.WebResponse) (*GetObjectResponse, error) {"));
+        assertTrue(responseCode.contains("func NewSimpleNoPayloadResponse(webResponse networking.WebResponse) (*SimpleNoPayloadResponse, error) {"));
         assertTrue(responseCode.contains("expectedStatusCodes := []int { 200 }"));
-        assertTrue(responseCode.contains("return &GetObjectResponse{}, nil"));
+        assertTrue(responseCode.contains("return &SimpleNoPayloadResponse{}, nil"));
 
         // Verify response payload type file was not generated
         final String typeCode = codeGenerator.getTypeCode();
@@ -69,9 +69,10 @@ public class GoFunctionalTests {
         final String client = codeGenerator.getClientCode(HttpVerb.GET);
         CODE_LOGGER.logFile(client, FileTypeToLog.CLIENT);
         assertTrue(hasContent(client));
-        assertTrue(client.contains("func (client *Client) GetObject(request *models.GetObjectRequest) (*models.GetObjectResponse, error) {"));
+        assertTrue(client.contains("func (client *Client) SimpleNoPayload(request *models.SimpleNoPayloadRequest) (*models.SimpleNoPayloadResponse, error) {"));
         assertTrue(client.contains("networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.netLayer), client.clientPolicy.maxRetries)"));
-        assertTrue(client.contains("response, requestErr := networkRetryDecorator.Invoke(request)"));
+        assertTrue(client.contains("httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(&networkRetryDecorator, client.clientPolicy.maxRedirect)"));
+        assertTrue(client.contains("response, requestErr := httpRedirectDecorator.Invoke(request)"));
     }
 
     @Test
@@ -410,8 +411,11 @@ public class GoFunctionalTests {
         final String responseCode = codeGenerator.getResponseCode();
         CODE_LOGGER.logFile(responseCode, FileTypeToLog.RESPONSE);
         assertTrue(hasContent(responseCode));
+        assertTrue(responseCode.contains("\"io\""));
+        assertTrue(responseCode.contains("Content io.ReadCloser"));
         assertTrue(responseCode.contains("func NewGetObjectResponse(webResponse networking.WebResponse) (*GetObjectResponse, error) {"));
         assertTrue(responseCode.contains("expectedStatusCodes := []int { 200, 206 }"));
+        assertTrue(responseCode.contains("return &GetObjectResponse{ Content: webResponse.Body() }, nil"));
         assertTrue(responseCode.contains("return &GetObjectResponse{}, nil"));
 
         // Verify response payload type file was not generated

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/response/BaseResponseGenerator_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/response/BaseResponseGenerator_Test.java
@@ -17,6 +17,7 @@ package com.spectralogic.ds3autogen.go.generators.response;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3ResponseCode;
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3ResponseType;
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3Type;
@@ -315,5 +316,11 @@ public class BaseResponseGenerator_Test {
         final ImmutableList<ResponseCode> result = generator.toResponseCodeList(responseCodes, "ResponseName");
 
         expectedCodes.forEach(expected -> assertThat(result, hasItem(expected)));
+    }
+
+    @Test
+    public void toImportSet_Test() {
+        final ImmutableSet<String> result = generator.toImportSet();
+        assertThat(result.size(), is(0));
     }
 }

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/response/GetObjectResponseGenerator_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/response/GetObjectResponseGenerator_Test.java
@@ -1,0 +1,73 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.go.generators.response;
+
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.spectralogic.ds3autogen.api.models.apispec.Ds3ResponseCode;
+import com.spectralogic.ds3autogen.api.models.apispec.Ds3ResponseType;
+import com.spectralogic.ds3autogen.go.models.response.ResponseCode;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class GetObjectResponseGenerator_Test {
+
+    private final GetObjectResponseGenerator generator = new GetObjectResponseGenerator();
+
+    @Test
+    public void toResponseCode_200_Test() {
+        final ResponseCode expected = new ResponseCode(200, "return &GetObjectResponse{ Content: webResponse.Body() }, nil");
+
+        final Ds3ResponseCode code = new Ds3ResponseCode(200,
+                ImmutableList.of(new Ds3ResponseType("null", null)));
+
+        final ResponseCode result = generator.toResponseCode(code, "GetObjectResponse");
+
+        assertThat(result, is(expected));
+    }
+
+    @Test
+    public void toResponseCode_206_Test() {
+        final ResponseCode expected = new ResponseCode(206, "return &GetObjectResponse{}, nil");
+
+        final Ds3ResponseCode code = new Ds3ResponseCode(206,
+                ImmutableList.of(new Ds3ResponseType("null", null)));
+
+        final ResponseCode result = generator.toResponseCode(code, "GetObjectResponse");
+
+        assertThat(result, is(expected));
+    }
+
+    @Test
+    public void toResponsePayloadStruct_Test() {
+        assertThat(generator.toResponsePayloadStruct(ImmutableList.of(), ImmutableMap.of()), is("Content io.ReadCloser"));
+    }
+
+    @Test
+    public void toImportSet_Test() {
+        final ImmutableSet<String> expectedImports = ImmutableSet.of("io");
+
+        final ImmutableSet<String> result = generator.toImportSet();
+
+        assertThat(result.size(), is(expectedImports.size()));
+        expectedImports.forEach(expected -> assertThat(result, hasItem(expected)));
+    }
+}

--- a/ds3-autogen-go/src/test/resources/input/simpleRequestNoPayload.xml
+++ b/ds3-autogen-go/src/test/resources/input/simpleRequestNoPayload.xml
@@ -1,8 +1,8 @@
 <Data>
     <Contract>
         <RequestHandlers>
-            <RequestHandler Classification="amazons3" Name="com.spectralogic.s3.server.handler.reqhandler.amazons3.GetObjectRequestHandler">
-                <Request BucketRequirement="REQUIRED" HttpVerb="GET" ObjectRequirement="REQUIRED">
+            <RequestHandler Classification="amazons3" Name="com.spectralogic.s3.server.handler.reqhandler.amazons3.SimpleNoPayloadRequest">
+                <Request BucketRequirement="REQUIRED" HttpVerb="GET" ObjectRequirement="NOT_ALLOWED">
                     <OptionalQueryParams>
                         <Param Name="UploadId" Type="java.util.UUID" />
                         <Param Name="Offset" Type="long"/>


### PR DESCRIPTION
Generated code:
```
package models

import (
    "ds3/networking"
    "io"
)

type GetObjectResponse struct {
    Content io.ReadCloser
}

func NewGetObjectResponse(webResponse networking.WebResponse) (*GetObjectResponse, error) {
    expectedStatusCodes := []int { 200, 206 }

    switch code := webResponse.StatusCode(); code {
    case 200:
        return &GetObjectResponse{ Content: webResponse.Body() }, nil
    case 206:
        return &GetObjectResponse{}, nil
    default:
        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
    }
}
```