### PR TITLE
SA-186: Special cased Go JobList parser

### DIFF
--- a/ds3-autogen-go/src/main/java/com/spectralogic/ds3autogen/go/GoCodeGenerator.java
+++ b/ds3-autogen-go/src/main/java/com/spectralogic/ds3autogen/go/GoCodeGenerator.java
@@ -29,6 +29,7 @@ import com.spectralogic.ds3autogen.api.models.enums.HttpVerb;
 import com.spectralogic.ds3autogen.go.generators.client.BaseClientGenerator;
 import com.spectralogic.ds3autogen.go.generators.client.ClientModelGenerator;
 import com.spectralogic.ds3autogen.go.generators.parser.BaseTypeParserGenerator;
+import com.spectralogic.ds3autogen.go.generators.parser.JobListParserGenerator;
 import com.spectralogic.ds3autogen.go.generators.parser.TypeParserModelGenerator;
 import com.spectralogic.ds3autogen.go.generators.request.*;
 import com.spectralogic.ds3autogen.go.generators.response.BaseResponseGenerator;
@@ -335,7 +336,9 @@ public class GoCodeGenerator implements CodeGenerator {
      * specified {@link Ds3Type}
      */
     private static TypeParserModelGenerator<?> getTypeParserGenerator(final Ds3Type ds3Type) {
-        //TODO special case as necessary
+        if (isJobsApiBean(ds3Type)) {
+            return new JobListParserGenerator();
+        }
         return new BaseTypeParserGenerator();
     }
 

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/parser/BaseTypeParserGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/parser/BaseTypeParserGenerator.kt
@@ -42,7 +42,7 @@ open class BaseTypeParserGenerator : TypeParserModelGenerator<TypeParser>, TypeP
      * Converts all non-attribute elements within a Ds3Element list into ParsingElements, which
      * contain the Go code for parsing the Ds3Elements as child nodes.
      */
-    fun toChildNodeList(
+    override fun toChildNodeList(
             ds3Elements: ImmutableList<Ds3Element>?,
             typeName: String,
             typeMap: ImmutableMap<String, Ds3Type>): ImmutableList<ParseElement> {
@@ -57,11 +57,20 @@ open class BaseTypeParserGenerator : TypeParserModelGenerator<TypeParser>, TypeP
                 .collect(GuavaCollectors.immutableList())
     }
 
+
+    /**
+     * Converts a Ds3Element into a ParsingElements.There are no special-cased Ds3Elements within
+     * the BaseTypeParserGenerator.
+     */
+    override fun toChildNode(ds3Element: Ds3Element, typeName: String, typeMap: ImmutableMap<String, Ds3Type>): ParseElement {
+        return toStandardChildNode(ds3Element, typeName, typeMap)
+    }
+
     /**
      * Converts a Ds3Element into a ParsingElement, which contains the Go code for parsing the
      * specified Ds3Element as a child node. This assumes that the specified Ds3Element is not an attribute.
      */
-    fun toChildNode(ds3Element: Ds3Element, typeName: String, typeMap: ImmutableMap<String, Ds3Type>): ParseElement {
+    fun toStandardChildNode(ds3Element: Ds3Element, typeName: String, typeMap: ImmutableMap<String, Ds3Type>): ParseElement {
         val xmlTag = getXmlTagName(ds3Element)
         val modelName = StringUtils.uncapitalize(typeName)
         val paramName = StringUtils.capitalize(ds3Element.name)

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/parser/JobListParserGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/parser/JobListParserGenerator.kt
@@ -1,0 +1,49 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.go.generators.parser
+
+import com.google.common.collect.ImmutableMap
+import com.spectralogic.ds3autogen.api.models.apispec.Ds3Element
+import com.spectralogic.ds3autogen.api.models.apispec.Ds3Type
+import com.spectralogic.ds3autogen.go.models.parser.ParseChildNodeAddToSlice
+import com.spectralogic.ds3autogen.go.models.parser.ParseElement
+import com.spectralogic.ds3autogen.go.utils.toGoType
+import org.apache.commons.lang3.StringUtils
+
+/**
+ * The Go generator for JobList parser. This is special-cased because there is
+ * no encapsulating data tag for the response payload represented by the type.
+ * As a result, the annotations for an encapsulating tag produce incorrect code.
+ */
+class JobListParserGenerator : BaseTypeParserGenerator() {
+
+    /**
+     * Converts a Ds3Element into a ParsingElements. The Ds3Element with name "Job"
+     * is special-cased to ignore the encapsulating tag "Job".
+     */
+    override fun toChildNode(ds3Element: Ds3Element, typeName: String, typeMap: ImmutableMap<String, Ds3Type>): ParseElement {
+        println(ds3Element)
+        if (ds3Element.name == "Jobs") {
+            val xmlTag = getXmlTagName(ds3Element)
+            val modelName = StringUtils.uncapitalize(typeName)
+            val paramName = StringUtils.capitalize(ds3Element.name)
+            val childType = toGoType(ds3Element.componentType!!)
+            return ParseChildNodeAddToSlice(xmlTag, modelName, paramName, childType)
+        }
+
+        return toStandardChildNode(ds3Element, typeName, typeMap)
+    }
+}

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/parser/TypeParserGeneratorUtil.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/parser/TypeParserGeneratorUtil.kt
@@ -15,11 +15,32 @@
 
 package com.spectralogic.ds3autogen.go.generators.parser
 
+import com.google.common.collect.ImmutableList
+import com.google.common.collect.ImmutableMap
+import com.spectralogic.ds3autogen.api.models.apispec.Ds3Element
+import com.spectralogic.ds3autogen.api.models.apispec.Ds3Type
+import com.spectralogic.ds3autogen.go.models.parser.ParseElement
+
 /**
  * Interface for utility functions used to generate Go model parsers. This
  * defines the methods that are overridden between the {@link BaseResponseParserGenerator}
  * and other implementations of response parsers during special casing.
  */
 interface TypeParserGeneratorUtil {
-    //todo implement as needed during special casing
+
+    /**
+     * Converts all non-attribute elements within a Ds3Element list into ParsingElements, which
+     * contain the Go code for parsing the Ds3Elements as child nodes.
+     */
+    fun toChildNodeList(
+            ds3Elements: ImmutableList<Ds3Element>?,
+            typeName: String,
+            typeMap: ImmutableMap<String, Ds3Type>): ImmutableList<ParseElement>
+
+    /**
+     * Converts a Ds3Element into a ParsingElements. This is overriden to special-case
+     * individual Ds3Element parsing within a Ds3Type. Non-special-cased Ds3Elements
+     * are passed onto {@link BaseTypeParserGenerator#toStandardChildNode}
+     */
+    fun toChildNode(ds3Element: Ds3Element, typeName: String, typeMap: ImmutableMap<String, Ds3Type>): ParseElement
 }

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTypeTests.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTypeTests.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 
 import static com.spectralogic.ds3autogen.utils.ConverterUtil.hasContent;
 import static com.spectralogic.ds3autogen.utils.ConverterUtil.isEmpty;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
@@ -212,7 +213,12 @@ public class GoFunctionalTypeTests {
         CODE_LOGGER.logFile(typeParserCode, FileTypeToLog.MODEL_PARSERS);
         assertTrue(hasContent(typeParserCode));
 
-        //TODO uncomment once parser is special cased
-        //assertTrue(typeParserCode.contains("jobList.Jobs = append(jobList.Jobs, job)"));
+        assertFalse(typeParserCode.contains("case \"Jobs\":"));
+        assertFalse(typeParserCode.contains("jobList.Jobs = parseJobSlice(\"Job\", child.Children, aggErr)"));
+
+        assertTrue(typeParserCode.contains("case \"Job\":"));
+        assertTrue(typeParserCode.contains("var model Job"));
+        assertTrue(typeParserCode.contains("model.parse(&child, aggErr)"));
+        assertTrue(typeParserCode.contains("jobList.Jobs = append(jobList.Jobs, model)"));
     }
 }

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/parser/BaseTypeParserGenerator_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/parser/BaseTypeParserGenerator_Test.java
@@ -209,7 +209,7 @@ public class BaseTypeParserGenerator_Test {
 
         assertThat(input.size(), is(expected.size()));
         for (int i = 0; i < expected.size(); i++) {
-            assertThat(generator.toChildNode(input.get(i), modelName, typeMape), is(expected.get(i)));
+            assertThat(generator.toStandardChildNode(input.get(i), modelName, typeMape), is(expected.get(i)));
         }
     }
 

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/parser/JobListParserGenerator_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/parser/JobListParserGenerator_Test.java
@@ -1,0 +1,51 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.go.generators.parser;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.spectralogic.ds3autogen.api.models.apispec.Ds3Annotation;
+import com.spectralogic.ds3autogen.api.models.apispec.Ds3AnnotationElement;
+import com.spectralogic.ds3autogen.api.models.apispec.Ds3Element;
+import com.spectralogic.ds3autogen.go.models.parser.ParseChildNodeAddToSlice;
+import com.spectralogic.ds3autogen.go.models.parser.ParseElement;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class JobListParserGenerator_Test {
+
+    private static final JobListParserGenerator generator = new JobListParserGenerator();
+
+    @Test
+    public void toChildNodeTest() {
+        final ParseElement expected = new ParseChildNodeAddToSlice("Job", "jobList", "Jobs", "Job");
+
+        final ImmutableList<Ds3AnnotationElement> annotationElements = ImmutableList.of(
+                new Ds3AnnotationElement("CollectionValue", "Jobs", "java.lang.String"),
+                new Ds3AnnotationElement("CollectionValueRenderingMode", "SINGLE_BLOCK_FOR_ALL_ELEMENTS", "com.spectralogic.util.marshal.CollectionNameRenderingMode"),
+                new Ds3AnnotationElement("Value", "Job", "java.lang.String")
+        );
+
+        final Ds3Annotation annotation = new Ds3Annotation("com.spectralogic.util.marshal.CustomMarshaledName", annotationElements);
+
+        final Ds3Element jobsElement = new Ds3Element("Jobs", "array", "com.spectralogic.s3.server.domain.Job", ImmutableList.of(annotation), false);
+
+        final ParseElement result = generator.toChildNode(jobsElement, "JobList", ImmutableMap.of());
+        assertThat(result, is(expected));
+    }
+}


### PR DESCRIPTION
With this change, all integration and unit tests in the Go SDK pass.

**Generated Code**
```
package models

func (jobList *JobList) parse(xmlNode *XmlNode, aggErr *AggregateError) {

    // Parse Child Nodes
    for _, child := range xmlNode.Children {
        switch child.XMLName.Local {
        case "Job":
            var model Job
            model.parse(&child, aggErr)
            jobList.Jobs = append(jobList.Jobs, model)
        }
    }
}
```