### PR TITLE
Updating java client templates for JSDK-242 fix

### DIFF
--- a/ds3-autogen-java/src/main/resources/tmpls/java/client/ds3client_impl_template.ftl
+++ b/ds3-autogen-java/src/main/resources/tmpls/java/client/ds3client_impl_template.ftl
@@ -4,6 +4,8 @@ package ${packageName};
 
 import java.io.IOException;
 import com.spectralogic.ds3client.commands.*;
+import com.spectralogic.ds3client.commands.decorators.PutFolderRequest;
+import com.spectralogic.ds3client.commands.decorators.PutFolderResponse;
 import com.spectralogic.ds3client.commands.parsers.*;
 import com.spectralogic.ds3client.commands.spectrads3.*;
 import com.spectralogic.ds3client.commands.spectrads3.notifications.*;
@@ -29,6 +31,12 @@ public class Ds3ClientImpl implements Ds3Client {
     @Override
     public ConnectionDetails getConnectionDetails() {
         return this.netClient.getConnectionDetails();
+    }
+
+    @Override
+    public PutFolderResponse putFolder(final PutFolderRequest request) throws IOException {
+        final PutObjectResponse response = putObject(request.getPutObjectRequest());
+        return new PutFolderResponse(response);
     }
 
     <#list commands as cmd>

--- a/ds3-autogen-java/src/main/resources/tmpls/java/client/ds3client_template.ftl
+++ b/ds3-autogen-java/src/main/resources/tmpls/java/client/ds3client_template.ftl
@@ -6,6 +6,8 @@ import com.spectralogic.ds3client.annotations.Action;
 import com.spectralogic.ds3client.annotations.Resource;
 import com.spectralogic.ds3client.annotations.ResponsePayloadModel;
 import com.spectralogic.ds3client.commands.*;
+import com.spectralogic.ds3client.commands.decorators.PutFolderRequest;
+import com.spectralogic.ds3client.commands.decorators.PutFolderResponse;
 import com.spectralogic.ds3client.commands.spectrads3.*;
 import com.spectralogic.ds3client.commands.spectrads3.notifications.*;
 import com.spectralogic.ds3client.models.JobNode;
@@ -20,6 +22,9 @@ import java.io.IOException;
 public interface Ds3Client extends Closeable {
 
     ConnectionDetails getConnectionDetails();
+
+    PutFolderResponse putFolder(final PutFolderRequest request)
+            throws IOException;
 
     <#list commands as cmd>
     ${javaHelper.toAnnotation(cmd.getAnnotationInfo())}


### PR DESCRIPTION
Generates code that has already been merged into java SDK in PRs:
https://github.com/SpectraLogic/ds3_java_sdk/pull/483
https://github.com/SpectraLogic/ds3_java_sdk/pull/485