### PR TITLE
Special cased Go generation of JobList type

### DIFF
--- a/ds3-autogen-go/src/main/java/com/spectralogic/ds3autogen/go/GoCodeGenerator.java
+++ b/ds3-autogen-go/src/main/java/com/spectralogic/ds3autogen/go/GoCodeGenerator.java
@@ -32,6 +32,7 @@ import com.spectralogic.ds3autogen.go.generators.response.GetObjectResponseGener
 import com.spectralogic.ds3autogen.go.generators.response.NoResponseGenerator;
 import com.spectralogic.ds3autogen.go.generators.response.ResponseModelGenerator;
 import com.spectralogic.ds3autogen.go.generators.type.BaseTypeGenerator;
+import com.spectralogic.ds3autogen.go.generators.type.JobListGenerator;
 import com.spectralogic.ds3autogen.go.generators.type.TypeModelGenerator;
 import com.spectralogic.ds3autogen.go.models.client.Client;
 import com.spectralogic.ds3autogen.go.models.request.Request;
@@ -53,6 +54,7 @@ import static com.spectralogic.ds3autogen.utils.ConverterUtil.isEmpty;
 import static com.spectralogic.ds3autogen.utils.ConverterUtil.isEnum;
 import static com.spectralogic.ds3autogen.utils.ConverterUtil.removeUnusedTypes;
 import static com.spectralogic.ds3autogen.utils.Ds3RequestClassificationUtil.*;
+import static com.spectralogic.ds3autogen.utils.Ds3TypeClassificationUtil.isJobsApiBean;
 import static com.spectralogic.ds3autogen.utils.ResponsePayloadUtil.hasResponsePayload;
 import static org.apache.commons.lang3.StringUtils.uncapitalize;
 
@@ -320,8 +322,10 @@ public class GoCodeGenerator implements CodeGenerator {
      * Retrieves the generator used to create the Go response model represented by the
      * specified {@link Ds3Type}
      */
-    private TypeModelGenerator<?> getTypeGenerator(final Ds3Type ds3Type) {
-        //TODO add special casing
+    private static TypeModelGenerator<?> getTypeGenerator(final Ds3Type ds3Type) {
+        if (isJobsApiBean(ds3Type)) {
+            return new JobListGenerator();
+        }
         return new BaseTypeGenerator();
     }
 }

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/type/BaseTypeGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/type/BaseTypeGenerator.kt
@@ -51,7 +51,7 @@ open class BaseTypeGenerator : TypeModelGenerator<Type>, TypeModelGeneratorUtil 
      * Creates the list of elements that make up the struct, including the xml parsing notation
      * used during un-marshaling
      */
-    fun toStructElementsList(ds3Elements: ImmutableList<Ds3Element>?): ImmutableList<StructElement> {
+    override fun toStructElementsList(ds3Elements: ImmutableList<Ds3Element>?): ImmutableList<StructElement> {
         if (isEmpty(ds3Elements)) {
             return ImmutableList.of()
         }
@@ -85,7 +85,7 @@ open class BaseTypeGenerator : TypeModelGenerator<Type>, TypeModelGeneratorUtil 
             return ImmutableList.of()
         }
         return ds3EnumConstants!!.stream()
-                .map { constant -> constant.name.toUpperCase() }
+                .map { (name) -> name.toUpperCase() }
                 .collect(GuavaCollectors.immutableList())
     }
 }

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/type/JobListGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/type/JobListGenerator.kt
@@ -1,0 +1,47 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.go.generators.type
+
+import com.google.common.collect.ImmutableList
+import com.spectralogic.ds3autogen.api.models.apispec.Ds3Element
+import com.spectralogic.ds3autogen.go.models.type.StructElement
+import com.spectralogic.ds3autogen.go.utils.toGoType
+import com.spectralogic.ds3autogen.utils.ConverterUtil
+import com.spectralogic.ds3autogen.utils.Ds3ElementUtil
+import org.apache.commons.lang3.StringUtils
+
+/**
+ * Generates the Go JobList type (called JobsApiBean within contract)
+ */
+class JobListGenerator : BaseTypeGenerator() {
+
+    /**
+     * Creates the list of elements that make up the struct. JobList should only have one
+     * element, which should not have an encapsulating tag despite ds3 annotation.
+     */
+    override fun toStructElementsList(ds3Elements: ImmutableList<Ds3Element>?): ImmutableList<StructElement> {
+        if (ConverterUtil.isEmpty(ds3Elements) || ds3Elements!!.size != 1) {
+            throw IllegalArgumentException("JobsApiBean should only contain one ds3Elements")
+        }
+        val element = ds3Elements[0]
+        val xmlTag = StringUtils.capitalize(Ds3ElementUtil.getXmlTagName(element))
+        val jobList = StructElement(element.name,
+                toGoType(element.type, element.componentType, element.nullable),
+                "xml:\"$xmlTag\"")
+
+        return ImmutableList.of(jobList)
+    }
+}

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/type/TypeModelGeneratorUtil.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/type/TypeModelGeneratorUtil.kt
@@ -15,6 +15,15 @@
 
 package com.spectralogic.ds3autogen.go.generators.type
 
+import com.google.common.collect.ImmutableList
+import com.spectralogic.ds3autogen.api.models.apispec.Ds3Element
+import com.spectralogic.ds3autogen.go.models.type.StructElement
+
 interface TypeModelGeneratorUtil {
-    //TODO implement as needed
+
+    /**
+     * Creates the list of elements that make up the struct, including the xml parsing notation
+     * used during un-marshaling
+     */
+    fun toStructElementsList(ds3Elements: ImmutableList<Ds3Element>?): ImmutableList<StructElement>
 }

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTypeTests.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTypeTests.java
@@ -139,4 +139,20 @@ public class GoFunctionalTypeTests {
         assertTrue(typeCode.contains("HttpsPort *int `xml:\"HttpsPort,attr\"`"));
         assertTrue(typeCode.contains("Id string `xml:\"Id,attr\"`"));
     }
+
+    @Test
+    public void jobList() throws IOException, TemplateModelException {
+        final String typeName = "JobList";
+        final FileUtils fileUtils = mock(FileUtils.class);
+        final GoTestCodeUtil codeGenerator = new GoTestCodeUtil(fileUtils, requestName, typeName);
+
+        codeGenerator.generateCode(fileUtils, "/input/jobListType.xml");
+
+        // Verify response payload type file was generated
+        final String typeCode = codeGenerator.getTypeCode();
+        CODE_LOGGER.logFile(typeCode, FileTypeToLog.MODEL);
+        assertTrue(hasContent(typeCode));
+
+        assertTrue(typeCode.contains("Jobs []Job `xml:\"Job\"`"));
+    }
 }

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/type/JobListGenerator_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/type/JobListGenerator_Test.java
@@ -1,0 +1,58 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.go.generators.type;
+
+import com.google.common.collect.ImmutableList;
+import com.spectralogic.ds3autogen.api.models.apispec.Ds3Annotation;
+import com.spectralogic.ds3autogen.api.models.apispec.Ds3AnnotationElement;
+import com.spectralogic.ds3autogen.api.models.apispec.Ds3Element;
+import com.spectralogic.ds3autogen.go.models.type.StructElement;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class JobListGenerator_Test {
+
+    private final JobListGenerator generator = new JobListGenerator();
+
+    private final Ds3Element jobsElement = new Ds3Element(
+            "Jobs",
+            "array",
+            "com.spectralogic.s3.server.domain.Job",
+            ImmutableList.of(
+                    new Ds3Annotation(
+                            "com.spectralogic.util.marshal.CustomMarshaledName",
+                            ImmutableList.of(
+                                    new Ds3AnnotationElement("CollectionValue", "Jobs", "java.lang.String"),
+                                    new Ds3AnnotationElement("CollectionValueRenderingMode", "SINGLE_BLOCK_FOR_ALL_ELEMENTS", "com.spectralogic.util.marshal.CustomMarshaledName$CollectionNameRenderingMode"),
+                                    new Ds3AnnotationElement("Value", "Job", "java.lang.String")))),
+            false);
+
+    @Test (expected = IllegalArgumentException.class)
+    public void toStructElementsListNoElementsTest() {
+        generator.toStructElementsList(ImmutableList.of());
+    }
+
+    @Test
+    public void toStructElementsListTest() {
+        final ImmutableList<StructElement> result = generator.toStructElementsList(ImmutableList.of(jobsElement));
+        assertThat(result.size(), is(1));
+        assertThat(result.get(0).getName(), is("Jobs"));
+        assertThat(result.get(0).getType(), is("[]Job"));
+        assertThat(result.get(0).getXmlNotation(), is("xml:\"Job\""));
+    }
+}

--- a/ds3-autogen-go/src/test/resources/input/jobListType.xml
+++ b/ds3-autogen-go/src/test/resources/input/jobListType.xml
@@ -1,0 +1,55 @@
+<!--
+  ~ *******************************************************************************
+  ~   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+  ~   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+  ~   this file except in compliance with the License. A copy of the License is located at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~   or in the "license" file accompanying this file.
+  ~   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+  ~   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+  ~   specific language governing permissions and limitations under the License.
+  ~ *****************************************************************************
+  -->
+
+<Data>
+    <Contract>
+        <RequestHandlers>
+            <RequestHandler Classification="amazons3" Name="com.spectralogic.s3.server.handler.reqhandler.PlaceHolderRequestHandler">
+                <Request BucketRequirement="REQUIRED" HttpVerb="DELETE" ObjectRequirement="REQUIRED">
+                    <OptionalQueryParams/>
+                    <RequiredQueryParams>
+                        <Param Name="Placeholder" Type="com.spectralogic.s3.server.domain.JobsApiBean"/>
+                    </RequiredQueryParams>
+                </Request>
+                <ResponseCodes>
+                    <ResponseCode>
+                        <Code>204</Code>
+                        <ResponseTypes>
+                            <ResponseType Type="null"/>
+                        </ResponseTypes>
+                    </ResponseCode>
+                </ResponseCodes>
+                <Version>1.D14152B32BAE4D9F43B0E7DFE275A88E</Version>
+            </RequestHandler>
+        </RequestHandlers>
+        <Types>
+            <Type Name="com.spectralogic.s3.server.domain.JobsApiBean" NameToMarshal="">
+                <Elements>
+                    <Element ComponentType="com.spectralogic.s3.server.domain.JobApiBean" Name="Jobs" Type="array">
+                        <Annotations>
+                            <Annotation Name="com.spectralogic.util.marshal.CustomMarshaledName">
+                                <AnnotationElements>
+                                    <AnnotationElement Name="CollectionValue" Value="Jobs" ValueType="java.lang.String"/>
+                                    <AnnotationElement Name="CollectionValueRenderingMode" Value="SINGLE_BLOCK_FOR_ALL_ELEMENTS" ValueType="com.spectralogic.util.marshal.CustomMarshaledName$CollectionNameRenderingMode"/>
+                                    <AnnotationElement Name="Value" Value="Job" ValueType="java.lang.String"/>
+                                </AnnotationElements>
+                            </Annotation>
+                        </Annotations>
+                    </Element>
+                </Elements>
+            </Type>
+        </Types>
+    </Contract>
+</Data>


### PR DESCRIPTION
**Changes**
`JobList` does not have an encapsulating tag like all other response models. Its highest level tag is `Jobs`. Since the Go parser ignores the highest tag, we should not unmarshal it.

Originally was generating incorrect line `Jobs []Job 'xml:"Jobs>Job"'`

Now it generates the correct xml parsing code.
```
package models

type JobList struct {
    Jobs []Job `xml:"Job"`
}
```