### PR TITLE
SA-182: Net request handler paths no longer convert string represented Guids into strings

### DIFF
--- a/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/utils/GeneratorUtils.java
+++ b/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/utils/GeneratorUtils.java
@@ -112,11 +112,23 @@ public final class GeneratorUtils {
             builder.append("/\"").append(" + BucketName");
         } else if (isResourceAnArg(ds3Request.getResource(), ds3Request.getIncludeInPath())) {
             final Arguments resourceArg = getArgFromResource(ds3Request.getResource());
-            builder.append("/\"").append(" + ").append(capFirst(NetHelper.argToString(resourceArg)));
+            builder.append("/\"").append(" + ").append(pathArgToString(resourceArg));
         } else {
             builder.append("\"");
         }
         return builder.toString();
+    }
+
+    /**
+     * Creates the Net code for converting an argument into a string for use in creating the
+     * request handler path. If the argument is of type UUID (which translates to Guid), it is
+     * treated as a string since all Guids are stored as strings inside the Net request handlers.
+     */
+    private static String pathArgToString(final Arguments resourceArg) {
+        if (resourceArg.getType().equals("UUID")) {
+            return capFirst(resourceArg.getName());
+        }
+        return capFirst(NetHelper.argToString(resourceArg));
     }
 
     /**

--- a/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/utils/GeneratorUtils_Test.java
+++ b/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/utils/GeneratorUtils_Test.java
@@ -44,7 +44,7 @@ public class GeneratorUtils_Test {
         assertThat(getSpectraDs3RequestPath(getRequestBulkGet()), is("\"/_rest_/bucket/\" + BucketName"));
         assertThat(getSpectraDs3RequestPath(getRequestBulkPut()), is("\"/_rest_/bucket/\" + BucketName"));
         assertThat(getSpectraDs3RequestPath(getRequestSpectraS3GetObject()), is("\"/_rest_/object/\" + ObjectName"));
-        assertThat(getSpectraDs3RequestPath(getRequestGetJob()), is("\"/_rest_/job/\" + JobId.ToString()"));
+        assertThat(getSpectraDs3RequestPath(getRequestGetJob()), is("\"/_rest_/job/\" + JobId"));
         assertThat(getSpectraDs3RequestPath(getJobChunksReadyForClientProcessingRequest()), is("\"/_rest_/job_chunk\""));
 
         //Amazon requests
@@ -81,7 +81,7 @@ public class GeneratorUtils_Test {
         assertThat(toRequestPath(getRequestBulkGet()), is("\"/_rest_/bucket/\" + BucketName"));
         assertThat(toRequestPath(getRequestBulkPut()), is("\"/_rest_/bucket/\" + BucketName"));
         assertThat(toRequestPath(getRequestSpectraS3GetObject()), is("\"/_rest_/object/\" + ObjectName"));
-        assertThat(toRequestPath(getRequestGetJob()), is("\"/_rest_/job/\" + JobId.ToString()"));
+        assertThat(toRequestPath(getRequestGetJob()), is("\"/_rest_/job/\" + JobId"));
 
         //Amazon requests
         assertThat(toRequestPath(getRequestMultiFileDelete()), is("\"/\" + BucketName"));


### PR DESCRIPTION
**Changes**
Removes unnecessary `string.ToString()` in net request handlers.

This generates the code in PR https://github.com/SpectraLogic/ds3_net_sdk/pull/265