### PR TITLE
SA-189: Fixing generated parsing code for handling common prefixes in Go

### DIFF
--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/parser/BaseTypeParserGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/parser/BaseTypeParserGenerator.kt
@@ -78,6 +78,12 @@ open class BaseTypeParserGenerator : TypeParserModelGenerator<TypeParser>, TypeP
         if (Ds3ElementUtil.hasWrapperAnnotations(ds3Element.ds3Annotations)) {
             val encapsulatingTag = Ds3ElementUtil.getEncapsulatingTagAnnotations(ds3Element.ds3Annotations).capitalize()
             val childType = NormalizingContractNamesUtil.removePath(ds3Element.componentType)
+
+            // Handle if the slice is common prefixes
+            if (encapsulatingTag == "CommonPrefixes") {
+                return ParseChildNodeAsCommonPrefix(modelName, paramName)
+
+            }
             return ParseChildNodeAsSlice(encapsulatingTag, xmlTag, modelName, paramName, childType)
         }
 

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/models/parser/ParseChildNodeImpls.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/models/parser/ParseChildNodeImpls.kt
@@ -138,3 +138,17 @@ data class ParseChildNodeAsNullableEnum(
     override val parsingCode: String
         get() { return "parseNullableEnum(child.Content, $modelName.$paramName, aggErr)" }
 }
+
+data class ParseChildNodeAsCommonPrefix(
+        val modelName: String,
+        val paramName: String) : ParseElement {
+
+    override val xmlTag: String = "CommonPrefixes"
+
+    override val parsingCode: String
+        get() {
+            return "var prefixes []string\n" +
+                    goIndent(3) + "prefixes = parseStringSlice(\"Prefix\", child.Children, aggErr)\n" +
+                    goIndent(3) +"$modelName.$paramName = append($modelName.$paramName, prefixes...)"
+        }
+}

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTypeTests.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTypeTests.java
@@ -253,4 +253,49 @@ public class GoFunctionalTypeTests {
         assertTrue(typeParserCode.contains("model.parse(&child, aggErr)"));
         assertTrue(typeParserCode.contains("jobList.Jobs = append(jobList.Jobs, model)"));
     }
+
+    @Test
+    public void listBucketResultTest() throws IOException, TemplateModelException {
+        final String typeName = "ListBucketResult";
+        final FileUtils fileUtils = mock(FileUtils.class);
+        final GoTestCodeUtil codeGenerator = new GoTestCodeUtil(fileUtils, requestName, typeName);
+
+        codeGenerator.generateCode(fileUtils, "/input/listBucketResult.xml");
+
+        // Verify response payload type file was generated
+        final String typeCode = codeGenerator.getTypeCode();
+        CODE_LOGGER.logFile(typeCode, FileTypeToLog.MODEL);
+        assertTrue(hasContent(typeCode));
+
+        assertTrue(typeCode.contains("CommonPrefixes []string"));
+        assertTrue(typeCode.contains("CreationDate *string"));
+        assertTrue(typeCode.contains("Delimiter *string"));
+        assertTrue(typeCode.contains("Marker *string"));
+        assertTrue(typeCode.contains("MaxKeys int"));
+        assertTrue(typeCode.contains("Name *string"));
+        assertTrue(typeCode.contains("NextMarker *string"));
+        assertTrue(typeCode.contains("Objects []Contents"));
+        assertTrue(typeCode.contains("Prefix *string"));
+        assertTrue(typeCode.contains("Truncated bool"));
+
+        // Verify type parser file was generated
+        final String typeParserCode = codeGenerator.getTypeParserCode();
+        CODE_LOGGER.logFile(typeParserCode, FileTypeToLog.MODEL_PARSERS);
+        assertTrue(hasContent(typeParserCode));
+
+        assertTrue(typeParserCode.contains("case \"CommonPrefixes\":"));
+        assertTrue(typeParserCode.contains("var prefixes []string"));
+        assertTrue(typeParserCode.contains("prefixes = parseStringSlice(\"Prefix\", child.Children, aggErr)"));
+        assertTrue(typeParserCode.contains("listBucketResult.CommonPrefixes = append(listBucketResult.CommonPrefixes, prefixes...)"));
+
+        assertTrue(typeParserCode.contains("listBucketResult.CreationDate = parseNullableString(child.Content)"));
+        assertTrue(typeParserCode.contains("listBucketResult.Delimiter = parseNullableString(child.Content)"));
+        assertTrue(typeParserCode.contains("listBucketResult.Marker = parseNullableString(child.Content)"));
+        assertTrue(typeParserCode.contains("listBucketResult.MaxKeys = parseInt(child.Content, aggErr)"));
+        assertTrue(typeParserCode.contains("listBucketResult.Name = parseNullableString(child.Content)"));
+        assertTrue(typeParserCode.contains("listBucketResult.NextMarker = parseNullableString(child.Content)"));
+        assertTrue(typeParserCode.contains("listBucketResult.Objects = append(listBucketResult.Objects, model)"));
+        assertTrue(typeParserCode.contains("listBucketResult.Prefix = parseNullableString(child.Content)"));
+        assertTrue(typeParserCode.contains("listBucketResult.Truncated = parseBool(child.Content, aggErr)"));
+    }
 }

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/parser/BaseTypeParserGenerator_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/parser/BaseTypeParserGenerator_Test.java
@@ -189,7 +189,8 @@ public class BaseTypeParserGenerator_Test {
                 ENUM_PTR_ELEMENT,
                 LIST_WITH_ENCAPS_TAG_ELEMENT,
                 DS3_TYPE_ELEMENT,
-                LIST_ENUM_ELEMENT);
+                LIST_ENUM_ELEMENT,
+                COMMON_PREFIX_ELEMENT);
 
         final String modelName = "modelName";
 
@@ -202,7 +203,8 @@ public class BaseTypeParserGenerator_Test {
                 new ParseChildNodeAsNullableEnum(ENUM_PTR_ELEMENT.getName(), modelName, ENUM_PTR_ELEMENT.getName()),
                 new ParseChildNodeAsSlice("TestCollectionValue", "CustomMarshaledName", modelName, LIST_WITH_ENCAPS_TAG_ELEMENT.getName(), removePath(LIST_WITH_ENCAPS_TAG_ELEMENT.getComponentType())),
                 new ParseChildNodeAsDs3Type(DS3_TYPE_ELEMENT.getName(), modelName, DS3_TYPE_ELEMENT.getName()),
-                new ParseChildNodeAddEnumToSlice(LIST_ENUM_ELEMENT.getName(), modelName, LIST_ENUM_ELEMENT.getName(), removePath(LIST_ENUM_ELEMENT.getComponentType())));
+                new ParseChildNodeAddEnumToSlice(LIST_ENUM_ELEMENT.getName(), modelName, LIST_ENUM_ELEMENT.getName(), removePath(LIST_ENUM_ELEMENT.getComponentType())),
+                new ParseChildNodeAsCommonPrefix(modelName, "CommonPrefixes"));
 
         final ImmutableMap<String, Ds3Type> typeMape = ImmutableMap.of(
                 ENUM_ELEMENT.getType(), new Ds3Type(ENUM_ELEMENT.getType(), "", ImmutableList.of(), ImmutableList.of(ENUM_CONSTANT)));

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/models/parser/ParseChildNodeImpls_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/models/parser/ParseChildNodeImpls_Test.java
@@ -19,6 +19,7 @@ import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 public class ParseChildNodeImpls_Test {
 
@@ -102,6 +103,17 @@ public class ParseChildNodeImpls_Test {
 
         final ParseElement parseElement = new ParseChildNodeAsNullableEnum(XML_TAG, MODEL_NAME, PARAM_NAME);
         assertThat(parseElement.getXmlTag(), is(XML_TAG));
+        assertThat(parseElement.getParsingCode(), is(expected));
+    }
+
+    @Test
+    public void ParseChildNodeAsCommonPrefixTest() {
+        final String expected = String.format("var prefixes []string\n" +
+                "            prefixes = parseStringSlice(\"Prefix\", child.Children, aggErr)\n" +
+                "            %s.%s = append(%s.%s, prefixes...)", MODEL_NAME, PARAM_NAME, MODEL_NAME, PARAM_NAME);
+
+        final ParseElement parseElement = new ParseChildNodeAsCommonPrefix(MODEL_NAME, PARAM_NAME);
+        assertThat(parseElement.getXmlTag(), is("CommonPrefixes"));
         assertThat(parseElement.getParsingCode(), is(expected));
     }
 }

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/utils/GoModelFixturesUtil.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/utils/GoModelFixturesUtil.java
@@ -36,6 +36,16 @@ public class GoModelFixturesUtil {
                             "com.spectralogic.util.marshal.CustomMarshaledName$CollectionNameRenderingMode"),
                     new Ds3AnnotationElement("Value", "CustomMarshaledName", "java.lang.String")));
 
+    private final static Ds3Annotation COMMON_PREFIX_ANNOTATION = new Ds3Annotation(
+            "com.spectralogic.util.marshal.CustomMarshaledName",
+            ImmutableList.of(
+                    new Ds3AnnotationElement("CollectionValue", "CommonPrefixes", "java.lang.String"),
+                    new Ds3AnnotationElement(
+                            "CollectionValueRenderingMode",
+                            "BLOCK_FOR_EVERY_ELEMENT",
+                            "com.spectralogic.util.marshal.CustomMarshaledName$CollectionNameRenderingMode"),
+                    new Ds3AnnotationElement("Value", "Prefix", "java.lang.String")));
+
     private final static Ds3Annotation ATTR_ANNOTATION = new Ds3Annotation("com.spectralogic.util.marshal.MarshalXmlAsAttribute", null);
 
     public final static Ds3Element STR_ELEMENT = new Ds3Element("StringElement", "java.lang.String", "", false);
@@ -47,6 +57,7 @@ public class GoModelFixturesUtil {
     public final static Ds3Element LIST_WITH_ENCAPS_TAG_ELEMENT = new Ds3Element("ElementListWithEncpsTag", "array", "com.test.TestType", ImmutableList.of(CUSTOM_MARSHALED_NAME), false);
     public final static Ds3Element DS3_TYPE_ELEMENT = new Ds3Element("Ds3TypeElement", "com.test.TestDs3Type", "", false);
     public final static Ds3Element LIST_ENUM_ELEMENT = new Ds3Element("ListEnumElement", "array", "com.test.TestEnum", false);
+    public final static Ds3Element COMMON_PREFIX_ELEMENT = new Ds3Element("CommonPrefixes", "array", "java.lang.String", ImmutableList.of(COMMON_PREFIX_ANNOTATION), false);
 
     public final static Ds3Element STR_ATTR = new Ds3Element("StringAttribute", "java.lang.String", "", ImmutableList.of(ATTR_ANNOTATION), false);
     public final static Ds3Element STR_PTR_ATTR = new Ds3Element("StringPtrAttribute", "java.lang.String", "", ImmutableList.of(ATTR_ANNOTATION), true);

--- a/ds3-autogen-go/src/test/resources/input/listBucketResult.xml
+++ b/ds3-autogen-go/src/test/resources/input/listBucketResult.xml
@@ -1,0 +1,99 @@
+<Data>
+    <Contract>
+        <RequestHandlers>
+            <RequestHandler Classification="amazons3" Name="com.spectralogic.s3.server.handler.reqhandler.PlaceHolderRequestHandler">
+                <Request BucketRequirement="REQUIRED" HttpVerb="DELETE" ObjectRequirement="REQUIRED">
+                    <OptionalQueryParams/>
+                    <RequiredQueryParams>
+                        <Param Name="Placeholder" Type="com.spectralogic.s3.server.domain.BucketObjectsApiBean"/>
+                    </RequiredQueryParams>
+                </Request>
+                <ResponseCodes>
+                    <ResponseCode>
+                        <Code>204</Code>
+                        <ResponseTypes>
+                            <ResponseType Type="null"/>
+                        </ResponseTypes>
+                    </ResponseCode>
+                </ResponseCodes>
+                <Version>1.D14152B32BAE4D9F43B0E7DFE275A88E</Version>
+            </RequestHandler>
+        </RequestHandlers>
+        <Types>
+            <Type Name="com.spectralogic.s3.server.domain.BucketObjectsApiBean" NameToMarshal="ListBucketResult">
+                <Elements>
+                    <Element ComponentType="java.lang.String" Name="CommonPrefixes" Type="array">
+                        <Annotations>
+                            <Annotation Name="com.spectralogic.util.marshal.CustomMarshaledName">
+                                <AnnotationElements>
+                                    <AnnotationElement Name="CollectionValue" Value="CommonPrefixes" ValueType="java.lang.String"/>
+                                    <AnnotationElement Name="CollectionValueRenderingMode" Value="BLOCK_FOR_EVERY_ELEMENT" ValueType="com.spectralogic.util.marshal.CustomMarshaledName$CollectionNameRenderingMode"/>
+                                    <AnnotationElement Name="Value" Value="Prefix" ValueType="java.lang.String"/>
+                                </AnnotationElements>
+                            </Annotation>
+                        </Annotations>
+                    </Element>
+                    <Element Name="CreationDate" Type="java.util.Date">
+                        <Annotations>
+                            <Annotation Name="com.spectralogic.util.bean.lang.Optional">
+                                <AnnotationElements/>
+                            </Annotation>
+                        </Annotations>
+                    </Element>
+                    <Element Name="Delimiter" Type="java.lang.String">
+                        <Annotations>
+                            <Annotation Name="com.spectralogic.util.bean.lang.Optional">
+                                <AnnotationElements/>
+                            </Annotation>
+                        </Annotations>
+                    </Element>
+                    <Element Name="Marker" Type="java.lang.String">
+                        <Annotations>
+                            <Annotation Name="com.spectralogic.util.bean.lang.Optional">
+                                <AnnotationElements/>
+                            </Annotation>
+                        </Annotations>
+                    </Element>
+                    <Element Name="MaxKeys" Type="int">
+                        <Annotations/>
+                    </Element>
+                    <Element Name="Name" Type="java.lang.String">
+                        <Annotations/>
+                    </Element>
+                    <Element Name="NextMarker" Type="java.lang.String">
+                        <Annotations/>
+                    </Element>
+                    <Element ComponentType="com.spectralogic.s3.server.domain.S3ObjectApiBean" Name="Objects" Type="array">
+                        <Annotations>
+                            <Annotation Name="com.spectralogic.util.marshal.CustomMarshaledName">
+                                <AnnotationElements>
+                                    <AnnotationElement Name="CollectionValue" Value="" ValueType="java.lang.String"/>
+                                    <AnnotationElement Name="CollectionValueRenderingMode" Value="UNDEFINED" ValueType="com.spectralogic.util.marshal.CustomMarshaledName$CollectionNameRenderingMode"/>
+                                    <AnnotationElement Name="Value" Value="Contents" ValueType="java.lang.String"/>
+                                </AnnotationElements>
+                            </Annotation>
+                        </Annotations>
+                    </Element>
+                    <Element Name="Prefix" Type="java.lang.String">
+                        <Annotations>
+                            <Annotation Name="com.spectralogic.util.bean.lang.Optional">
+                                <AnnotationElements/>
+                            </Annotation>
+                        </Annotations>
+                    </Element>
+                    <Element Name="Truncated" Type="boolean">
+                        <Annotations>
+                            <Annotation Name="com.spectralogic.util.marshal.CustomMarshaledName">
+                                <AnnotationElements>
+                                    <AnnotationElement Name="CollectionValue" Value="" ValueType="java.lang.String"/>
+                                    <AnnotationElement Name="CollectionValueRenderingMode" Value="UNDEFINED" ValueType="com.spectralogic.util.marshal.CustomMarshaledName$CollectionNameRenderingMode"/>
+                                    <AnnotationElement Name="Value" Value="IsTruncated" ValueType="java.lang.String"/>
+                                </AnnotationElements>
+                            </Annotation>
+                        </Annotations>
+                    </Element>
+                </Elements>
+            </Type>
+        </Types>
+    </Contract>
+</Data>


### PR DESCRIPTION
**Changes**
- Special cased the parsing code for the CommonPrefixes Ds3Element
- Added unit and functional tests

Generated code was merged to Go SDK in PR: https://github.com/SpectraLogic/ds3_go_sdk/pull/27