### PR TITLE
Updating go enum generation to set UNDEFINED as default value

### DIFF
--- a/ds3-autogen-go/src/main/resources/tmpls/go/type/enum_type.ftl
+++ b/ds3-autogen-go/src/main/resources/tmpls/go/type/enum_type.ftl
@@ -20,6 +20,7 @@ const (
 func (${name?uncap_first} *${name}) UnmarshalText(text []byte) error {
     var str string = string(bytes.ToUpper(text))
     switch str {
+        case "": *${name?uncap_first} = UNDEFINED
         <#list enumConstants as const>
         case "${const}": *${name?uncap_first} = ${enumPrefix}${const}
         </#list>

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTypeTests.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTypeTests.java
@@ -57,6 +57,7 @@ public class GoFunctionalTypeTests {
         assertTrue(typeCode.contains("DATABASE_PHYSICAL_SPACE_STATE_NORMAL DatabasePhysicalSpaceState = 1 + iota"));
 
         // Test un-marshaling
+        assertTrue(typeCode.contains("case \"\": *databasePhysicalSpaceState = UNDEFINED"));
         assertTrue(typeCode.contains("case \"CRITICAL\": *databasePhysicalSpaceState = DATABASE_PHYSICAL_SPACE_STATE_CRITICAL"));
         assertTrue(typeCode.contains("case \"LOW\": *databasePhysicalSpaceState = DATABASE_PHYSICAL_SPACE_STATE_LOW"));
         assertTrue(typeCode.contains("case \"NEAR_LOW\": *databasePhysicalSpaceState = DATABASE_PHYSICAL_SPACE_STATE_NEAR_LOW"));


### PR DESCRIPTION
**Example Code**
```
package models

import (
    "errors"
    "fmt"
    "bytes"
    "log"
)

type Priority Enum

const (
    PRIORITY_CRITICAL Priority = 1 + iota
    PRIORITY_URGENT Priority = 1 + iota
    PRIORITY_HIGH Priority = 1 + iota
    PRIORITY_NORMAL Priority = 1 + iota
    PRIORITY_LOW Priority = 1 + iota
    PRIORITY_BACKGROUND Priority = 1 + iota
)

func (priority *Priority) UnmarshalText(text []byte) error {
    var str string = string(bytes.ToUpper(text))
    switch str {
        case "": *priority = UNDEFINED
        case "CRITICAL": *priority = PRIORITY_CRITICAL
        case "URGENT": *priority = PRIORITY_URGENT
        case "HIGH": *priority = PRIORITY_HIGH
        case "NORMAL": *priority = PRIORITY_NORMAL
        case "LOW": *priority = PRIORITY_LOW
        case "BACKGROUND": *priority = PRIORITY_BACKGROUND
        default:
            *priority = UNDEFINED
            return errors.New(fmt.Sprintf("Cannot marshal '%s' into Priority", str))
    }
    return nil
}

func (priority Priority) String() string {
    switch priority {
        case PRIORITY_CRITICAL: return "CRITICAL"
        case PRIORITY_URGENT: return "URGENT"
        case PRIORITY_HIGH: return "HIGH"
        case PRIORITY_NORMAL: return "NORMAL"
        case PRIORITY_LOW: return "LOW"
        case PRIORITY_BACKGROUND: return "BACKGROUND"
        default:
            log.Printf("Error: invalid Priority represented by '%d'", priority)
            return ""
    }
}
```