### PR TITLE
SA-185: Fixed Go parsing of enum slices

### DIFF
--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/parser/BaseTypeParserGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/parser/BaseTypeParserGenerator.kt
@@ -75,7 +75,14 @@ open class BaseTypeParserGenerator : TypeParserModelGenerator<TypeParser>, TypeP
 
         // Handle case if there is a slice to be parsed (no encapsulating tag)
         if (ds3Element.type.equals("array")) {
-            return ParseChildNodeAddToSlice(xmlTag, modelName, paramName, toGoType(ds3Element.componentType!!))
+            val childType = toGoType(ds3Element.componentType!!)
+
+            // Handle if the slice is a Ds3Type defined enum
+            if (isElementEnum(ds3Element.componentType!!, typeMap)) {
+                return ParseChildNodeAddEnumToSlice(xmlTag, modelName, paramName, childType)
+            }
+
+            return ParseChildNodeAddToSlice(xmlTag, modelName, paramName, childType)
         }
 
         // Handle case if the element is an enum

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/models/parser/ParseChildNodeImpls.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/models/parser/ParseChildNodeImpls.kt
@@ -78,6 +78,25 @@ data class ParseChildNodeAsSlice(
 }
 
 /**
+ * Creates the Go code for parsing a single child node as an enum and adding it to a
+ * slice. This is used when there are multiple child nodes of the same type with no
+ * encapsulating xml tag.
+ */
+data class ParseChildNodeAddEnumToSlice(
+        override val xmlTag: String,
+        val modelName: String,
+        val paramName: String,
+        val childType: String) : ParseElement {
+
+    override val parsingCode: String
+        get() {
+            return "var model $childType\n" +
+                    goIndent(3) + "parseEnum(child.Content, &model, aggErr)\n" +
+                    goIndent(3) + "$modelName.$paramName = append($modelName.$paramName, model)"
+        }
+}
+
+/**
  * Creates the Go code for parsing a single child node and adding it to a slice. This
  * is used when there are multiple child nodes of the same type with no encapsulating
  * xml tag.

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/parser/BaseTypeParserGenerator_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/parser/BaseTypeParserGenerator_Test.java
@@ -188,7 +188,8 @@ public class BaseTypeParserGenerator_Test {
                 ENUM_ELEMENT,
                 ENUM_PTR_ELEMENT,
                 LIST_WITH_ENCAPS_TAG_ELEMENT,
-                DS3_TYPE_ELEMENT);
+                DS3_TYPE_ELEMENT,
+                LIST_ENUM_ELEMENT);
 
         final String modelName = "modelName";
 
@@ -200,7 +201,8 @@ public class BaseTypeParserGenerator_Test {
                 new ParseChildNodeAsEnum(ENUM_ELEMENT.getName(), modelName, ENUM_ELEMENT.getName()),
                 new ParseChildNodeAsNullableEnum(ENUM_PTR_ELEMENT.getName(), modelName, ENUM_PTR_ELEMENT.getName()),
                 new ParseChildNodeAsSlice("TestCollectionValue", "CustomMarshaledName", modelName, LIST_WITH_ENCAPS_TAG_ELEMENT.getName(), removePath(LIST_WITH_ENCAPS_TAG_ELEMENT.getComponentType())),
-                new ParseChildNodeAsDs3Type(DS3_TYPE_ELEMENT.getName(), modelName, DS3_TYPE_ELEMENT.getName()));
+                new ParseChildNodeAsDs3Type(DS3_TYPE_ELEMENT.getName(), modelName, DS3_TYPE_ELEMENT.getName()),
+                new ParseChildNodeAddEnumToSlice(LIST_ENUM_ELEMENT.getName(), modelName, LIST_ENUM_ELEMENT.getName(), removePath(LIST_ENUM_ELEMENT.getComponentType())));
 
         final ImmutableMap<String, Ds3Type> typeMape = ImmutableMap.of(
                 ENUM_ELEMENT.getType(), new Ds3Type(ENUM_ELEMENT.getType(), "", ImmutableList.of(), ImmutableList.of(ENUM_CONSTANT)));

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/models/parser/ParseChildNodeImpls_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/models/parser/ParseChildNodeImpls_Test.java
@@ -20,7 +20,7 @@ import org.junit.Test;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
-public class ParserAttributeImpls_Test {
+public class ParseChildNodeImpls_Test {
 
     private static final String XML_TAG = "XmlTag";
     private static final String MODEL_NAME = "modelName";
@@ -72,6 +72,17 @@ public class ParserAttributeImpls_Test {
                 "            %s.%s = append(%s.%s, model)", CHILD_TYPE, MODEL_NAME, PARAM_NAME, MODEL_NAME, PARAM_NAME);
 
         final ParseElement parseElement = new ParseChildNodeAddToSlice(XML_TAG, MODEL_NAME, PARAM_NAME, CHILD_TYPE);
+        assertThat(parseElement.getXmlTag(), is(XML_TAG));
+        assertThat(parseElement.getParsingCode(), is(expected));
+    }
+
+    @Test
+    public void ParseChildNodeAddEnumToSliceTest() {
+        final String expected = String.format("var model %s\n" +
+                "            parseEnum(child.Content, &model, aggErr)\n" +
+                "            %s.%s = append(%s.%s, model)", CHILD_TYPE, MODEL_NAME, PARAM_NAME, MODEL_NAME, PARAM_NAME);
+
+        final ParseElement parseElement = new ParseChildNodeAddEnumToSlice(XML_TAG, MODEL_NAME, PARAM_NAME, CHILD_TYPE);
         assertThat(parseElement.getXmlTag(), is(XML_TAG));
         assertThat(parseElement.getParsingCode(), is(expected));
     }

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/utils/GoModelFixturesUtil.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/utils/GoModelFixturesUtil.java
@@ -46,6 +46,7 @@ public class GoModelFixturesUtil {
     public final static Ds3Element ENUM_PTR_ELEMENT = new Ds3Element("EnumPtrElement", "com.test.TestEnum", "", true);
     public final static Ds3Element LIST_WITH_ENCAPS_TAG_ELEMENT = new Ds3Element("ElementListWithEncpsTag", "array", "com.test.TestType", ImmutableList.of(CUSTOM_MARSHALED_NAME), false);
     public final static Ds3Element DS3_TYPE_ELEMENT = new Ds3Element("Ds3TypeElement", "com.test.TestDs3Type", "", false);
+    public final static Ds3Element LIST_ENUM_ELEMENT = new Ds3Element("ListEnumElement", "array", "com.test.TestEnum", false);
 
     public final static Ds3Element STR_ATTR = new Ds3Element("StringAttribute", "java.lang.String", "", ImmutableList.of(ATTR_ANNOTATION), false);
     public final static Ds3Element STR_PTR_ATTR = new Ds3Element("StringPtrAttribute", "java.lang.String", "", ImmutableList.of(ATTR_ANNOTATION), true);


### PR DESCRIPTION
**Changes**
- Slices of enums were being parsed incorrectly in generated parser code. This fix removes the last of the compilation errors in Go SDK.

**Sample Code**
See `TapeTypes` and `DriveTypes` in switch for updated code.
```
package models

func (detailedTapePartition *DetailedTapePartition) parse(xmlNode *XmlNode, aggErr *AggregateError) {

    // Parse Child Nodes
    for _, child := range xmlNode.Children {
        switch child.XMLName.Local {
        case "DriveType":
            parseNullableEnum(child.Content, detailedTapePartition.DriveType, aggErr)
        case "DriveTypes":
            var model TapeDriveType
            parseEnum(child.Content, &model, aggErr)
            detailedTapePartition.DriveTypes = append(detailedTapePartition.DriveTypes, model)
        case "ErrorMessage":
            detailedTapePartition.ErrorMessage = parseNullableString(child.Content)
        case "Id":
            detailedTapePartition.Id = parseString(child.Content)
        case "ImportExportConfiguration":
            parseEnum(child.Content, &detailedTapePartition.ImportExportConfiguration, aggErr)
        case "LibraryId":
            detailedTapePartition.LibraryId = parseString(child.Content)
        case "Name":
            detailedTapePartition.Name = parseNullableString(child.Content)
        case "Quiesced":
            parseEnum(child.Content, &detailedTapePartition.Quiesced, aggErr)
        case "SerialNumber":
            detailedTapePartition.SerialNumber = parseNullableString(child.Content)
        case "State":
            parseEnum(child.Content, &detailedTapePartition.State, aggErr)
        case "TapeTypes":
            var model TapeType
            parseEnum(child.Content, &model, aggErr)
            detailedTapePartition.TapeTypes = append(detailedTapePartition.TapeTypes, model)
        }
    }
}
```