### PR TITLE
Added headers to Go response handler generation

### DIFF
--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/response/BaseResponseGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/response/BaseResponseGenerator.kt
@@ -95,7 +95,7 @@ open class BaseResponseGenerator : ResponseModelGenerator<Response>, ResponseMod
      * Creates the Go code for returning an empty response when there is no payload
      */
     fun toNullPayloadResponseCode(code: Int, responseName: String): ResponseCode {
-        return ResponseCode(code, "return &$responseName{}, nil")
+        return ResponseCode(code, "return &$responseName{Headers: webResponse.Header()}, nil")
     }
 
     /**
@@ -106,7 +106,7 @@ open class BaseResponseGenerator : ResponseModelGenerator<Response>, ResponseMod
                 indent(2) + "if err != nil {\n" +
                 indent(3) + "return nil, err\n" +
                 indent(2) + "}\n" +
-                indent(2) + "return &$responseName{Content: content}, nil"
+                indent(2) + "return &$responseName{Content: content, Headers: webResponse.Header()}, nil"
         return ResponseCode(code, parseResponse)
     }
 
@@ -118,6 +118,7 @@ open class BaseResponseGenerator : ResponseModelGenerator<Response>, ResponseMod
                 indent(2) + "if err := readResponseBody(webResponse, &body.$payloadName); err != nil {\n" +
                 indent(3) + "return nil, err\n" +
                 indent(2) + "}\n" +
+                indent(2) + "body.Headers = webResponse.Header()\n" +
                 indent(2) + "return &body, nil"
 
         return ResponseCode(code, parseResponse)

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/response/GetObjectResponseGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/response/GetObjectResponseGenerator.kt
@@ -44,7 +44,7 @@ class GetObjectResponseGenerator : BaseResponseGenerator() {
      */
     override fun toResponseCode(ds3ResponseCode: Ds3ResponseCode, responseName: String): ResponseCode {
         if (ds3ResponseCode.code == 200) {
-            return ResponseCode(ds3ResponseCode.code, "return &$responseName{ Content: webResponse.Body() }, nil")
+            return ResponseCode(ds3ResponseCode.code, "return &$responseName{ Content: webResponse.Body(), Headers: webResponse.Header() }, nil")
         }
         return toStandardResponseCode(ds3ResponseCode, responseName)
     }

--- a/ds3-autogen-go/src/main/resources/tmpls/go/response/response_template.ftl
+++ b/ds3-autogen-go/src/main/resources/tmpls/go/response/response_template.ftl
@@ -4,6 +4,7 @@ package models
 
 import (
     "ds3/networking"
+    "net/http"
     <#list imports as import>
     "${import}"
     </#list>
@@ -11,6 +12,7 @@ import (
 
 type ${name} struct {
     ${payloadStruct}
+    Headers *http.Header
 }
 
 func New${name}(webResponse networking.WebResponse) (*${name}, error) {

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTests.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTests.java
@@ -56,9 +56,15 @@ public class GoFunctionalTests {
         final String responseCode = codeGenerator.getResponseCode();
         CODE_LOGGER.logFile(responseCode, FileTypeToLog.RESPONSE);
         assertTrue(hasContent(responseCode));
+
+        assertTrue(responseCode.contains("\"ds3/networking\""));
+        assertTrue(responseCode.contains("\"net/http\""));
+
+        assertTrue(responseCode.contains("Headers *http.Header"));
+
         assertTrue(responseCode.contains("func NewSimpleNoPayloadResponse(webResponse networking.WebResponse) (*SimpleNoPayloadResponse, error) {"));
         assertTrue(responseCode.contains("expectedStatusCodes := []int { 200 }"));
-        assertTrue(responseCode.contains("return &SimpleNoPayloadResponse{}, nil"));
+        assertTrue(responseCode.contains("return &SimpleNoPayloadResponse{Headers: webResponse.Header()}, nil"));
 
         // Verify response payload type file was not generated
         final String typeCode = codeGenerator.getTypeCode();
@@ -94,12 +100,18 @@ public class GoFunctionalTests {
         CODE_LOGGER.logFile(responseCode, FileTypeToLog.RESPONSE);
         assertTrue(hasContent(responseCode));
 
+        assertTrue(responseCode.contains("\"ds3/networking\""));
+        assertTrue(responseCode.contains("\"net/http\""));
+
         assertTrue(responseCode.contains("Bucket Bucket"));
         assertFalse(responseCode.contains("`xml:\"Bucket\"`"));
+        assertTrue(responseCode.contains("Headers *http.Header"));
+
         assertTrue(responseCode.contains("func NewSimpleWithPayloadResponse(webResponse networking.WebResponse) (*SimpleWithPayloadResponse, error) {"));
         assertTrue(responseCode.contains("expectedStatusCodes := []int { 204 }"));
         assertTrue(responseCode.contains("var body SimpleWithPayloadResponse"));
         assertTrue(responseCode.contains("if err := readResponseBody(webResponse, &body.Bucket); err != nil {"));
+        assertTrue(responseCode.contains("body.Headers = webResponse.Header()"));
         assertTrue(responseCode.contains("return &body, nil"));
 
         // Verify response payload type file was not generated
@@ -138,9 +150,15 @@ public class GoFunctionalTests {
         final String responseCode = codeGenerator.getResponseCode();
         CODE_LOGGER.logFile(responseCode, FileTypeToLog.RESPONSE);
         assertTrue(hasContent(responseCode));
+
+        assertTrue(responseCode.contains("\"ds3/networking\""));
+        assertTrue(responseCode.contains("\"net/http\""));
+
+        assertTrue(responseCode.contains("Headers *http.Header"));
+
         assertTrue(responseCode.contains("func NewDeleteBucketAclSpectraS3Response(webResponse networking.WebResponse) (*DeleteBucketAclSpectraS3Response, error) {"));
         assertTrue(responseCode.contains("expectedStatusCodes := []int { 204 }"));
-        assertTrue(responseCode.contains("return &DeleteBucketAclSpectraS3Response{}, nil"));
+        assertTrue(responseCode.contains("return &DeleteBucketAclSpectraS3Response{Headers: webResponse.Header()}, nil"));
 
         // Verify response payload type file was not generated
         final String typeCode = codeGenerator.getTypeCode();
@@ -179,12 +197,18 @@ public class GoFunctionalTests {
         CODE_LOGGER.logFile(responseCode, FileTypeToLog.RESPONSE);
         assertTrue(hasContent(responseCode));
 
+        assertTrue(responseCode.contains("\"ds3/networking\""));
+        assertTrue(responseCode.contains("\"net/http\""));
+
         assertTrue(responseCode.contains("PhysicalPlacement PhysicalPlacement"));
         assertFalse(responseCode.contains("`xml:\"PhysicalPlacement\"`"));
+        assertTrue(responseCode.contains("Headers *http.Header"));
+
         assertTrue(responseCode.contains("func NewVerifyPhysicalPlacementForObjectsSpectraS3Response(webResponse networking.WebResponse) (*VerifyPhysicalPlacementForObjectsSpectraS3Response, error) {"));
         assertTrue(responseCode.contains("expectedStatusCodes := []int { 200 }"));
         assertTrue(responseCode.contains("var body VerifyPhysicalPlacementForObjectsSpectraS3Response"));
         assertTrue(responseCode.contains("if err := readResponseBody(webResponse, &body.PhysicalPlacement); err != nil {"));
+        assertTrue(responseCode.contains("body.Headers = webResponse.Header()"));
         assertTrue(responseCode.contains("return &body, nil"));
 
         // Verify response payload type file was not generated
@@ -225,14 +249,21 @@ public class GoFunctionalTests {
         CODE_LOGGER.logFile(responseCode, FileTypeToLog.RESPONSE);
         assertTrue(hasContent(responseCode));
 
+        assertTrue(responseCode.contains("\"ds3/networking\""));
+        assertTrue(responseCode.contains("\"net/http\""));
+
         assertTrue(responseCode.contains("MasterObjectList *MasterObjectList"));
         assertFalse(responseCode.contains("`xml:\"MasterObjectList\"`"));
+        assertTrue(responseCode.contains("Headers *http.Header"));
+
         assertTrue(responseCode.contains("func NewReplicatePutJobSpectraS3Response(webResponse networking.WebResponse) (*ReplicatePutJobSpectraS3Response, error) {"));
         assertTrue(responseCode.contains("expectedStatusCodes := []int { 200, 204 }"));
         assertTrue(responseCode.contains("var body ReplicatePutJobSpectraS3Response"));
         assertTrue(responseCode.contains("if err := readResponseBody(webResponse, &body.MasterObjectList); err != nil {"));
+        assertTrue(responseCode.contains("body.Headers = webResponse.Header()"));
         assertTrue(responseCode.contains("return &body, nil"));
-        assertTrue(responseCode.contains("return &ReplicatePutJobSpectraS3Response{}, nil"));
+
+        assertTrue(responseCode.contains("return &ReplicatePutJobSpectraS3Response{Headers: webResponse.Header()}, nil"));
 
         // Verify response payload type file was not generated
         final String typeCode = codeGenerator.getTypeCode();
@@ -270,12 +301,18 @@ public class GoFunctionalTests {
         final String responseCode = codeGenerator.getResponseCode();
         CODE_LOGGER.logFile(responseCode, FileTypeToLog.RESPONSE);
         assertTrue(hasContent(responseCode));
+        assertTrue(responseCode.contains("\"ds3/networking\""));
+        assertTrue(responseCode.contains("\"net/http\""));
+
         assertTrue(responseCode.contains("CompleteMultipartUploadResult CompleteMultipartUploadResult"));
+        assertTrue(responseCode.contains("Headers *http.Header"));
+
         assertFalse(responseCode.contains("`xml:\"CompleteMultipartUploadResult\"`"));
         assertTrue(responseCode.contains("func NewCompleteMultiPartUploadResponse(webResponse networking.WebResponse) (*CompleteMultiPartUploadResponse, error) {"));
         assertTrue(responseCode.contains("expectedStatusCodes := []int { 200 }"));
         assertTrue(responseCode.contains("var body CompleteMultiPartUploadResponse"));
         assertTrue(responseCode.contains("if err := readResponseBody(webResponse, &body.CompleteMultipartUploadResult); err != nil {"));
+        assertTrue(responseCode.contains("body.Headers = webResponse.Header()"));
         assertTrue(responseCode.contains("return &body, nil"));
 
         // Verify response payload type file was not generated
@@ -318,12 +355,19 @@ public class GoFunctionalTests {
         final String responseCode = codeGenerator.getResponseCode();
         CODE_LOGGER.logFile(responseCode, FileTypeToLog.RESPONSE);
         assertTrue(hasContent(responseCode));
+
+        assertTrue(responseCode.contains("\"ds3/networking\""));
+        assertTrue(responseCode.contains("\"net/http\""));
+
         assertTrue(responseCode.contains("DeleteResult DeleteResult"));
+        assertTrue(responseCode.contains("Headers *http.Header"));
         assertFalse(responseCode.contains("`xml:\"DeleteResult\"`"));
+
         assertTrue(responseCode.contains("func NewDeleteObjectsResponse(webResponse networking.WebResponse) (*DeleteObjectsResponse, error) {"));
         assertTrue(responseCode.contains("expectedStatusCodes := []int { 200 }"));
         assertTrue(responseCode.contains("var body DeleteObjectsResponse"));
         assertTrue(responseCode.contains("if err := readResponseBody(webResponse, &body.DeleteResult); err != nil {"));
+        assertTrue(responseCode.contains("body.Headers = webResponse.Header()"));
         assertTrue(responseCode.contains("return &body, nil"));
 
         // Verify response payload type file was not generated
@@ -362,10 +406,16 @@ public class GoFunctionalTests {
         final String responseCode = codeGenerator.getResponseCode();
         CODE_LOGGER.logFile(responseCode, FileTypeToLog.RESPONSE);
         assertTrue(hasContent(responseCode));
+
+        assertTrue(responseCode.contains("\"ds3/networking\""));
+        assertTrue(responseCode.contains("\"net/http\""));
+
         assertTrue(responseCode.contains("Content string"));
+        assertTrue(responseCode.contains("Headers *http.Header"));
+
         assertTrue(responseCode.contains("func NewGetJobToReplicateSpectraS3Response(webResponse networking.WebResponse) (*GetJobToReplicateSpectraS3Response, error) {"));
         assertTrue(responseCode.contains("expectedStatusCodes := []int { 200 }"));
-        assertTrue(responseCode.contains("return &GetJobToReplicateSpectraS3Response{Content: content}, nil"));
+        assertTrue(responseCode.contains("return &GetJobToReplicateSpectraS3Response{Content: content, Headers: webResponse.Header()}, nil"));
 
         // Verify response payload type file was not generated
         final String typeCode = codeGenerator.getTypeCode();
@@ -423,12 +473,18 @@ public class GoFunctionalTests {
         final String responseCode = codeGenerator.getResponseCode();
         CODE_LOGGER.logFile(responseCode, FileTypeToLog.RESPONSE);
         assertTrue(hasContent(responseCode));
+
         assertTrue(responseCode.contains("\"io\""));
+        assertTrue(responseCode.contains("\"ds3/networking\""));
+        assertTrue(responseCode.contains("\"net/http\""));
+
         assertTrue(responseCode.contains("Content io.ReadCloser"));
+        assertTrue(responseCode.contains("Headers *http.Header"));
+
         assertTrue(responseCode.contains("func NewGetObjectResponse(webResponse networking.WebResponse) (*GetObjectResponse, error) {"));
         assertTrue(responseCode.contains("expectedStatusCodes := []int { 200, 206 }"));
-        assertTrue(responseCode.contains("return &GetObjectResponse{ Content: webResponse.Body() }, nil"));
-        assertTrue(responseCode.contains("return &GetObjectResponse{}, nil"));
+        assertTrue(responseCode.contains("return &GetObjectResponse{ Content: webResponse.Body(), Headers: webResponse.Header() }, nil"));
+        assertTrue(responseCode.contains("return &GetObjectResponse{Headers: webResponse.Header()}, nil"));
 
         // Verify response payload type file was not generated
         final String typeCode = codeGenerator.getTypeCode();
@@ -490,11 +546,17 @@ public class GoFunctionalTests {
         CODE_LOGGER.logFile(responseCode, FileTypeToLog.RESPONSE);
         assertTrue(hasContent(responseCode));
 
+        assertTrue(responseCode.contains("\"ds3/networking\""));
+        assertTrue(responseCode.contains("\"net/http\""));
+
         assertTrue(responseCode.contains("AzureDataReplicationRuleList AzureDataReplicationRuleList"));
         assertFalse(responseCode.contains("`xml:\"AzureDataReplicationRuleList\"`"));
+        assertTrue(responseCode.contains("Headers *http.Header"));
+
         assertTrue(responseCode.contains("func NewGetAzureDataReplicationRulesSpectraS3Response(webResponse networking.WebResponse) (*GetAzureDataReplicationRulesSpectraS3Response, error) {"));
         assertTrue(responseCode.contains("expectedStatusCodes := []int { 200 }"));
         assertTrue(responseCode.contains("if err := readResponseBody(webResponse, &body.AzureDataReplicationRuleList); err != nil {"));
+        assertTrue(responseCode.contains("body.Headers = webResponse.Header()"));
         assertTrue(responseCode.contains("return &body, nil"));
 
         // Verify response payload type file was not generated
@@ -554,11 +616,17 @@ public class GoFunctionalTests {
         CODE_LOGGER.logFile(responseCode, FileTypeToLog.RESPONSE);
         assertTrue(hasContent(responseCode));
 
+        assertTrue(responseCode.contains("\"ds3/networking\""));
+        assertTrue(responseCode.contains("\"net/http\""));
+
         assertTrue(responseCode.contains("AzureDataReplicationRule AzureDataReplicationRule"));
         assertFalse(responseCode.contains("`xml:\"AzureDataReplicationRule\"`"));
+        assertTrue(responseCode.contains("Headers *http.Header"));
+
         assertTrue(responseCode.contains("func NewPutAzureDataReplicationRuleSpectraS3Response(webResponse networking.WebResponse) (*PutAzureDataReplicationRuleSpectraS3Response, error) {"));
         assertTrue(responseCode.contains("expectedStatusCodes := []int { 201 }"));
         assertTrue(responseCode.contains("if err := readResponseBody(webResponse, &body.AzureDataReplicationRule); err != nil {"));
+        assertTrue(responseCode.contains("body.Headers = webResponse.Header()"));
         assertTrue(responseCode.contains("return &body, nil"));
 
         // Verify response payload type file was not generated
@@ -612,9 +680,14 @@ public class GoFunctionalTests {
         CODE_LOGGER.logFile(responseCode, FileTypeToLog.RESPONSE);
         assertTrue(hasContent(responseCode));
 
+        assertTrue(responseCode.contains("\"ds3/networking\""));
+        assertTrue(responseCode.contains("\"net/http\""));
+
+        assertTrue(responseCode.contains("Headers *http.Header"));
+
         assertTrue(responseCode.contains("func NewDeleteJobCreatedNotificationRegistrationSpectraS3Response(webResponse networking.WebResponse) (*DeleteJobCreatedNotificationRegistrationSpectraS3Response, error) {"));
         assertTrue(responseCode.contains("expectedStatusCodes := []int { 204 }"));
-        assertTrue(responseCode.contains("return &DeleteJobCreatedNotificationRegistrationSpectraS3Response{}, nil"));
+        assertTrue(responseCode.contains("return &DeleteJobCreatedNotificationRegistrationSpectraS3Response{Headers: webResponse.Header()}, nil"));
 
         // Verify response payload type file was not generated
         final String typeCode = codeGenerator.getTypeCode();
@@ -678,9 +751,14 @@ public class GoFunctionalTests {
         CODE_LOGGER.logFile(responseCode, FileTypeToLog.RESPONSE);
         assertTrue(hasContent(responseCode));
 
+        assertTrue(responseCode.contains("\"ds3/networking\""));
+        assertTrue(responseCode.contains("\"net/http\""));
+
+        assertTrue(responseCode.contains("Headers *http.Header"));
+
         assertTrue(responseCode.contains("func NewPutMultiPartUploadPartResponse(webResponse networking.WebResponse) (*PutMultiPartUploadPartResponse, error) {"));
         assertTrue(responseCode.contains("expectedStatusCodes := []int { 200 }"));
-        assertTrue(responseCode.contains("return &PutMultiPartUploadPartResponse{}, nil"));
+        assertTrue(responseCode.contains("return &PutMultiPartUploadPartResponse{Headers: webResponse.Header()}, nil"));
 
         // Verify response payload type file was not generated
         final String typeCode = codeGenerator.getTypeCode();
@@ -757,6 +835,15 @@ public class GoFunctionalTests {
         final String responseCode = codeGenerator.getResponseCode();
         CODE_LOGGER.logFile(responseCode, FileTypeToLog.RESPONSE);
         assertTrue(hasContent(responseCode));
+
+        assertTrue(responseCode.contains("\"ds3/networking\""));
+        assertTrue(responseCode.contains("\"net/http\""));
+
+        assertTrue(responseCode.contains("Headers *http.Header"));
+
+        assertTrue(responseCode.contains("func NewPutObjectResponse(webResponse networking.WebResponse) (*PutObjectResponse, error) {"));
+        assertTrue(responseCode.contains("expectedStatusCodes := []int { 200 }"));
+        assertTrue(responseCode.contains("return &PutObjectResponse{Headers: webResponse.Header()}, nil"));
 
         // Verify response payload type file was not generated
         final String typeCode = codeGenerator.getTypeCode();

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/response/BaseResponseGenerator_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/response/BaseResponseGenerator_Test.java
@@ -171,6 +171,7 @@ public class BaseResponseGenerator_Test {
                 "        if err := readResponseBody(webResponse, &body.PayloadName); err != nil {\n" +
                 "            return nil, err\n" +
                 "        }\n" +
+                "        body.Headers = webResponse.Header()\n" +
                 "        return &body, nil";
 
         final ResponseCode result = generator.toPayloadResponseCode(200, "ResponseName", "PayloadName");
@@ -180,7 +181,7 @@ public class BaseResponseGenerator_Test {
 
     @Test
     public void toNullPayloadResponseCode_Test() {
-        final String expectedGoCode = "return &ResponseName{}, nil";
+        final String expectedGoCode = "return &ResponseName{Headers: webResponse.Header()}, nil";
 
         final ResponseCode result = generator.toNullPayloadResponseCode(200, "ResponseName");
         assertThat(result.getCode(), is(200));
@@ -193,7 +194,7 @@ public class BaseResponseGenerator_Test {
                 "        if err != nil {\n" +
                 "            return nil, err\n" +
                 "        }\n" +
-                "        return &ResponseName{Content: content}, nil";
+                "        return &ResponseName{Content: content, Headers: webResponse.Header()}, nil";
 
         final ResponseCode result = generator.toStringPayloadResponseCode(200, "ResponseName");
         assertThat(result.getCode(), is(200));
@@ -208,7 +209,7 @@ public class BaseResponseGenerator_Test {
 
     @Test
     public void toResponseCode_NullPayload_Test() {
-        final String expectedGoCode = "return &ResponseName{}, nil";
+        final String expectedGoCode = "return &ResponseName{Headers: webResponse.Header()}, nil";
         final Ds3ResponseCode responseCode = new Ds3ResponseCode(
                 200,
                 ImmutableList.of(new Ds3ResponseType("null", "")));
@@ -224,7 +225,7 @@ public class BaseResponseGenerator_Test {
                 "        if err != nil {\n" +
                 "            return nil, err\n" +
                 "        }\n" +
-                "        return &ResponseName{Content: content}, nil";
+                "        return &ResponseName{Content: content, Headers: webResponse.Header()}, nil";
 
         final Ds3ResponseCode responseCode = new Ds3ResponseCode(
                 200,
@@ -241,6 +242,7 @@ public class BaseResponseGenerator_Test {
                 "        if err := readResponseBody(webResponse, &body.TypeName); err != nil {\n" +
                 "            return nil, err\n" +
                 "        }\n" +
+                "        body.Headers = webResponse.Header()\n" +
                 "        return &body, nil";
 
         final Ds3ResponseCode responseCode = new Ds3ResponseCode(
@@ -269,8 +271,9 @@ public class BaseResponseGenerator_Test {
                         "        if err := readResponseBody(webResponse, &body.TypeName); err != nil {\n" +
                         "            return nil, err\n" +
                         "        }\n" +
+                        "        body.Headers = webResponse.Header()\n" +
                         "        return &body, nil"),
-                new ResponseCode(204, "return &ResponseName{}, nil")
+                new ResponseCode(204, "return &ResponseName{Headers: webResponse.Header()}, nil")
         );
 
         final ImmutableList<Ds3ResponseCode> responseCodes = ImmutableList.of(

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/response/GetObjectResponseGenerator_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/response/GetObjectResponseGenerator_Test.java
@@ -33,7 +33,7 @@ public class GetObjectResponseGenerator_Test {
 
     @Test
     public void toResponseCode_200_Test() {
-        final ResponseCode expected = new ResponseCode(200, "return &GetObjectResponse{ Content: webResponse.Body() }, nil");
+        final ResponseCode expected = new ResponseCode(200, "return &GetObjectResponse{ Content: webResponse.Body(), Headers: webResponse.Header() }, nil");
 
         final Ds3ResponseCode code = new Ds3ResponseCode(200,
                 ImmutableList.of(new Ds3ResponseType("null", null)));
@@ -45,7 +45,7 @@ public class GetObjectResponseGenerator_Test {
 
     @Test
     public void toResponseCode_206_Test() {
-        final ResponseCode expected = new ResponseCode(206, "return &GetObjectResponse{}, nil");
+        final ResponseCode expected = new ResponseCode(206, "return &GetObjectResponse{Headers: webResponse.Header()}, nil");
 
         final Ds3ResponseCode code = new Ds3ResponseCode(206,
                 ImmutableList.of(new Ds3ResponseType("null", null)));


### PR DESCRIPTION
**Changes**
Added response header to response struct and propagated with web response headers.

**Example Code**
```
package models

import (
    "ds3/networking"
    "net/http"
)

type GetServiceResponse struct {
    ListAllMyBucketsResult ListAllMyBucketsResult
    Headers *http.Header
}

func NewGetServiceResponse(webResponse networking.WebResponse) (*GetServiceResponse, error) {
    expectedStatusCodes := []int { 200 }

    switch code := webResponse.StatusCode(); code {
    case 200:
        var body GetServiceResponse
        if err := readResponseBody(webResponse, &body.ListAllMyBucketsResult); err != nil {
            return nil, err
        }
        body.Headers = webResponse.Header()
        return &body, nil
    default:
        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
    }
}
```