### PR TITLE
SA-183 continued: Updated Go response handlers to use new parsing method

### DIFF
--- a/ds3-autogen-go/src/main/java/com/spectralogic/ds3autogen/go/GoCodeGenerator.java
+++ b/ds3-autogen-go/src/main/java/com/spectralogic/ds3autogen/go/GoCodeGenerator.java
@@ -325,7 +325,7 @@ public class GoCodeGenerator implements CodeGenerator {
      */
     private Template getTypeParserTemplate(final Ds3Type ds3Type, ImmutableSet<String> typesParsedAsSlices) throws IOException {
         if (typesParsedAsSlices.contains(ds3Type.getName())) {
-            return config.getTemplate("parser/type_parser_as_list.ftl");
+            return config.getTemplate("parser/type_parser_with_list.ftl");
         }
         return config.getTemplate("parser/base_type_parser.ftl");
     }

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/models/parser/ParseChildNodeImpls.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/models/parser/ParseChildNodeImpls.kt
@@ -15,7 +15,7 @@
 
 package com.spectralogic.ds3autogen.go.models.parser
 
-import com.spectralogic.ds3autogen.go.utils.indent
+import com.spectralogic.ds3autogen.go.utils.goIndent
 
 /**
  * Contains the ParseElement implementation for all non-attribute elements
@@ -91,8 +91,8 @@ data class ParseChildNodeAddToSlice(
     override val parsingCode: String
         get() {
             return "var model $childType\n" +
-                    indent(3) + "model.parse(&child, aggErr)\n" +
-                    indent(3) + "$modelName.$paramName = append($modelName.$paramName, model)"
+                    goIndent(3) + "model.parse(&child, aggErr)\n" +
+                    goIndent(3) + "$modelName.$paramName = append($modelName.$paramName, model)"
         }
 }
 

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/models/response/Response.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/models/response/Response.kt
@@ -22,5 +22,6 @@ data class Response(
         val name: String,
         val payloadStruct: String, //The struct definition for the response payload
         val expectedCodes: String,
+        val parseResponseMethod: String, //Contains the Go code for the parse method if one is needed, else empty
         val responseCodes: ImmutableList<ResponseCode>,
         val imports: ImmutableSet<String>)

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/utils/GoFormattingUtil.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/utils/GoFormattingUtil.kt
@@ -25,7 +25,7 @@ private val GO_INDENT = "    "
 /**
  * Creates the specified indentation in accordance with the Go SDK formatting
  */
-fun indent(indent: Int): String {
+fun goIndent(indent: Int): String {
     var curIndent = ""
     repeat(indent) {
         curIndent += GO_INDENT

--- a/ds3-autogen-go/src/main/resources/tmpls/go/parser/base_type_parser.ftl
+++ b/ds3-autogen-go/src/main/resources/tmpls/go/parser/base_type_parser.ftl
@@ -2,28 +2,4 @@
 
 package models
 
-func (${modelName?uncap_first} *${modelName?cap_first}) parse(node *XmlNode, aggErr *AggregateError) {
-    <#if helper.hasContent(attributes) == true>
-    // Parse Attributes
-    for _, attr := range node.Attrs {
-        switch attr.Name.Local {
-        <#list attributes as attr>
-        case "${attr.xmlTag}":
-            ${attr.parsingCode}
-        </#list>
-        }
-    }
-    </#if>
-
-    <#if helper.hasContent(childNodes) == true>
-    // Parse Child Nodes
-    for _, child := range node.Children {
-        switch child.XMLName.Local {
-        <#list childNodes as child>
-        case "${child.xmlTag}":
-            ${child.parsingCode}
-        </#list>
-        }
-    }
-    </#if>
-}
+<#include "parser_body.ftl" />

--- a/ds3-autogen-go/src/main/resources/tmpls/go/parser/parser_body.ftl
+++ b/ds3-autogen-go/src/main/resources/tmpls/go/parser/parser_body.ftl
@@ -1,0 +1,25 @@
+func (${modelName?uncap_first} *${modelName?cap_first}) parse(xmlNode *XmlNode, aggErr *AggregateError) {
+    <#if helper.hasContent(attributes) == true>
+    // Parse Attributes
+    for _, attr := range xmlNode.Attrs {
+        switch attr.Name.Local {
+        <#list attributes as attr>
+        case "${attr.xmlTag}":
+            ${attr.parsingCode}
+        </#list>
+        }
+    }
+    </#if>
+
+    <#if helper.hasContent(childNodes) == true>
+    // Parse Child Nodes
+    for _, child := range xmlNode.Children {
+        switch child.XMLName.Local {
+        <#list childNodes as child>
+        case "${child.xmlTag}":
+            ${child.parsingCode}
+        </#list>
+        }
+    }
+    </#if>
+}

--- a/ds3-autogen-go/src/main/resources/tmpls/go/parser/type_parser_with_list.ftl
+++ b/ds3-autogen-go/src/main/resources/tmpls/go/parser/type_parser_with_list.ftl
@@ -1,4 +1,10 @@
-<#include "base_type_parser.ftl" />
+<#include "../common/copyright.ftl" />
+
+package models
+
+import "log"
+
+<#include "parser_body.ftl" />
 
 func parse${modelName}Slice(tagName string, xmlNodes []XmlNode, aggErr *AggregateError) []${modelName} {
     var result []${modelName}

--- a/ds3-autogen-go/src/main/resources/tmpls/go/response/response_template.ftl
+++ b/ds3-autogen-go/src/main/resources/tmpls/go/response/response_template.ftl
@@ -15,6 +15,8 @@ type ${name} struct {
     Headers *http.Header
 }
 
+${parseResponseMethod}
+
 func New${name}(webResponse networking.WebResponse) (*${name}, error) {
     expectedStatusCodes := []int { ${expectedCodes} }
 

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTests.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTests.java
@@ -66,6 +66,8 @@ public class GoFunctionalTests {
         assertTrue(responseCode.contains("expectedStatusCodes := []int { 200 }"));
         assertTrue(responseCode.contains("return &SimpleNoPayloadResponse{Headers: webResponse.Header()}, nil"));
 
+        assertFalse(responseCode.contains("parse(webResponse networking.WebResponse)"));
+
         // Verify response payload type file was not generated
         final String typeCode = codeGenerator.getTypeCode();
         CODE_LOGGER.logFile(typeCode, FileTypeToLog.MODEL);
@@ -110,9 +112,12 @@ public class GoFunctionalTests {
         assertTrue(responseCode.contains("func NewSimpleWithPayloadResponse(webResponse networking.WebResponse) (*SimpleWithPayloadResponse, error) {"));
         assertTrue(responseCode.contains("expectedStatusCodes := []int { 204 }"));
         assertTrue(responseCode.contains("var body SimpleWithPayloadResponse"));
-        assertTrue(responseCode.contains("if err := readResponseBody(webResponse, &body.Bucket); err != nil {"));
+        assertTrue(responseCode.contains("if err := body.parse(webResponse); err != nil {"));
         assertTrue(responseCode.contains("body.Headers = webResponse.Header()"));
         assertTrue(responseCode.contains("return &body, nil"));
+
+        assertTrue(responseCode.contains("func (simpleWithPayloadResponse *SimpleWithPayloadResponse) parse(webResponse networking.WebResponse) error {"));
+        assertTrue(responseCode.contains("return parseResponsePayload(webResponse, &simpleWithPayloadResponse.Bucket)"));
 
         // Verify response payload type file was not generated
         final String typeCode = codeGenerator.getTypeCode();
@@ -159,6 +164,8 @@ public class GoFunctionalTests {
         assertTrue(responseCode.contains("func NewDeleteBucketAclSpectraS3Response(webResponse networking.WebResponse) (*DeleteBucketAclSpectraS3Response, error) {"));
         assertTrue(responseCode.contains("expectedStatusCodes := []int { 204 }"));
         assertTrue(responseCode.contains("return &DeleteBucketAclSpectraS3Response{Headers: webResponse.Header()}, nil"));
+
+        assertFalse(responseCode.contains("parse(webResponse networking.WebResponse)"));
 
         // Verify response payload type file was not generated
         final String typeCode = codeGenerator.getTypeCode();
@@ -207,9 +214,12 @@ public class GoFunctionalTests {
         assertTrue(responseCode.contains("func NewVerifyPhysicalPlacementForObjectsSpectraS3Response(webResponse networking.WebResponse) (*VerifyPhysicalPlacementForObjectsSpectraS3Response, error) {"));
         assertTrue(responseCode.contains("expectedStatusCodes := []int { 200 }"));
         assertTrue(responseCode.contains("var body VerifyPhysicalPlacementForObjectsSpectraS3Response"));
-        assertTrue(responseCode.contains("if err := readResponseBody(webResponse, &body.PhysicalPlacement); err != nil {"));
+        assertTrue(responseCode.contains("if err := body.parse(webResponse); err != nil {"));
         assertTrue(responseCode.contains("body.Headers = webResponse.Header()"));
         assertTrue(responseCode.contains("return &body, nil"));
+
+        assertTrue(responseCode.contains("func (verifyPhysicalPlacementForObjectsSpectraS3Response *VerifyPhysicalPlacementForObjectsSpectraS3Response) parse(webResponse networking.WebResponse) error {"));
+        assertTrue(responseCode.contains("return parseResponsePayload(webResponse, &verifyPhysicalPlacementForObjectsSpectraS3Response.PhysicalPlacement)"));
 
         // Verify response payload type file was not generated
         final String typeCode = codeGenerator.getTypeCode();
@@ -259,11 +269,14 @@ public class GoFunctionalTests {
         assertTrue(responseCode.contains("func NewReplicatePutJobSpectraS3Response(webResponse networking.WebResponse) (*ReplicatePutJobSpectraS3Response, error) {"));
         assertTrue(responseCode.contains("expectedStatusCodes := []int { 200, 204 }"));
         assertTrue(responseCode.contains("var body ReplicatePutJobSpectraS3Response"));
-        assertTrue(responseCode.contains("if err := readResponseBody(webResponse, &body.MasterObjectList); err != nil {"));
+        assertTrue(responseCode.contains("if err := body.parse(webResponse); err != nil {"));
         assertTrue(responseCode.contains("body.Headers = webResponse.Header()"));
         assertTrue(responseCode.contains("return &body, nil"));
 
         assertTrue(responseCode.contains("return &ReplicatePutJobSpectraS3Response{Headers: webResponse.Header()}, nil"));
+
+        assertTrue(responseCode.contains("func (replicatePutJobSpectraS3Response *ReplicatePutJobSpectraS3Response) parse(webResponse networking.WebResponse) error {"));
+        assertTrue(responseCode.contains("return parseResponsePayload(webResponse, replicatePutJobSpectraS3Response.MasterObjectList)"));
 
         // Verify response payload type file was not generated
         final String typeCode = codeGenerator.getTypeCode();
@@ -311,9 +324,12 @@ public class GoFunctionalTests {
         assertTrue(responseCode.contains("func NewCompleteMultiPartUploadResponse(webResponse networking.WebResponse) (*CompleteMultiPartUploadResponse, error) {"));
         assertTrue(responseCode.contains("expectedStatusCodes := []int { 200 }"));
         assertTrue(responseCode.contains("var body CompleteMultiPartUploadResponse"));
-        assertTrue(responseCode.contains("if err := readResponseBody(webResponse, &body.CompleteMultipartUploadResult); err != nil {"));
+        assertTrue(responseCode.contains("if err := body.parse(webResponse); err != nil {"));
         assertTrue(responseCode.contains("body.Headers = webResponse.Header()"));
         assertTrue(responseCode.contains("return &body, nil"));
+
+        assertTrue(responseCode.contains("func (completeMultiPartUploadResponse *CompleteMultiPartUploadResponse) parse(webResponse networking.WebResponse) error {"));
+        assertTrue(responseCode.contains("return parseResponsePayload(webResponse, &completeMultiPartUploadResponse.CompleteMultipartUploadResult)"));
 
         // Verify response payload type file was not generated
         final String typeCode = codeGenerator.getTypeCode();
@@ -366,9 +382,12 @@ public class GoFunctionalTests {
         assertTrue(responseCode.contains("func NewDeleteObjectsResponse(webResponse networking.WebResponse) (*DeleteObjectsResponse, error) {"));
         assertTrue(responseCode.contains("expectedStatusCodes := []int { 200 }"));
         assertTrue(responseCode.contains("var body DeleteObjectsResponse"));
-        assertTrue(responseCode.contains("if err := readResponseBody(webResponse, &body.DeleteResult); err != nil {"));
+        assertTrue(responseCode.contains("if err := body.parse(webResponse); err != nil {"));
         assertTrue(responseCode.contains("body.Headers = webResponse.Header()"));
         assertTrue(responseCode.contains("return &body, nil"));
+
+        assertTrue(responseCode.contains("func (deleteObjectsResponse *DeleteObjectsResponse) parse(webResponse networking.WebResponse) error {"));
+        assertTrue(responseCode.contains("return parseResponsePayload(webResponse, &deleteObjectsResponse.DeleteResult)"));
 
         // Verify response payload type file was not generated
         final String typeCode = codeGenerator.getTypeCode();
@@ -416,6 +435,8 @@ public class GoFunctionalTests {
         assertTrue(responseCode.contains("func NewGetJobToReplicateSpectraS3Response(webResponse networking.WebResponse) (*GetJobToReplicateSpectraS3Response, error) {"));
         assertTrue(responseCode.contains("expectedStatusCodes := []int { 200 }"));
         assertTrue(responseCode.contains("return &GetJobToReplicateSpectraS3Response{Content: content, Headers: webResponse.Header()}, nil"));
+
+        assertFalse(responseCode.contains("parse(webResponse networking.WebResponse)"));
 
         // Verify response payload type file was not generated
         final String typeCode = codeGenerator.getTypeCode();
@@ -486,6 +507,8 @@ public class GoFunctionalTests {
         assertTrue(responseCode.contains("return &GetObjectResponse{ Content: webResponse.Body(), Headers: webResponse.Header() }, nil"));
         assertTrue(responseCode.contains("return &GetObjectResponse{Headers: webResponse.Header()}, nil"));
 
+        assertFalse(responseCode.contains("parse(webResponse networking.WebResponse)"));
+
         // Verify response payload type file was not generated
         final String typeCode = codeGenerator.getTypeCode();
         CODE_LOGGER.logFile(typeCode, FileTypeToLog.MODEL);
@@ -555,9 +578,12 @@ public class GoFunctionalTests {
 
         assertTrue(responseCode.contains("func NewGetAzureDataReplicationRulesSpectraS3Response(webResponse networking.WebResponse) (*GetAzureDataReplicationRulesSpectraS3Response, error) {"));
         assertTrue(responseCode.contains("expectedStatusCodes := []int { 200 }"));
-        assertTrue(responseCode.contains("if err := readResponseBody(webResponse, &body.AzureDataReplicationRuleList); err != nil {"));
+        assertTrue(responseCode.contains("if err := body.parse(webResponse); err != nil {"));
         assertTrue(responseCode.contains("body.Headers = webResponse.Header()"));
         assertTrue(responseCode.contains("return &body, nil"));
+
+        assertTrue(responseCode.contains("func (getAzureDataReplicationRulesSpectraS3Response *GetAzureDataReplicationRulesSpectraS3Response) parse(webResponse networking.WebResponse) error {"));
+        assertTrue(responseCode.contains("return parseResponsePayload(webResponse, &getAzureDataReplicationRulesSpectraS3Response.AzureDataReplicationRuleList)"));
 
         // Verify response payload type file was not generated
         final String typeCode = codeGenerator.getTypeCode();
@@ -625,9 +651,12 @@ public class GoFunctionalTests {
 
         assertTrue(responseCode.contains("func NewPutAzureDataReplicationRuleSpectraS3Response(webResponse networking.WebResponse) (*PutAzureDataReplicationRuleSpectraS3Response, error) {"));
         assertTrue(responseCode.contains("expectedStatusCodes := []int { 201 }"));
-        assertTrue(responseCode.contains("if err := readResponseBody(webResponse, &body.AzureDataReplicationRule); err != nil {"));
+        assertTrue(responseCode.contains("if err := body.parse(webResponse); err != nil {"));
         assertTrue(responseCode.contains("body.Headers = webResponse.Header()"));
         assertTrue(responseCode.contains("return &body, nil"));
+
+        assertTrue(responseCode.contains("func (putAzureDataReplicationRuleSpectraS3Response *PutAzureDataReplicationRuleSpectraS3Response) parse(webResponse networking.WebResponse) error {"));
+        assertTrue(responseCode.contains("return parseResponsePayload(webResponse, &putAzureDataReplicationRuleSpectraS3Response.AzureDataReplicationRule)"));
 
         // Verify response payload type file was not generated
         final String typeCode = codeGenerator.getTypeCode();
@@ -688,6 +717,8 @@ public class GoFunctionalTests {
         assertTrue(responseCode.contains("func NewDeleteJobCreatedNotificationRegistrationSpectraS3Response(webResponse networking.WebResponse) (*DeleteJobCreatedNotificationRegistrationSpectraS3Response, error) {"));
         assertTrue(responseCode.contains("expectedStatusCodes := []int { 204 }"));
         assertTrue(responseCode.contains("return &DeleteJobCreatedNotificationRegistrationSpectraS3Response{Headers: webResponse.Header()}, nil"));
+
+        assertFalse(responseCode.contains("parse(webResponse networking.WebResponse)"));
 
         // Verify response payload type file was not generated
         final String typeCode = codeGenerator.getTypeCode();
@@ -759,6 +790,8 @@ public class GoFunctionalTests {
         assertTrue(responseCode.contains("func NewPutMultiPartUploadPartResponse(webResponse networking.WebResponse) (*PutMultiPartUploadPartResponse, error) {"));
         assertTrue(responseCode.contains("expectedStatusCodes := []int { 200 }"));
         assertTrue(responseCode.contains("return &PutMultiPartUploadPartResponse{Headers: webResponse.Header()}, nil"));
+
+        assertFalse(responseCode.contains("parse(webResponse networking.WebResponse)"));
 
         // Verify response payload type file was not generated
         final String typeCode = codeGenerator.getTypeCode();
@@ -844,6 +877,8 @@ public class GoFunctionalTests {
         assertTrue(responseCode.contains("func NewPutObjectResponse(webResponse networking.WebResponse) (*PutObjectResponse, error) {"));
         assertTrue(responseCode.contains("expectedStatusCodes := []int { 200 }"));
         assertTrue(responseCode.contains("return &PutObjectResponse{Headers: webResponse.Header()}, nil"));
+
+        assertFalse(responseCode.contains("parse(webResponse networking.WebResponse)"));
 
         // Verify response payload type file was not generated
         final String typeCode = codeGenerator.getTypeCode();

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/utils/GoFormattingUtil_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/utils/GoFormattingUtil_Test.java
@@ -23,11 +23,11 @@ import static org.junit.Assert.assertThat;
 public class GoFormattingUtil_Test {
 
     @Test
-    public void indentTest() {
-        assertThat(GoFormattingUtilKt.indent(-1), is(""));
-        assertThat(GoFormattingUtilKt.indent(0), is(""));
-        assertThat(GoFormattingUtilKt.indent(1), is("    "));
-        assertThat(GoFormattingUtilKt.indent(2), is("        "));
-        assertThat(GoFormattingUtilKt.indent(3), is("            "));
+    public void goIndentTest() {
+        assertThat(GoFormattingUtilKt.goIndent(-1), is(""));
+        assertThat(GoFormattingUtilKt.goIndent(0), is(""));
+        assertThat(GoFormattingUtilKt.goIndent(1), is("    "));
+        assertThat(GoFormattingUtilKt.goIndent(2), is("        "));
+        assertThat(GoFormattingUtilKt.goIndent(3), is("            "));
     }
 }


### PR DESCRIPTION
**Changes**
- Updated generation of Go response handlers to use the new parsing method.
  - Added a `parse` method to response handlers when response payload is of a Ds3Type
- Fixed load template error caused by incorrect file name.
- Namespaced Go module's `indent` util to `goIndent` to remove conflict with `helper.indent`
- Readjusted type model templates for better code reuse and to add in a required import

**Future Changes**
- Fix bug in model parser generation where lists of enums are not parsed correctly
- Remove unnecessary logic from model generation related to unused xml notation

**Example Generated Code**
```
package models

import (
    "ds3/networking"
    "net/http"
)

type GetJobsSpectraS3Response struct {
    JobList JobList
    Headers *http.Header
}

func (getJobsSpectraS3Response *GetJobsSpectraS3Response) parse(webResponse networking.WebResponse) error {
        return parseResponsePayload(webResponse, &getJobsSpectraS3Response.JobList)
}

func NewGetJobsSpectraS3Response(webResponse networking.WebResponse) (*GetJobsSpectraS3Response, error) {
    expectedStatusCodes := []int { 200 }

    switch code := webResponse.StatusCode(); code {
    case 200:
        var body GetJobsSpectraS3Response
        if err := body.parse(webResponse); err != nil {
            return nil, err
        }
        body.Headers = webResponse.Header()
        return &body, nil
    default:
        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
    }
}
```