### PR TITLE
Updated Go generation to generate files with lower cased names

### DIFF
--- a/ds3-autogen-go/src/main/java/com/spectralogic/ds3autogen/go/GoCodeGenerator.java
+++ b/ds3-autogen-go/src/main/java/com/spectralogic/ds3autogen/go/GoCodeGenerator.java
@@ -54,6 +54,7 @@ import static com.spectralogic.ds3autogen.utils.ConverterUtil.isEnum;
 import static com.spectralogic.ds3autogen.utils.ConverterUtil.removeUnusedTypes;
 import static com.spectralogic.ds3autogen.utils.Ds3RequestClassificationUtil.*;
 import static com.spectralogic.ds3autogen.utils.ResponsePayloadUtil.hasResponsePayload;
+import static org.apache.commons.lang3.StringUtils.uncapitalize;
 
 public class GoCodeGenerator implements CodeGenerator {
 
@@ -116,7 +117,7 @@ public class GoCodeGenerator implements CodeGenerator {
         final Request request = generator.generate(ds3Request);
         final Path path = destDir.resolve(
                 BASE_PROJECT_PATH.resolve(
-                        Paths.get(COMMANDS_NAMESPACE.replace(".", "/") + "/" + request.getName() + ".go")));
+                        Paths.get(COMMANDS_NAMESPACE.replace(".", "/") + "/" + uncapitalize(request.getName())  + ".go")));
 
         LOG.info("Getting Output Stream for file: {}", path.toString());
 
@@ -188,7 +189,7 @@ public class GoCodeGenerator implements CodeGenerator {
         final Response response = generator.generate(ds3Request, typeMap);
         final Path path = destDir.resolve(
                 BASE_PROJECT_PATH.resolve(
-                        Paths.get(COMMANDS_NAMESPACE.replace(".", "/") + "/" + response.getName() + ".go")));
+                        Paths.get(COMMANDS_NAMESPACE.replace(".", "/") + "/" + uncapitalize(response.getName()) + ".go")));
 
         LOG.info("Getting Output Stream for file: {}", path.toString());
 
@@ -299,7 +300,7 @@ public class GoCodeGenerator implements CodeGenerator {
         final Type type = generator.generate(ds3Type);
         final Path path = destDir.resolve(
                 BASE_PROJECT_PATH.resolve(
-                        Paths.get(COMMANDS_NAMESPACE.replace(".", "/") + "/" + type.getName() + ".go")));
+                        Paths.get(COMMANDS_NAMESPACE.replace(".", "/") + "/" + uncapitalize(type.getName()) + ".go")));
 
         LOG.info("Getting OutputStream for file: {}", path.toString());
 

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTests.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTests.java
@@ -159,7 +159,7 @@ public class GoFunctionalTests {
         // Test for request with payload of Ds3Object list
         final String requestName = "VerifyPhysicalPlacementForObjectsSpectraS3Request";
         final FileUtils fileUtils = mock(FileUtils.class);
-        final GoTestCodeUtil codeGenerator = new GoTestCodeUtil(fileUtils, requestName);
+        final GoTestCodeUtil codeGenerator = new GoTestCodeUtil(fileUtils, requestName, "PhysicalPlacement");
 
         codeGenerator.generateCode(fileUtils, "/input/verifyPhysicalPlacement.xml");
 
@@ -185,7 +185,7 @@ public class GoFunctionalTests {
         // Verify response payload type file was not generated
         final String typeCode = codeGenerator.getTypeCode();
         CODE_LOGGER.logFile(typeCode, FileTypeToLog.MODEL);
-        assertTrue(isEmpty(typeCode));
+        assertTrue(hasContent(typeCode));
 
         // Verify that the client code was generated
         final String client = codeGenerator.getClientCode(HttpVerb.GET);
@@ -202,7 +202,7 @@ public class GoFunctionalTests {
         // Test for request with string payload
         final String requestName = "ReplicatePutJobSpectraS3Request";
         final FileUtils fileUtils = mock(FileUtils.class);
-        final GoTestCodeUtil codeGenerator = new GoTestCodeUtil(fileUtils, requestName);
+        final GoTestCodeUtil codeGenerator = new GoTestCodeUtil(fileUtils, requestName, "MasterObjectList");
 
         codeGenerator.generateCode(fileUtils, "/input/replicatePutJob.xml");
 
@@ -229,7 +229,7 @@ public class GoFunctionalTests {
         // Verify response payload type file was not generated
         final String typeCode = codeGenerator.getTypeCode();
         CODE_LOGGER.logFile(typeCode, FileTypeToLog.MODEL);
-        assertTrue(isEmpty(typeCode));
+        assertTrue(hasContent(typeCode));
 
         // Verify that the client code was generated
         final String client = codeGenerator.getClientCode(HttpVerb.PUT);
@@ -245,7 +245,7 @@ public class GoFunctionalTests {
         // Test for request with CompleteMultipartUpload payload
         final String requestName = "CompleteMultiPartUploadRequest";
         final FileUtils fileUtils = mock(FileUtils.class);
-        final GoTestCodeUtil codeGenerator = new GoTestCodeUtil(fileUtils, requestName);
+        final GoTestCodeUtil codeGenerator = new GoTestCodeUtil(fileUtils, requestName, "CompleteMultipartUploadResult");
 
         codeGenerator.generateCode(fileUtils, "/input/completeMultipartUpload.xml");
 
@@ -271,7 +271,7 @@ public class GoFunctionalTests {
         // Verify response payload type file was not generated
         final String typeCode = codeGenerator.getTypeCode();
         CODE_LOGGER.logFile(typeCode, FileTypeToLog.MODEL);
-        assertTrue(isEmpty(typeCode));
+        assertTrue(hasContent(typeCode));
 
         // Verify that the client code was generated
         final String client = codeGenerator.getClientCode(HttpVerb.POST);
@@ -287,7 +287,7 @@ public class GoFunctionalTests {
         // Test for request with object name list payload and optional void parameter
         final String requestName = "DeleteObjectsRequest";
         final FileUtils fileUtils = mock(FileUtils.class);
-        final GoTestCodeUtil codeGenerator = new GoTestCodeUtil(fileUtils, requestName);
+        final GoTestCodeUtil codeGenerator = new GoTestCodeUtil(fileUtils, requestName, "DeleteResult");
 
         codeGenerator.generateCode(fileUtils, "/input/deleteObjects.xml");
 
@@ -317,7 +317,7 @@ public class GoFunctionalTests {
         // Verify response payload type file was not generated
         final String typeCode = codeGenerator.getTypeCode();
         CODE_LOGGER.logFile(typeCode, FileTypeToLog.MODEL);
-        assertTrue(isEmpty(typeCode));
+        assertTrue(hasContent(typeCode));
 
         // Verify that the client code was generated
         final String client = codeGenerator.getClientCode(HttpVerb.POST);
@@ -437,7 +437,7 @@ public class GoFunctionalTests {
         // This tests generation of request with "type" optional parameter keyword conflict
         final String requestName = "GetAzureDataReplicationRulesSpectraS3Request";
         final FileUtils fileUtils = mock(FileUtils.class);
-        final GoTestCodeUtil codeGenerator = new GoTestCodeUtil(fileUtils, requestName);
+        final GoTestCodeUtil codeGenerator = new GoTestCodeUtil(fileUtils, requestName, "AzureDataReplicationRule");
 
         codeGenerator.generateCode(fileUtils, "/input/getAzureDataReplicationRules.xml");
 
@@ -486,7 +486,7 @@ public class GoFunctionalTests {
         // Verify response payload type file was not generated
         final String typeCode = codeGenerator.getTypeCode();
         CODE_LOGGER.logFile(typeCode, FileTypeToLog.MODEL);
-        assertTrue(isEmpty(typeCode));
+        assertTrue(hasContent(typeCode));
 
         // Verify that the client code was generated
         final String client = codeGenerator.getClientCode(HttpVerb.GET);
@@ -504,7 +504,7 @@ public class GoFunctionalTests {
         // This tests generation of request with "type" required parameter keyword conflict
         final String requestName = "PutAzureDataReplicationRuleSpectraS3Request";
         final FileUtils fileUtils = mock(FileUtils.class);
-        final GoTestCodeUtil codeGenerator = new GoTestCodeUtil(fileUtils, requestName);
+        final GoTestCodeUtil codeGenerator = new GoTestCodeUtil(fileUtils, requestName, "AzureDataReplicationRule");
 
         codeGenerator.generateCode(fileUtils, "/input/putAzureDataReplicationRule.xml");
 
@@ -548,7 +548,7 @@ public class GoFunctionalTests {
         // Verify response payload type file was not generated
         final String typeCode = codeGenerator.getTypeCode();
         CODE_LOGGER.logFile(typeCode, FileTypeToLog.MODEL);
-        assertTrue(isEmpty(typeCode));
+        assertTrue(hasContent(typeCode));
 
         // Verify that the client code was generated
         final String client = codeGenerator.getClientCode(HttpVerb.POST);

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/utils/GoTestCodeUtil.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/utils/GoTestCodeUtil.java
@@ -34,6 +34,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
 
+import static org.apache.commons.lang3.StringUtils.uncapitalize;
 import static org.mockito.Mockito.when;
 
 /**
@@ -60,8 +61,8 @@ public class GoTestCodeUtil {
     public GoTestCodeUtil(
             final FileUtils fileUtils,
             final String requestName) throws IOException {
-        this.requestOutputStream = setupOutputStream(fileUtils, COMMAND_PATH + requestName + ".go");
-        this.responseOutputStream = setupOutputStream(fileUtils, COMMAND_PATH + NormalizingContractNamesUtil.toResponseName(requestName) + ".go");
+        this.requestOutputStream = setupOutputStream(fileUtils, COMMAND_PATH + uncapitalize(requestName) + ".go");
+        this.responseOutputStream = setupOutputStream(fileUtils, COMMAND_PATH + NormalizingContractNamesUtil.toResponseName(uncapitalize(requestName)) + ".go");
         this.clientOutputStreams = setupClientStreams(fileUtils);
     }
 
@@ -73,7 +74,7 @@ public class GoTestCodeUtil {
             final String requestName,
             final String responseType) throws IOException {
         this(fileUtils, requestName);
-        this.typeOutputStream = setupOutputStream(fileUtils, COMMAND_PATH + responseType + ".go");
+        this.typeOutputStream = setupOutputStream(fileUtils, COMMAND_PATH + uncapitalize(responseType) + ".go");
     }
 
     /**


### PR DESCRIPTION
**Changes**
- Request handlers, response handlers, and types are now generated with the first character lower-cased.  Before, there was an oversight were only the clients were being generated correctly.
- Updated some Go functional tests that were throwing null pointer exception errors due to incorrectly assuming some test scenarios were not generating types.  These exceptions were being swallowed and not interfering with the tests, but printed stack-traces were pointlessly cluttering up the output.