### PR TITLE
Go response models now generating with captilazed tag names

### DIFF
--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/type/BaseTypeGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/type/BaseTypeGenerator.kt
@@ -27,6 +27,7 @@ import com.spectralogic.ds3autogen.utils.ConverterUtil.isEmpty
 import com.spectralogic.ds3autogen.utils.Ds3ElementUtil.*
 import com.spectralogic.ds3autogen.utils.NormalizingContractNamesUtil
 import com.spectralogic.ds3autogen.utils.collections.GuavaCollectors
+import org.apache.commons.lang3.StringUtils.capitalize
 
 open class BaseTypeGenerator : TypeModelGenerator<Type>, TypeModelGeneratorUtil {
 
@@ -65,9 +66,9 @@ open class BaseTypeGenerator : TypeModelGenerator<Type>, TypeModelGeneratorUtil 
      * Creates the xml notation for parsing the GO element within the struct
      */
     fun toXmlNotation(ds3Element: Ds3Element): String {
-        val xmlTag = getXmlTagName(ds3Element)
+        val xmlTag = capitalize(getXmlTagName(ds3Element))
         if (hasWrapperAnnotations(ds3Element.ds3Annotations)) {
-            val encapsulatingTag = getEncapsulatingTagAnnotations(ds3Element.ds3Annotations)
+            val encapsulatingTag = capitalize(getEncapsulatingTagAnnotations(ds3Element.ds3Annotations))
             return "xml:\"$encapsulatingTag>$xmlTag\""
         }
         if (isAttribute(ds3Element.ds3Annotations)) {

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/type/BaseTypeGenerator_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/type/BaseTypeGenerator_Test.java
@@ -108,6 +108,38 @@ public class BaseTypeGenerator_Test {
     }
 
     @Test
+    public void toXmlNotation_LowerCasedName_Test() {
+        final Ds3Element lowerCasedElement = new Ds3Element(
+                "lowerCasedElement",
+                "Type",
+                "",
+                ImmutableList.of(),
+                false
+        );
+
+        final String result = generator.toXmlNotation(lowerCasedElement);
+        assertThat(result, is("xml:\"LowerCasedElement\""));
+    }
+
+    @Test
+    public void toXmlNotation_LowerCasedAnnotations_Test() {
+        final Ds3Element lowerCasedElement = new Ds3Element(
+                "lowerCasedElement",
+                "Type",
+                "",
+                ImmutableList.of(new Ds3Annotation(
+                        "com.spectralogic.util.marshal.CustomMarshaledName",
+                        ImmutableList.of(
+                                new Ds3AnnotationElement("CollectionValue", "lowerCasedOuterTag", "java.lang.String"),
+                                new Ds3AnnotationElement("Value", "lowerCasedInnerTag", "java.lang.String")))),
+                false
+        );
+
+        final String result = generator.toXmlNotation(lowerCasedElement);
+        assertThat(result, is("xml:\"LowerCasedOuterTag>LowerCasedInnerTag\""));
+    }
+
+    @Test
     public void toStructElementsList_NullList_Test() {
         final ImmutableList<StructElement> result = generator.toStructElementsList(null);
         assertThat(result.size(), is(0));


### PR DESCRIPTION
**Changes**
Go response types now generating with xml parsing assuming capitalized tag names.

**Tests**
This fixes the last 2 broken unit tests in the Go SDK.

**Example Code**
Originally the ID variable was generated as `Id string 'xml:"iD"'`
```
package models

type User struct {
    DisplayName *string `xml:"DisplayName"`
    Id string `xml:"ID"`
}
```