### PR TITLE
Update resource from string to UUID, and fixed java test

### DIFF
--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaFunctionalTests.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaFunctionalTests.java
@@ -53,7 +53,7 @@ import static org.mockito.Mockito.mock;
 public class JavaFunctionalTests {
 
     private static final Logger LOG = LoggerFactory.getLogger(JavaFunctionalTests.class);
-    private final static GeneratedCodeLogger CODE_LOGGER = new GeneratedCodeLogger(FileTypeToLog.REQUEST, LOG);
+    private final static GeneratedCodeLogger CODE_LOGGER = new GeneratedCodeLogger(FileTypeToLog.PARSER, LOG);
 
     @Rule
     public TemporaryFolder tempFolder = new TemporaryFolder();

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/utils/TestHelper.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/utils/TestHelper.java
@@ -307,12 +307,16 @@ public final class TestHelper {
         assertTrue(hasImport("com.spectralogic.ds3client.commands.spectrads3." + responseName, code));
         assertTrue(hasImport("com.spectralogic.ds3client.commands.parsers.utils.ResponseParserUtils", code));
 
-        final BaseParseResponse expectedParsing = new BaseParseResponse(responseName, "MasterObjectList");
-        final String expectedParsingCode = "if (ResponseParserUtils.getSizeFromHeaders(response.getHeaders()) == 0) {\n" +
-                "                    return new " + responseName + "(null, this.getChecksum(), this.getChecksumType());\n" +
-                "                }\n" +
-                "                " + expectedParsing.toJavaCode();
+        final Pattern expectedParsing = Pattern.compile(
+                "\\s+if \\(ResponseParserUtils.getSizeFromHeaders\\(response\\.getHeaders\\(\\)\\) == 0\\) \\{"
+                        + "\\s+return new " + responseName + "\\(null, this\\.getChecksum\\(\\), this\\.getChecksumType\\(\\)\\);"
+                        + "\\s+}"
+                        + "\\s+try \\(final InputStream inputStream = response\\.getResponseStream\\(\\)\\) \\{"
+                        + "\\s+final MasterObjectList result = XmlOutput\\.fromXml\\(inputStream, MasterObjectList\\.class\\);"
+                        + "\\s+return new " + responseName + "\\(result, this\\.getChecksum\\(\\), this\\.getChecksumType\\(\\)\\);"
+                        + "\\s+}",
+                Pattern.MULTILINE | Pattern.UNIX_LINES);
 
-        assertTrue(code.contains(expectedParsingCode));
+        assertTrue(expectedParsing.matcher(code).find());
     }
 }

--- a/ds3-autogen-utils/src/main/java/com/spectralogic/ds3autogen/utils/RequestConverterUtil.java
+++ b/ds3-autogen-utils/src/main/java/com/spectralogic/ds3autogen/utils/RequestConverterUtil.java
@@ -121,6 +121,7 @@ public final class RequestConverterUtil {
             case TAPE_LIBRARY:
             case USER:
             case DATA_POLICY:
+            case DATA_PERSISTENCE_RULE:
                 return true;
         }
         return false;


### PR DESCRIPTION
**Changes**
- Updated DATA_PERSISTENCE_RULE to be treated as an ID (i.e. UUID or Guid) and not as a string
  - The effects of this update have already been approved and merged in the Net SDK https://github.com/SpectraLogic/ds3_net_sdk/pull/257#discussion_r118050948
- A java test was failing due to line ending differences when run on windows. Updated test to use a pattern rather than matching a string.