### PR TITLE
Fixed generation of Go response handlers

### DIFF
--- a/ds3-autogen-go/src/main/java/com/spectralogic/ds3autogen/go/GoCodeGenerator.java
+++ b/ds3-autogen-go/src/main/java/com/spectralogic/ds3autogen/go/GoCodeGenerator.java
@@ -84,7 +84,7 @@ public class GoCodeGenerator implements CodeGenerator {
                     spec.getTypes(),
                     spec.getRequests());
 
-            generateCommands(ds3Requests, typeMap);
+            generateCommands(ds3Requests);
             generateClient(ds3Requests);
             generateAllTypes(typeMap);
         } catch (final Exception e) {
@@ -95,16 +95,14 @@ public class GoCodeGenerator implements CodeGenerator {
     /**
      * Generates Go code for requests and responses
      */
-    private void generateCommands(
-            final ImmutableList<Ds3Request> ds3Requests,
-            final ImmutableMap<String, Ds3Type> typeMap) throws IOException, TemplateException {
+    private void generateCommands(final ImmutableList<Ds3Request> ds3Requests) throws IOException, TemplateException {
         if (isEmpty(ds3Requests)) {
             LOG.info("There were no requests to generate.");
             return;
         }
         for (final Ds3Request ds3Request : ds3Requests) {
             generateRequest(ds3Request);
-            generateResponse(ds3Request, typeMap);
+            generateResponse(ds3Request);
         }
     }
 
@@ -181,12 +179,10 @@ public class GoCodeGenerator implements CodeGenerator {
     /**
      * Generates the Go code for a response handler/parser
      */
-    private void generateResponse(
-            final Ds3Request ds3Request,
-            final ImmutableMap<String, Ds3Type> typeMap) throws IOException, TemplateException {
+    private void generateResponse(final Ds3Request ds3Request) throws IOException, TemplateException {
         final Template tmpl = getResponseTemplate(ds3Request);
         final ResponseModelGenerator<?> generator = getResponseGenerator(ds3Request);
-        final Response response = generator.generate(ds3Request, typeMap);
+        final Response response = generator.generate(ds3Request);
         final Path path = destDir.resolve(
                 BASE_PROJECT_PATH.resolve(
                         Paths.get(COMMANDS_NAMESPACE.replace(".", "/") + "/" + uncapitalize(response.getName()) + ".go")));

--- a/ds3-autogen-go/src/main/java/com/spectralogic/ds3autogen/go/generators/response/ResponseModelGenerator.java
+++ b/ds3-autogen-go/src/main/java/com/spectralogic/ds3autogen/go/generators/response/ResponseModelGenerator.java
@@ -22,5 +22,5 @@ import com.spectralogic.ds3autogen.go.models.response.Response;
 
 @FunctionalInterface
 public interface ResponseModelGenerator<T extends Response> {
-    T generate(final Ds3Request ds3Request, final ImmutableMap<String, Ds3Type> typeMap);
+    T generate(final Ds3Request ds3Request);
 }

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/response/GetObjectResponseGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/response/GetObjectResponseGenerator.kt
@@ -34,7 +34,7 @@ class GetObjectResponseGenerator : BaseResponseGenerator() {
     /**
      * Retrieves the response payload struct content, which is an io.ReadCloser
      */
-    override fun toResponsePayloadStruct(expectedResponseCodes: ImmutableList<Ds3ResponseCode>?, typeMap: ImmutableMap<String, Ds3Type>): String {
+    override fun toResponsePayloadStruct(expectedResponseCodes: ImmutableList<Ds3ResponseCode>?): String {
         return "Content io.ReadCloser"
     }
 

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/response/NoResponseGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/response/NoResponseGenerator.kt
@@ -28,7 +28,7 @@ open class NoResponseGenerator : BaseResponseGenerator() {
     /**
      * Return an empty string, which represents an empty response struct
      */
-    override fun toResponsePayloadStruct(expectedResponseCodes: ImmutableList<Ds3ResponseCode>?, typeMap: ImmutableMap<String, Ds3Type>): String {
+    override fun toResponsePayloadStruct(expectedResponseCodes: ImmutableList<Ds3ResponseCode>?): String {
         return ""
     }
 }

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/response/ResponseModelGeneratorUtil.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/response/ResponseModelGeneratorUtil.kt
@@ -13,13 +13,11 @@
  * ****************************************************************************
  */
 
-package com.spectralogic.ds3autogen.go.generators.response;
+package com.spectralogic.ds3autogen.go.generators.response
 
 import com.google.common.collect.ImmutableList
-import com.google.common.collect.ImmutableMap
 import com.google.common.collect.ImmutableSet
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3ResponseCode
-import com.spectralogic.ds3autogen.api.models.apispec.Ds3Type
 import com.spectralogic.ds3autogen.go.models.response.ResponseCode
 
 interface ResponseModelGeneratorUtil {
@@ -27,7 +25,7 @@ interface ResponseModelGeneratorUtil {
     /**
      * Retrieves the content of the response struct
      */
-    fun toResponsePayloadStruct(expectedResponseCodes: ImmutableList<Ds3ResponseCode>?, typeMap: ImmutableMap<String, Ds3Type>): String
+    fun toResponsePayloadStruct(expectedResponseCodes: ImmutableList<Ds3ResponseCode>?): String
 
     /**
      * Converts a Ds3ResponseCode into a ResponseCode model which contains the Go

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/models/response/Response.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/models/response/Response.kt
@@ -20,7 +20,7 @@ import com.google.common.collect.ImmutableSet
 
 data class Response(
         val name: String,
-        val payloadStruct: String, //The struct definition for the response payload including xml parsing when relevant
+        val payloadStruct: String, //The struct definition for the response payload
         val expectedCodes: String,
         val responseCodes: ImmutableList<ResponseCode>,
         val imports: ImmutableSet<String>)

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTests.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTests.java
@@ -94,10 +94,12 @@ public class GoFunctionalTests {
         CODE_LOGGER.logFile(responseCode, FileTypeToLog.RESPONSE);
         assertTrue(hasContent(responseCode));
 
+        assertTrue(responseCode.contains("Bucket Bucket"));
+        assertFalse(responseCode.contains("`xml:\"Bucket\"`"));
         assertTrue(responseCode.contains("func NewSimpleWithPayloadResponse(webResponse networking.WebResponse) (*SimpleWithPayloadResponse, error) {"));
         assertTrue(responseCode.contains("expectedStatusCodes := []int { 204 }"));
-        assertTrue(responseCode.contains("Bucket Bucket `xml:\"Bucket\"`"));
         assertTrue(responseCode.contains("var body SimpleWithPayloadResponse"));
+        assertTrue(responseCode.contains("if err := readResponseBody(webResponse, &body.Bucket); err != nil {"));
         assertTrue(responseCode.contains("return &body, nil"));
 
         // Verify response payload type file was not generated
@@ -176,10 +178,13 @@ public class GoFunctionalTests {
         final String responseCode = codeGenerator.getResponseCode();
         CODE_LOGGER.logFile(responseCode, FileTypeToLog.RESPONSE);
         assertTrue(hasContent(responseCode));
-        assertTrue(responseCode.contains("PhysicalPlacement PhysicalPlacement `xml:\"PhysicalPlacement\"`"));
+
+        assertTrue(responseCode.contains("PhysicalPlacement PhysicalPlacement"));
+        assertFalse(responseCode.contains("`xml:\"PhysicalPlacement\"`"));
         assertTrue(responseCode.contains("func NewVerifyPhysicalPlacementForObjectsSpectraS3Response(webResponse networking.WebResponse) (*VerifyPhysicalPlacementForObjectsSpectraS3Response, error) {"));
         assertTrue(responseCode.contains("expectedStatusCodes := []int { 200 }"));
         assertTrue(responseCode.contains("var body VerifyPhysicalPlacementForObjectsSpectraS3Response"));
+        assertTrue(responseCode.contains("if err := readResponseBody(webResponse, &body.PhysicalPlacement); err != nil {"));
         assertTrue(responseCode.contains("return &body, nil"));
 
         // Verify response payload type file was not generated
@@ -219,10 +224,13 @@ public class GoFunctionalTests {
         final String responseCode = codeGenerator.getResponseCode();
         CODE_LOGGER.logFile(responseCode, FileTypeToLog.RESPONSE);
         assertTrue(hasContent(responseCode));
-        assertTrue(responseCode.contains("MasterObjectList *MasterObjectList `xml:\"MasterObjectList\"`"));
+
+        assertTrue(responseCode.contains("MasterObjectList *MasterObjectList"));
+        assertFalse(responseCode.contains("`xml:\"MasterObjectList\"`"));
         assertTrue(responseCode.contains("func NewReplicatePutJobSpectraS3Response(webResponse networking.WebResponse) (*ReplicatePutJobSpectraS3Response, error) {"));
         assertTrue(responseCode.contains("expectedStatusCodes := []int { 200, 204 }"));
         assertTrue(responseCode.contains("var body ReplicatePutJobSpectraS3Response"));
+        assertTrue(responseCode.contains("if err := readResponseBody(webResponse, &body.MasterObjectList); err != nil {"));
         assertTrue(responseCode.contains("return &body, nil"));
         assertTrue(responseCode.contains("return &ReplicatePutJobSpectraS3Response{}, nil"));
 
@@ -262,10 +270,12 @@ public class GoFunctionalTests {
         final String responseCode = codeGenerator.getResponseCode();
         CODE_LOGGER.logFile(responseCode, FileTypeToLog.RESPONSE);
         assertTrue(hasContent(responseCode));
-        assertTrue(responseCode.contains("CompleteMultipartUploadResult CompleteMultipartUploadResult `xml:\"CompleteMultipartUploadResult\"`"));
+        assertTrue(responseCode.contains("CompleteMultipartUploadResult CompleteMultipartUploadResult"));
+        assertFalse(responseCode.contains("`xml:\"CompleteMultipartUploadResult\"`"));
         assertTrue(responseCode.contains("func NewCompleteMultiPartUploadResponse(webResponse networking.WebResponse) (*CompleteMultiPartUploadResponse, error) {"));
         assertTrue(responseCode.contains("expectedStatusCodes := []int { 200 }"));
         assertTrue(responseCode.contains("var body CompleteMultiPartUploadResponse"));
+        assertTrue(responseCode.contains("if err := readResponseBody(webResponse, &body.CompleteMultipartUploadResult); err != nil {"));
         assertTrue(responseCode.contains("return &body, nil"));
 
         // Verify response payload type file was not generated
@@ -308,10 +318,12 @@ public class GoFunctionalTests {
         final String responseCode = codeGenerator.getResponseCode();
         CODE_LOGGER.logFile(responseCode, FileTypeToLog.RESPONSE);
         assertTrue(hasContent(responseCode));
-        assertTrue(responseCode.contains("DeleteResult DeleteResult `xml:\"DeleteResult\"`"));
+        assertTrue(responseCode.contains("DeleteResult DeleteResult"));
+        assertFalse(responseCode.contains("`xml:\"DeleteResult\"`"));
         assertTrue(responseCode.contains("func NewDeleteObjectsResponse(webResponse networking.WebResponse) (*DeleteObjectsResponse, error) {"));
         assertTrue(responseCode.contains("expectedStatusCodes := []int { 200 }"));
         assertTrue(responseCode.contains("var body DeleteObjectsResponse"));
+        assertTrue(responseCode.contains("if err := readResponseBody(webResponse, &body.DeleteResult); err != nil {"));
         assertTrue(responseCode.contains("return &body, nil"));
 
         // Verify response payload type file was not generated
@@ -478,9 +490,11 @@ public class GoFunctionalTests {
         CODE_LOGGER.logFile(responseCode, FileTypeToLog.RESPONSE);
         assertTrue(hasContent(responseCode));
 
+        assertTrue(responseCode.contains("AzureDataReplicationRuleList AzureDataReplicationRuleList"));
+        assertFalse(responseCode.contains("`xml:\"AzureDataReplicationRuleList\"`"));
         assertTrue(responseCode.contains("func NewGetAzureDataReplicationRulesSpectraS3Response(webResponse networking.WebResponse) (*GetAzureDataReplicationRulesSpectraS3Response, error) {"));
         assertTrue(responseCode.contains("expectedStatusCodes := []int { 200 }"));
-        assertTrue(responseCode.contains("if err := readResponseBody(webResponse, &body); err != nil {"));
+        assertTrue(responseCode.contains("if err := readResponseBody(webResponse, &body.AzureDataReplicationRuleList); err != nil {"));
         assertTrue(responseCode.contains("return &body, nil"));
 
         // Verify response payload type file was not generated
@@ -540,9 +554,11 @@ public class GoFunctionalTests {
         CODE_LOGGER.logFile(responseCode, FileTypeToLog.RESPONSE);
         assertTrue(hasContent(responseCode));
 
+        assertTrue(responseCode.contains("AzureDataReplicationRule AzureDataReplicationRule"));
+        assertFalse(responseCode.contains("`xml:\"AzureDataReplicationRule\"`"));
         assertTrue(responseCode.contains("func NewPutAzureDataReplicationRuleSpectraS3Response(webResponse networking.WebResponse) (*PutAzureDataReplicationRuleSpectraS3Response, error) {"));
         assertTrue(responseCode.contains("expectedStatusCodes := []int { 201 }"));
-        assertTrue(responseCode.contains("if err := readResponseBody(webResponse, &body); err != nil {"));
+        assertTrue(responseCode.contains("if err := readResponseBody(webResponse, &body.AzureDataReplicationRule); err != nil {"));
         assertTrue(responseCode.contains("return &body, nil"));
 
         // Verify response payload type file was not generated

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/response/BaseResponseGenerator_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/response/BaseResponseGenerator_Test.java
@@ -16,11 +16,9 @@
 package com.spectralogic.ds3autogen.go.generators.response;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3ResponseCode;
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3ResponseType;
-import com.spectralogic.ds3autogen.api.models.apispec.Ds3Type;
 import com.spectralogic.ds3autogen.go.models.response.ResponseCode;
 import org.junit.Test;
 
@@ -77,35 +75,6 @@ public class BaseResponseGenerator_Test {
     }
 
     @Test (expected = IllegalArgumentException.class)
-    public void toXmlParsingPayload_Exception_Test() {
-        generator.toXmlParsingPayload(null);
-    }
-
-    @Test
-    public void toXmlParsingPayload_WithNameToMarshal_Test() {
-        final String expected = "MyNameToMarshal";
-        final Ds3Type ds3Type = new Ds3Type("com.test.Name", "MyNameToMarshal", ImmutableList.of(), ImmutableList.of());
-        final String result = generator.toXmlParsingPayload(ds3Type);
-        assertThat(result, is(expected));
-    }
-
-    @Test
-    public void toXmlParsingPayload_WithDataNameToMarshal_Test() {
-        final String expected = "Name";
-        final Ds3Type ds3Type = new Ds3Type("com.test.Name", "Data", ImmutableList.of(), ImmutableList.of());
-        final String result = generator.toXmlParsingPayload(ds3Type);
-        assertThat(result, is(expected));
-    }
-
-    @Test
-    public void toXmlParsingPayload_Test() {
-        final String expected = "Name";
-        final Ds3Type ds3Type = new Ds3Type("com.test.Name", ImmutableList.of());
-        final String result = generator.toXmlParsingPayload(ds3Type);
-        assertThat(result, is(expected));
-    }
-
-    @Test (expected = IllegalArgumentException.class)
     public void toResponsePayloadType_NullList_Test() {
         generator.toResponsePayloadType("com.test.Type", null);
     }
@@ -144,7 +113,7 @@ public class BaseResponseGenerator_Test {
 
     @Test (expected = IllegalArgumentException.class)
     public void toResponsePayloadStruct_Exception_Test() {
-        generator.toResponsePayloadStruct(ImmutableList.of(), ImmutableMap.of());
+        generator.toResponsePayloadStruct(ImmutableList.of());
     }
 
     @Test
@@ -155,23 +124,19 @@ public class BaseResponseGenerator_Test {
                 new Ds3ResponseCode(200, ImmutableList.of(new Ds3ResponseType("java.lang.String", ""))),
                 new Ds3ResponseCode(204, ImmutableList.of(new Ds3ResponseType("null", ""))));
 
-        final String result = generator.toResponsePayloadStruct(responseCodes, ImmutableMap.of());
+        final String result = generator.toResponsePayloadStruct(responseCodes);
         assertThat(result, is(expected));
     }
 
     @Test
     public void toResponsePayloadStruct_Test() {
-        final String expected = "TypeName *TypeName `xml:\"NameToMarshal\"`";
-
-        final Ds3Type ds3Type = new Ds3Type("com.test.TypeName", "NameToMarshal", ImmutableList.of(), ImmutableList.of());
+        final String expected = "TypeName *TypeName";
 
         final ImmutableList<Ds3ResponseCode> responseCodes = ImmutableList.of(
-                new Ds3ResponseCode(200, ImmutableList.of(new Ds3ResponseType(ds3Type.getName(), ""))),
+                new Ds3ResponseCode(200, ImmutableList.of(new Ds3ResponseType("com.test.TypeName", ""))),
                 new Ds3ResponseCode(204, ImmutableList.of(new Ds3ResponseType("null", ""))));
 
-        final ImmutableMap<String, Ds3Type> typeMap = ImmutableMap.of(ds3Type.getName(), ds3Type);
-
-        final String result = generator.toResponsePayloadStruct(responseCodes, typeMap);
+        final String result = generator.toResponsePayloadStruct(responseCodes);
         assertThat(result, is(expected));
     }
 
@@ -203,12 +168,12 @@ public class BaseResponseGenerator_Test {
     @Test
     public void toPayloadResponseCode_Test() {
         final String expectedGoCode = "var body ResponseName\n" +
-                "        if err := readResponseBody(webResponse, &body); err != nil {\n" +
+                "        if err := readResponseBody(webResponse, &body.PayloadName); err != nil {\n" +
                 "            return nil, err\n" +
                 "        }\n" +
                 "        return &body, nil";
 
-        final ResponseCode result = generator.toPayloadResponseCode(200, "ResponseName");
+        final ResponseCode result = generator.toPayloadResponseCode(200, "ResponseName", "PayloadName");
         assertThat(result.getCode(), is(200));
         assertThat(result.getParseResponse(), is(expectedGoCode));
     }
@@ -273,7 +238,7 @@ public class BaseResponseGenerator_Test {
     @Test
     public void toResponseCode_Test() {
         final String expectedGoCode = "var body ResponseName\n" +
-                "        if err := readResponseBody(webResponse, &body); err != nil {\n" +
+                "        if err := readResponseBody(webResponse, &body.TypeName); err != nil {\n" +
                 "            return nil, err\n" +
                 "        }\n" +
                 "        return &body, nil";
@@ -301,7 +266,7 @@ public class BaseResponseGenerator_Test {
     public void toResponseCodeList_Test() {
         final ImmutableList<ResponseCode> expectedCodes = ImmutableList.of(
                 new ResponseCode(200, "var body ResponseName\n" +
-                        "        if err := readResponseBody(webResponse, &body); err != nil {\n" +
+                        "        if err := readResponseBody(webResponse, &body.TypeName); err != nil {\n" +
                         "            return nil, err\n" +
                         "        }\n" +
                         "        return &body, nil"),

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/response/GetObjectResponseGenerator_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/response/GetObjectResponseGenerator_Test.java
@@ -17,7 +17,6 @@ package com.spectralogic.ds3autogen.go.generators.response;
 
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3ResponseCode;
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3ResponseType;
@@ -58,7 +57,7 @@ public class GetObjectResponseGenerator_Test {
 
     @Test
     public void toResponsePayloadStruct_Test() {
-        assertThat(generator.toResponsePayloadStruct(ImmutableList.of(), ImmutableMap.of()), is("Content io.ReadCloser"));
+        assertThat(generator.toResponsePayloadStruct(ImmutableList.of()), is("Content io.ReadCloser"));
     }
 
     @Test

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/response/NoResponseGenerator_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/response/NoResponseGenerator_Test.java
@@ -16,7 +16,6 @@
 package com.spectralogic.ds3autogen.go.generators.response;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -28,6 +27,6 @@ public class NoResponseGenerator_Test {
 
     @Test
     public void toResponsePayloadStructTest() {
-        assertThat(generator.toResponsePayloadStruct(ImmutableList.of(), ImmutableMap.of()), is(""));
+        assertThat(generator.toResponsePayloadStruct(ImmutableList.of()), is(""));
     }
 }


### PR DESCRIPTION
**Changes**
Discovered that the response parsing function starts parsing from one xml tag within (i.e. the outer-most tag is ignored).  Therefore, I updated the response handlers to not specify xml parsing for the highest level tag, and now the response payload is passed into the parsing function, and not the response handler (which contains the response payload).

**Tests**
This update makes 5 additional Go unit tests pass (all those with response payloads that are not failing due to unrelated errors).

**Example Code**
```
package models

import (
    "ds3/networking"
)

type GetServiceResponse struct {
    ListAllMyBucketsResult ListAllMyBucketsResult
}

func NewGetServiceResponse(webResponse networking.WebResponse) (*GetServiceResponse, error) {
    expectedStatusCodes := []int { 200 }

    switch code := webResponse.StatusCode(); code {
    case 200:
        var body GetServiceResponse
        if err := readResponseBody(webResponse, &body.ListAllMyBucketsResult); err != nil {
            return nil, err
        }
        return &body, nil
    default:
        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
    }
}
```