### PR TITLE
Changed from using StringUtils cap and uncap to using kotlin cap and decap

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,6 @@ subprojects {
         compile     'org.freemarker:freemarker:2.3.23'
         compile     'org.slf4j:slf4j-api:1.7.12'
         compile     'org.slf4j:jcl-over-slf4j:1.7.12'
-        compile     'org.apache.commons:commons-lang3:3.0'
         testCompile ('org.mockito:mockito-core:1.9.5') {
             exclude group: 'org.hamcrest'
         }

--- a/ds3-autogen-go/src/main/java/com/spectralogic/ds3autogen/go/GoCodeGenerator.java
+++ b/ds3-autogen-go/src/main/java/com/spectralogic/ds3autogen/go/GoCodeGenerator.java
@@ -62,7 +62,7 @@ import static com.spectralogic.ds3autogen.utils.Ds3ElementUtil.hasWrapperAnnotat
 import static com.spectralogic.ds3autogen.utils.Ds3RequestClassificationUtil.*;
 import static com.spectralogic.ds3autogen.utils.Ds3TypeClassificationUtil.isJobsApiBean;
 import static com.spectralogic.ds3autogen.utils.ResponsePayloadUtil.hasResponsePayload;
-import static org.apache.commons.lang3.StringUtils.uncapitalize;
+import static kotlin.text.StringsKt.decapitalize;
 
 public class GoCodeGenerator implements CodeGenerator {
 
@@ -124,7 +124,7 @@ public class GoCodeGenerator implements CodeGenerator {
         final Request request = generator.generate(ds3Request);
         final Path path = destDir.resolve(
                 BASE_PROJECT_PATH.resolve(
-                        Paths.get(COMMANDS_NAMESPACE.replace(".", "/") + "/" + uncapitalize(request.getName())  + ".go")));
+                        Paths.get(COMMANDS_NAMESPACE.replace(".", "/") + "/" + decapitalize(request.getName())  + ".go")));
 
         LOG.info("Getting Output Stream for file: {}", path.toString());
 
@@ -194,7 +194,7 @@ public class GoCodeGenerator implements CodeGenerator {
         final Response response = generator.generate(ds3Request);
         final Path path = destDir.resolve(
                 BASE_PROJECT_PATH.resolve(
-                        Paths.get(COMMANDS_NAMESPACE.replace(".", "/") + "/" + uncapitalize(response.getName()) + ".go")));
+                        Paths.get(COMMANDS_NAMESPACE.replace(".", "/") + "/" + decapitalize(response.getName()) + ".go")));
 
         LOG.info("Getting Output Stream for file: {}", path.toString());
 
@@ -311,7 +311,7 @@ public class GoCodeGenerator implements CodeGenerator {
         final TypeParser typeParser = generator.generate(ds3Type, typeMap);
         final Path path = destDir.resolve(
                 BASE_PROJECT_PATH.resolve(
-                        Paths.get(COMMANDS_NAMESPACE.replace(".", "/") + "/" + uncapitalize(typeParser.getName()) + ".go")));
+                        Paths.get(COMMANDS_NAMESPACE.replace(".", "/") + "/" + decapitalize(typeParser.getName()) + ".go")));
 
         LOG.info("Getting OutputStream for file: {}", path.toString());
 
@@ -364,7 +364,7 @@ public class GoCodeGenerator implements CodeGenerator {
         final Type type = generator.generate(ds3Type);
         final Path path = destDir.resolve(
                 BASE_PROJECT_PATH.resolve(
-                        Paths.get(COMMANDS_NAMESPACE.replace(".", "/") + "/" + uncapitalize(type.getName()) + ".go")));
+                        Paths.get(COMMANDS_NAMESPACE.replace(".", "/") + "/" + decapitalize(type.getName()) + ".go")));
 
         LOG.info("Getting OutputStream for file: {}", path.toString());
 

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/parser/BaseTypeParserGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/parser/BaseTypeParserGenerator.kt
@@ -25,7 +25,6 @@ import com.spectralogic.ds3autogen.utils.ConverterUtil
 import com.spectralogic.ds3autogen.utils.Ds3ElementUtil
 import com.spectralogic.ds3autogen.utils.NormalizingContractNamesUtil
 import com.spectralogic.ds3autogen.utils.collections.GuavaCollectors
-import org.apache.commons.lang3.StringUtils
 
 open class BaseTypeParserGenerator : TypeParserModelGenerator<TypeParser>, TypeParserGeneratorUtil {
 
@@ -72,12 +71,12 @@ open class BaseTypeParserGenerator : TypeParserModelGenerator<TypeParser>, TypeP
      */
     fun toStandardChildNode(ds3Element: Ds3Element, typeName: String, typeMap: ImmutableMap<String, Ds3Type>): ParseElement {
         val xmlTag = getXmlTagName(ds3Element)
-        val modelName = StringUtils.uncapitalize(typeName)
-        val paramName = StringUtils.capitalize(ds3Element.name)
+        val modelName = typeName.decapitalize()
+        val paramName = ds3Element.name.capitalize()
 
         // Handle case if there is an encapsulating tag around a list of elements
         if (Ds3ElementUtil.hasWrapperAnnotations(ds3Element.ds3Annotations)) {
-            val encapsulatingTag = StringUtils.capitalize(Ds3ElementUtil.getEncapsulatingTagAnnotations(ds3Element.ds3Annotations))
+            val encapsulatingTag = Ds3ElementUtil.getEncapsulatingTagAnnotations(ds3Element.ds3Annotations).capitalize()
             val childType = NormalizingContractNamesUtil.removePath(ds3Element.componentType)
             return ParseChildNodeAsSlice(encapsulatingTag, xmlTag, modelName, paramName, childType)
         }
@@ -149,8 +148,8 @@ open class BaseTypeParserGenerator : TypeParserModelGenerator<TypeParser>, TypeP
         val xmlName = getXmlTagName(ds3Element)
 
         val goType = toGoType(ds3Element.type, ds3Element.componentType, ds3Element.nullable)
-        val modelName = StringUtils.uncapitalize(typeName)
-        val paramName = StringUtils.capitalize(ds3Element.name)
+        val modelName = typeName.decapitalize()
+        val paramName = ds3Element.name.capitalize()
 
         when (goType) {
             "bool", "*bool", "int", "*int", "int64", "*int64", "float64", "*float64"  -> {
@@ -174,7 +173,7 @@ open class BaseTypeParserGenerator : TypeParserModelGenerator<TypeParser>, TypeP
      * Retrieves the xml tag name for the specified Ds3Element. The result is capitalized.
      */
     fun getXmlTagName(ds3Element: Ds3Element): String {
-        return StringUtils.capitalize(Ds3ElementUtil.getXmlTagName(ds3Element))
+        return Ds3ElementUtil.getXmlTagName(ds3Element).capitalize()
     }
 
     /**
@@ -183,7 +182,7 @@ open class BaseTypeParserGenerator : TypeParserModelGenerator<TypeParser>, TypeP
      * a pointer to a Go primitive type.
      */
     fun getPrimitiveTypeParserNamespace(type: String, nullable: Boolean): String {
-        val parserPrefix = StringUtils.capitalize(toGoType(type))
+        val parserPrefix = toGoType(type).capitalize()
         if (nullable) {
             return "Nullable$parserPrefix"
         }

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/parser/JobListParserGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/parser/JobListParserGenerator.kt
@@ -21,7 +21,6 @@ import com.spectralogic.ds3autogen.api.models.apispec.Ds3Type
 import com.spectralogic.ds3autogen.go.models.parser.ParseChildNodeAddToSlice
 import com.spectralogic.ds3autogen.go.models.parser.ParseElement
 import com.spectralogic.ds3autogen.go.utils.toGoType
-import org.apache.commons.lang3.StringUtils
 
 /**
  * The Go generator for JobList parser. This is special-cased because there is
@@ -38,8 +37,8 @@ class JobListParserGenerator : BaseTypeParserGenerator() {
         println(ds3Element)
         if (ds3Element.name == "Jobs") {
             val xmlTag = getXmlTagName(ds3Element)
-            val modelName = StringUtils.uncapitalize(typeName)
-            val paramName = StringUtils.capitalize(ds3Element.name)
+            val modelName = typeName.decapitalize()
+            val paramName = ds3Element.name.capitalize()
             val childType = toGoType(ds3Element.componentType!!)
             return ParseChildNodeAddToSlice(xmlTag, modelName, paramName, childType)
         }

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/response/BaseResponseGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/response/BaseResponseGenerator.kt
@@ -28,7 +28,6 @@ import com.spectralogic.ds3autogen.utils.NormalizingContractNamesUtil
 import com.spectralogic.ds3autogen.utils.NormalizingContractNamesUtil.removePath
 import com.spectralogic.ds3autogen.utils.ResponsePayloadUtil
 import com.spectralogic.ds3autogen.utils.collections.GuavaCollectors
-import org.apache.commons.lang3.StringUtils
 import java.util.stream.Collectors
 
 open class BaseResponseGenerator : ResponseModelGenerator<Response>, ResponseModelGeneratorUtil {
@@ -62,7 +61,7 @@ open class BaseResponseGenerator : ResponseModelGenerator<Response>, ResponseMod
             return ""
         }
 
-        val modelName = StringUtils.uncapitalize(name)
+        val modelName = name.decapitalize()
         val dereference = toDereferenceResponsePayload(payloadStruct)
         return "func ($modelName *$name) parse(webResponse networking.WebResponse) error {\n" +
                 goIndent(1) + "    return parseResponsePayload(webResponse, $dereference$modelName.$elementName)\n" +

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/type/BaseTypeGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/type/BaseTypeGenerator.kt
@@ -27,7 +27,6 @@ import com.spectralogic.ds3autogen.utils.ConverterUtil.isEmpty
 import com.spectralogic.ds3autogen.utils.Ds3ElementUtil.*
 import com.spectralogic.ds3autogen.utils.NormalizingContractNamesUtil
 import com.spectralogic.ds3autogen.utils.collections.GuavaCollectors
-import org.apache.commons.lang3.StringUtils.capitalize
 
 open class BaseTypeGenerator : TypeModelGenerator<Type>, TypeModelGeneratorUtil {
 
@@ -66,9 +65,9 @@ open class BaseTypeGenerator : TypeModelGenerator<Type>, TypeModelGeneratorUtil 
      * Creates the xml notation for parsing the GO element within the struct
      */
     fun toXmlNotation(ds3Element: Ds3Element): String {
-        val xmlTag = capitalize(getXmlTagName(ds3Element))
+        val xmlTag = getXmlTagName(ds3Element).capitalize()
         if (hasWrapperAnnotations(ds3Element.ds3Annotations)) {
-            val encapsulatingTag = capitalize(getEncapsulatingTagAnnotations(ds3Element.ds3Annotations))
+            val encapsulatingTag = getEncapsulatingTagAnnotations(ds3Element.ds3Annotations).capitalize()
             return "xml:\"$encapsulatingTag>$xmlTag\""
         }
         if (isAttribute(ds3Element.ds3Annotations)) {

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/type/JobListGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/type/JobListGenerator.kt
@@ -21,7 +21,6 @@ import com.spectralogic.ds3autogen.go.models.type.StructElement
 import com.spectralogic.ds3autogen.go.utils.toGoType
 import com.spectralogic.ds3autogen.utils.ConverterUtil
 import com.spectralogic.ds3autogen.utils.Ds3ElementUtil
-import org.apache.commons.lang3.StringUtils
 
 /**
  * Generates the Go JobList type (called JobsApiBean within contract)
@@ -37,7 +36,7 @@ class JobListGenerator : BaseTypeGenerator() {
             throw IllegalArgumentException("JobsApiBean should only contain one ds3Elements")
         }
         val element = ds3Elements[0]
-        val xmlTag = StringUtils.capitalize(Ds3ElementUtil.getXmlTagName(element))
+        val xmlTag = Ds3ElementUtil.getXmlTagName(element).capitalize()
         val jobList = StructElement(element.name,
                 toGoType(element.type, element.componentType, element.nullable),
                 "xml:\"$xmlTag\"")

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/utils/GoTestCodeUtil.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/utils/GoTestCodeUtil.java
@@ -34,7 +34,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
 
-import static org.apache.commons.lang3.StringUtils.uncapitalize;
+import static kotlin.text.StringsKt.decapitalize;
+
 import static org.mockito.Mockito.when;
 
 /**
@@ -63,8 +64,8 @@ public class GoTestCodeUtil {
     public GoTestCodeUtil(
             final FileUtils fileUtils,
             final String requestName) throws IOException {
-        this.requestOutputStream = setupOutputStream(fileUtils, COMMAND_PATH + uncapitalize(requestName) + ".go");
-        this.responseOutputStream = setupOutputStream(fileUtils, COMMAND_PATH + NormalizingContractNamesUtil.toResponseName(uncapitalize(requestName)) + ".go");
+        this.requestOutputStream = setupOutputStream(fileUtils, COMMAND_PATH + decapitalize(requestName) + ".go");
+        this.responseOutputStream = setupOutputStream(fileUtils, COMMAND_PATH + NormalizingContractNamesUtil.toResponseName(decapitalize(requestName)) + ".go");
         this.clientOutputStreams = setupClientStreams(fileUtils);
     }
 
@@ -76,8 +77,8 @@ public class GoTestCodeUtil {
             final String requestName,
             final String responseType) throws IOException {
         this(fileUtils, requestName);
-        this.typeOutputStream = setupOutputStream(fileUtils, COMMAND_PATH + uncapitalize(responseType) + ".go");
-        this.typeParserOutputStream = setupOutputStream(fileUtils, COMMAND_PATH + uncapitalize(responseType) + "Parser.go");
+        this.typeOutputStream = setupOutputStream(fileUtils, COMMAND_PATH + decapitalize(responseType) + ".go");
+        this.typeParserOutputStream = setupOutputStream(fileUtils, COMMAND_PATH + decapitalize(responseType) + "Parser.go");
     }
 
     /**

--- a/ds3-autogen-test-util/src/main/java/com/spectralogic/ds3autogen/testutil/logging/GeneratedCodeLogger.java
+++ b/ds3-autogen-test-util/src/main/java/com/spectralogic/ds3autogen/testutil/logging/GeneratedCodeLogger.java
@@ -17,7 +17,6 @@ package com.spectralogic.ds3autogen.testutil.logging;
 
 import org.slf4j.Logger;
 
-import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 /**
  * Used to log generated code based on file type. This is used in unit tests
@@ -51,7 +50,7 @@ public class GeneratedCodeLogger {
      * Creates the message that will be logged, including the generated code
      */
     private String getLogMessage(final String code) {
-        if (isEmpty(code)) {
+        if (code == null || code.equals("")) {
             return "Generated code: <EMPTY>";
         }
         return "Generated code:\n" + code;

--- a/ds3-autogen-utils/src/main/java/com/spectralogic/ds3autogen/utils/Helper.java
+++ b/ds3-autogen-utils/src/main/java/com/spectralogic/ds3autogen/utils/Helper.java
@@ -17,18 +17,19 @@ package com.spectralogic.ds3autogen.utils;
 
 import com.google.common.base.CaseFormat;
 import com.google.common.collect.ImmutableList;
-import com.spectralogic.ds3autogen.api.models.*;
+import com.spectralogic.ds3autogen.api.models.Arguments;
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3ResponseCode;
 import com.spectralogic.ds3autogen.api.models.enums.Action;
 import com.spectralogic.ds3autogen.api.models.enums.HttpVerb;
 import com.spectralogic.ds3autogen.api.models.enums.Operation;
 import com.spectralogic.ds3autogen.utils.comparators.CustomArgumentComparator;
-import org.apache.commons.lang3.StringUtils;
 
 import java.util.*;
 import java.util.stream.Collectors;
 
 import static com.spectralogic.ds3autogen.utils.ConverterUtil.isEmpty;
+import static kotlin.text.StringsKt.capitalize;
+import static kotlin.text.StringsKt.decapitalize;
 
 public final class Helper {
 
@@ -52,11 +53,11 @@ public final class Helper {
     }
 
     public static String capFirst(final String str) {
-        return StringUtils.capitalize(str);
+        return capitalize(str);
     }
 
     public static String uncapFirst(final String str) {
-        return StringUtils.uncapitalize(str);
+        return decapitalize(str);
     }
 
     public static String camelToUnderscore(final String str) {

--- a/ds3-autogen-utils/src/test/java/com/spectralogic/ds3autogen/utils/Helper_Test.java
+++ b/ds3-autogen-utils/src/test/java/com/spectralogic/ds3autogen/utils/Helper_Test.java
@@ -279,15 +279,39 @@ public class Helper_Test {
         assertFalse(result.get(0).getType().equals("void"));
         assertFalse(result.get(1).getType().equals("void"));
     }
+
     @Test
     public void testIsBasicType() {
         final String testString = "boolean";
         assertThat(Helper.isPrimitiveType(testString), is(true));
     }
+
     @Test
     public void testIsBasicTypeNegative() {
 
         final String testString = "com.spectralogic.s3.server.domain.UserApiBean";
         assertThat(Helper.isPrimitiveType(testString), is(false));
+    }
+
+    @Test
+    public void capFirstTest() {
+        assertThat(Helper.capFirst(""), is(""));
+        assertThat(Helper.capFirst("helloWorld"), is("HelloWorld"));
+        assertThat(Helper.capFirst("HelloWorld"), is("HelloWorld"));
+        assertThat(Helper.capFirst(".HelloWorld"), is(".HelloWorld"));
+        assertThat(Helper.capFirst(".helloWorld"), is(".helloWorld"));
+        assertThat(Helper.capFirst(" helloWorld"), is(" helloWorld"));
+        assertThat(Helper.capFirst(" HelloWorld"), is(" HelloWorld"));
+    }
+
+    @Test
+    public void uncapFirstTest() {
+        assertThat(Helper.uncapFirst(""), is(""));
+        assertThat(Helper.uncapFirst("helloWorld"), is("helloWorld"));
+        assertThat(Helper.uncapFirst("HelloWorld"), is("helloWorld"));
+        assertThat(Helper.uncapFirst(".HelloWorld"), is(".HelloWorld"));
+        assertThat(Helper.uncapFirst(".helloWorld"), is(".helloWorld"));
+        assertThat(Helper.uncapFirst(" helloWorld"), is(" helloWorld"));
+        assertThat(Helper.uncapFirst(" HelloWorld"), is(" HelloWorld"));
     }
 }


### PR DESCRIPTION
**Changes**
Replaced Java StringUtils implementation of capitalize and uncapitalize strings with Kotlin build in string extension methods. This was done for code cleanup.  Instances of cap/uncap were also replaced within Java code for consistency.
- Replaced `StringUtils.capitalize` with `StringsKt.capitalize`
- Replaced `StringUtils.uncapitalize` with `StringsKt.decapitalize`

Added unit tests to `Helper.uncap` and `Helper.cap` as sanity check due to change of library implementation.