### PR TITLE
SDKPM-33: Update java module to generate requests with percent encoded query params

### DIFF
--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/QueryParam.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/QueryParam.java
@@ -18,6 +18,8 @@ package com.spectralogic.ds3autogen.java.models;
 import com.spectralogic.ds3autogen.api.models.Arguments;
 
 import static com.spectralogic.ds3autogen.java.utils.WithConstructorUtil.putQueryParamLine;
+import static com.spectralogic.ds3autogen.java.utils.WithConstructorUtil.updateQueryParamLine;
+import static com.spectralogic.ds3autogen.utils.Helper.uncapFirst;
 
 public class QueryParam {
 
@@ -36,7 +38,12 @@ public class QueryParam {
      * the request handler
      */
     public String toPutJavaCode() {
-        return putQueryParamLine(param);
+        if (param.getType().equals("void")) {
+            // set query params with no value using Put, since UpdateQueryParam will remove null valued parameters
+            return putQueryParamLine(param);
+        }
+        // set query param with updateQueryParam call which percent encodes data
+        return updateQueryParamLine(param.getName(), uncapFirst(param.getName()));
     }
 
     public String getName() {

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaFunctionalTests.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaFunctionalTests.java
@@ -53,7 +53,7 @@ import static org.mockito.Mockito.mock;
 public class JavaFunctionalTests {
 
     private static final Logger LOG = LoggerFactory.getLogger(JavaFunctionalTests.class);
-    private final static GeneratedCodeLogger CODE_LOGGER = new GeneratedCodeLogger(FileTypeToLog.PARSER, LOG);
+    private final static GeneratedCodeLogger CODE_LOGGER = new GeneratedCodeLogger(FileTypeToLog.REQUEST, LOG);
 
     @Rule
     public TemporaryFolder tempFolder = new TemporaryFolder();
@@ -1212,8 +1212,8 @@ public class JavaFunctionalTests {
         assertTrue(hasConstructor(requestName, streamConstructorArgs, requestGeneratedCode));
         assertTrue(hasConstructor(requestName, modifyType(streamConstructorArgs, "UUID", "String"), requestGeneratedCode));
 
-        assertTrue(requestGeneratedCode.contains("this.getQueryParams().put(\"job\", job.toString())"));
-        assertTrue(requestGeneratedCode.contains("this.getQueryParams().put(\"offset\", Long.toString(offset))"));
+        assertTrue(requestGeneratedCode.contains("this.updateQueryParam(\"job\", job)"));
+        assertTrue(requestGeneratedCode.contains("this.updateQueryParam(\"offset\", offset)"));
 
         //Test the generated response
         final String responseGeneratedCode = testGeneratedCode.getResponseGeneratedCode();

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/models/QueryParam_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/models/QueryParam_Test.java
@@ -1,0 +1,50 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.java.models;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class QueryParam_Test {
+
+    @Test
+    public void toPutJavaCodeDifferentTypesTest() {
+        final String expected = "this.updateQueryParam(\"name\", name);\n";
+
+        final ImmutableList<QueryParam> qps = ImmutableList.of(
+                new QueryParam("String", "Name"),
+                new QueryParam("java.lang.String", "Name"),
+                new QueryParam("int", "Name"),
+                new QueryParam("java.lang.Integer", "Name"),
+                new QueryParam("boolean", "Name"),
+                new QueryParam("java.lang.UUID", "Name")
+        );
+
+        qps.forEach(qp -> assertThat(qp.toPutJavaCode(), is(expected)));
+    }
+
+    @Test
+    public void toPutJavaCodeVoidTypeTest() {
+        final String expected = "this.getQueryParams().put(\"name\", null);";
+
+        final QueryParam qp = new QueryParam("void", "Name");
+
+        assertThat(qp.toPutJavaCode(), is(expected));
+    }
+}


### PR DESCRIPTION
**Changes**
Updates java request generation to use percent encoding method for query params. The code generated by this change has been merged into the SDK in PR https://github.com/SpectraLogic/ds3_java_sdk/pull/475