### PR TITLE
SA-193: Added util for determining Ids request payload and special cased in Java module

### DIFF
--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/JavaCodeGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/JavaCodeGenerator.java
@@ -507,7 +507,10 @@ public class JavaCodeGenerator implements CodeGenerator {
     /**
      * Retrieves the associated request generator for the specified Ds3Request
      */
-    protected static RequestModelGenerator<?> getRequestGenerator(final Ds3Request ds3Request) {
+    static RequestModelGenerator<?> getRequestGenerator(final Ds3Request ds3Request) {
+        if (hasIdsRequestPayload(ds3Request)) {
+            return new IdsRequestPayloadGenerator();
+        }
         if (hasStringRequestPayload(ds3Request)) {
             return new StringRequestPayloadGenerator();
         }
@@ -551,25 +554,38 @@ public class JavaCodeGenerator implements CodeGenerator {
     private Template getRequestTemplate(final Ds3Request ds3Request) throws IOException {
         if (isBulkRequest(ds3Request)) {
             return config.getTemplate("request/bulk_request_template.ftl");
-        } else if(hasStringRequestPayload(ds3Request)) {
+        }
+        if (hasIdsRequestPayload(ds3Request)) {
+            return config.getTemplate("request/ids_request_payload_template.ftl");
+        }
+        if (hasStringRequestPayload(ds3Request)) {
             return config.getTemplate("request/request_with_string_payload_template.ftl");
-        } else if (hasListObjectsRequestPayload(ds3Request)) {
+        }
+        if (hasListObjectsRequestPayload(ds3Request)) {
             return config.getTemplate("request/objects_request_payload_request_template.ftl");
-        } else if (isMultiFileDeleteRequest(ds3Request)) {
+        }
+        if (isMultiFileDeleteRequest(ds3Request)) {
             return config.getTemplate("request/multi_file_delete_request_template.ftl");
-        } else if (isGetObjectRequest(ds3Request)) {
+        }
+        if (isGetObjectRequest(ds3Request)) {
             return config.getTemplate("request/get_object_template.ftl");
-        } else if (isCreateObjectRequest(ds3Request)) {
+        }
+        if (isCreateObjectRequest(ds3Request)) {
             return config.getTemplate("request/create_object_template.ftl");
-        } else if (isDeleteNotificationRequest(ds3Request)) {
+        }
+        if (isDeleteNotificationRequest(ds3Request)) {
             return config.getTemplate("request/delete_notification_request_template.ftl");
-        } else if (isCreateNotificationRequest(ds3Request)) {
+        }
+        if (isCreateNotificationRequest(ds3Request)) {
             return config.getTemplate("request/create_notification_request_template.ftl");
-        } else if (isGetNotificationRequest(ds3Request) && ds3Request.getIncludeInPath()) {
+        }
+        if (isGetNotificationRequest(ds3Request) && ds3Request.getIncludeInPath()) {
             return config.getTemplate("request/get_notification_request_template.ftl");
-        } else if (isGetJobRequest(ds3Request)) {
+        }
+        if (isGetJobRequest(ds3Request)) {
             return config.getTemplate("request/get_job_request_template.ftl");
-        } else if (isCompleteMultiPartUploadRequest(ds3Request)) {
+        }
+        if (isCompleteMultiPartUploadRequest(ds3Request)) {
             return config.getTemplate("request/complete_multipart_upload_template.ftl");
         }
         return config.getTemplate("request/request_template.ftl");

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/requestmodels/IdsRequestPayloadGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/requestmodels/IdsRequestPayloadGenerator.java
@@ -1,0 +1,38 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.java.generators.requestmodels;
+
+import com.spectralogic.ds3autogen.api.models.apispec.Ds3Request;
+
+/**
+ * Generator for Java Request handlers that have a request payload of format
+ * <Ids><Id>id1</Id><Id>id2</Id>...</Ids>
+ *
+ * These requests extend the AbstractIdsPayloadRequest
+ */
+public class IdsRequestPayloadGenerator extends BaseRequestGenerator {
+
+    private final static String ABSTRACT_IDS_PAYLOAD_REQUEST = "com.spectralogic.ds3client.commands.interfaces.AbstractIdsPayloadRequest";
+
+    /**
+     * Returns the import for the parent class for the create notification request,
+     * which is AbstractIdsPayloadRequest
+     */
+    @Override
+    public String getParentImport(final Ds3Request ds3Request) {
+        return ABSTRACT_IDS_PAYLOAD_REQUEST;
+    }
+}

--- a/ds3-autogen-java/src/main/resources/tmpls/java/request/ids_request_payload_template.ftl
+++ b/ds3-autogen-java/src/main/resources/tmpls/java/request/ids_request_payload_template.ftl
@@ -1,0 +1,35 @@
+<#include "../copyright.ftl"/>
+
+package ${packageName};
+
+import com.spectralogic.ds3client.networking.HttpVerb;
+<#include "../imports.ftl"/>
+
+import java.util.List;
+
+public class ${name} extends ${parentClass} {
+
+    // Variables
+    <#include "common/variables.ftl"/>
+
+    // Constructor
+    <#list constructors as constructor>
+    ${constructor.documentation}
+    public ${name}(final List<String> ids) {
+        super(ids);
+        <#list constructor.getAssignments() as arg>
+        this.${arg.getName()?uncap_first} = ${javaHelper.paramAssignmentRHS(arg)};
+        </#list>
+<#include "common/add_query_params.ftl"/>
+        <#list constructor.getAdditionalLines() as line>
+        ${line}
+        </#list>
+    }
+    </#list>
+
+    <#include "common/with_constructors.ftl"/>
+
+    <#include "common/getters_verb_path.ftl"/>
+
+    <#include "common/getters.ftl"/>
+}

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaCodeGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaCodeGenerator_Test.java
@@ -20,9 +20,7 @@ import com.spectralogic.ds3autogen.java.generators.responsemodels.*;
 import com.spectralogic.ds3autogen.java.generators.responseparser.*;
 import org.junit.Test;
 
-import static com.spectralogic.ds3autogen.java.JavaCodeGenerator.getResponseParserGenerator;
-import static com.spectralogic.ds3autogen.java.JavaCodeGenerator.getResponseGenerator;
-import static com.spectralogic.ds3autogen.java.JavaCodeGenerator.getRequestGenerator;
+import static com.spectralogic.ds3autogen.java.JavaCodeGenerator.*;
 import static com.spectralogic.ds3autogen.testutil.Ds3ModelFixtures.*;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertThat;
@@ -54,6 +52,16 @@ public class JavaCodeGenerator_Test {
 
     @Test
     public void getRequestGenerator_Test() {
+        assertThat(getRequestGenerator(clearSuspectBlobAzureTargetsRequest()), instanceOf(IdsRequestPayloadGenerator.class));
+        assertThat(getRequestGenerator(clearSuspectBlobPoolsRequest()), instanceOf(IdsRequestPayloadGenerator.class));
+        assertThat(getRequestGenerator(clearSuspectBlobS3TargetsRequest()), instanceOf(IdsRequestPayloadGenerator.class));
+        assertThat(getRequestGenerator(clearSuspectBlobTapesRequest()), instanceOf(IdsRequestPayloadGenerator.class));
+        assertThat(getRequestGenerator(markSuspectBlobAzureTargetsAsDegradedRequest()), instanceOf(IdsRequestPayloadGenerator.class));
+        assertThat(getRequestGenerator(markSuspectBlobDs3TargetsAsDegradedRequest()), instanceOf(IdsRequestPayloadGenerator.class));
+        assertThat(getRequestGenerator(markSuspectBlobPoolsAsDegradedRequest()), instanceOf(IdsRequestPayloadGenerator.class));
+        assertThat(getRequestGenerator(markSuspectBlobS3TargetsAsDegradedRequest()), instanceOf(IdsRequestPayloadGenerator.class));
+        assertThat(getRequestGenerator(markSuspectBlobTapesAsDegradedRequest()), instanceOf(IdsRequestPayloadGenerator.class));
+
         assertThat(getRequestGenerator(getGetBlobPersistence()), instanceOf(StringRequestPayloadGenerator.class));
         assertThat(getRequestGenerator(getRequestBulkPut()), instanceOf(BulkRequestGenerator.class));
         assertThat(getRequestGenerator(getRequestBulkGet()), instanceOf(BulkRequestGenerator.class));

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaFunctionalTests.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaFunctionalTests.java
@@ -2564,6 +2564,54 @@ public class JavaFunctionalTests {
     }
 
     @Test
+    public void clearSuspectBlobAzureTargetsSpectraS3Request_Test() throws IOException, TemplateModelException {
+        final String requestName = "ClearSuspectBlobAzureTargetsSpectraS3Request";
+        final FileUtils fileUtils = mock(FileUtils.class);
+        final TestGeneratedCode testGeneratedCode = new TestGeneratedCode(
+                fileUtils,
+                requestName,
+                "./ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/");
+
+        testGeneratedCode.generateCode(fileUtils, "/input/clearSuspectBlobAzureTargetsSpectraS3Request.xml");
+
+        final String requestGeneratedCode = testGeneratedCode.getRequestGeneratedCode();
+        CODE_LOGGER.logFile(requestGeneratedCode, FileTypeToLog.REQUEST);
+
+        assertTrue(extendsClass(requestName, "AbstractIdsPayloadRequest", requestGeneratedCode));
+        assertTrue(isOfPackage("com.spectralogic.ds3client.commands.spectrads3", requestGeneratedCode));
+
+        assertTrue(hasImport("com.spectralogic.ds3client.networking.HttpVerb", requestGeneratedCode));
+        assertTrue(hasImport("com.spectralogic.ds3client.commands.interfaces.AbstractIdsPayloadRequest", requestGeneratedCode));
+        assertTrue(hasImport("java.util.List", requestGeneratedCode));
+
+        assertTrue(hasCopyright(requestGeneratedCode));
+        assertTrue(isReqParamOfType("ids", "List<String>", requestName, requestGeneratedCode, true));
+        assertTrue(isOptParamOfType("force", "boolean", requestName, requestGeneratedCode, false));
+
+        //Test the generated response
+        final String responseGeneratedCode = testGeneratedCode.getResponseGeneratedCode();
+        CODE_LOGGER.logFile(responseGeneratedCode, FileTypeToLog.RESPONSE);
+        assertFalse(responseGeneratedCode.isEmpty());
+
+        //Test the Ds3Client
+        final String ds3ClientGeneratedCode = testGeneratedCode.getDs3ClientGeneratedCode();
+        CODE_LOGGER.logFile(ds3ClientGeneratedCode, FileTypeToLog.CLIENT);
+        testDs3Client(requestName, ds3ClientGeneratedCode);
+
+        assertTrue(ds3ClientGeneratedCode.contains("@Action(\"BULK_DELETE\")"));
+        assertTrue(ds3ClientGeneratedCode.contains("@Resource(\"SUSPECT_BLOB_AZURE_TARGET\")"));
+
+        final String ds3ClientImplGeneratedCode = testGeneratedCode.getDs3ClientImplGeneratedCode();
+        CODE_LOGGER.logFile(ds3ClientImplGeneratedCode, FileTypeToLog.CLIENT);
+        testDs3ClientImpl(requestName, ds3ClientImplGeneratedCode);
+
+        //Test the response parser
+        final String responseParserCode = testGeneratedCode.getResponseParserGeneratedCode();
+        CODE_LOGGER.logFile(responseParserCode, FileTypeToLog.PARSER);
+        assertFalse(responseParserCode.isEmpty());
+    }
+
+    @Test
     public void wholeXmlDoc() throws IOException, TemplateModelException {
         final FileUtils fileUtils = new TestFileUtilsImpl();
         final Ds3SpecParser parser = new Ds3SpecParserImpl();

--- a/ds3-autogen-java/src/test/resources/input/clearSuspectBlobAzureTargetsSpectraS3Request.xml
+++ b/ds3-autogen-java/src/test/resources/input/clearSuspectBlobAzureTargetsSpectraS3Request.xml
@@ -1,0 +1,35 @@
+<Data>
+    <Contract>
+        <RequestHandlers>
+            <RequestHandler Classification="spectrads3" Name="com.spectralogic.s3.server.handler.reqhandler.spectrads3.degradation.ClearSuspectBlobAzureTargetsRequestHandler">
+                <Request Action="BULK_DELETE" HttpVerb="DELETE" IncludeIdInPath="false" Resource="SUSPECT_BLOB_AZURE_TARGET" ResourceType="NON_SINGLETON">
+                    <OptionalQueryParams>
+                        <Param Name="Force" Type="void"/>
+                    </OptionalQueryParams>
+                    <RequiredQueryParams/>
+                </Request>
+                <ResponseCodes>
+                    <ResponseCode>
+                        <Code>204</Code>
+                        <ResponseTypes>
+                            <ResponseType Type="null"/>
+                        </ResponseTypes>
+                    </ResponseCode>
+                    <ResponseCode>
+                        <Code>400</Code>
+                        <ResponseTypes>
+                            <ResponseType Type="com.spectralogic.s3.server.domain.HttpErrorResultApiBean"/>
+                        </ResponseTypes>
+                    </ResponseCode>
+                    <ResponseCode>
+                        <Code>409</Code>
+                        <ResponseTypes>
+                            <ResponseType Type="com.spectralogic.s3.server.domain.HttpErrorResultApiBean"/>
+                        </ResponseTypes>
+                    </ResponseCode>
+                </ResponseCodes>
+                <Version>1.F51C99474F629A2CFD5CDB6BC5CB7C6D</Version>
+            </RequestHandler>
+        </RequestHandlers>
+    </Contract>
+</Data>

--- a/ds3-autogen-test-util/src/main/java/com/spectralogic/ds3autogen/testutil/Ds3ModelFixtures.java
+++ b/ds3-autogen-test-util/src/main/java/com/spectralogic/ds3autogen/testutil/Ds3ModelFixtures.java
@@ -28,6 +28,8 @@ import com.spectralogic.ds3autogen.api.models.enums.*;
  */
 public class Ds3ModelFixtures {
 
+    private static final Ds3Param FORCE_PARAM = new Ds3Param("Force", "void", false);
+
     /**
      * Creates a populated list of Ds3ResponseTypes with the ability to set a variation to append
      * to type and component type names to ensure name uniqueness.
@@ -755,8 +757,7 @@ public class Ds3ModelFixtures {
                 null, // operation
                 true,// includeIdInPath
                 null, // ds3ResponseCodes
-                ImmutableList.of(
-                        new Ds3Param("Force", "void", false)), // optional query params
+                ImmutableList.of(FORCE_PARAM), // optional query params
                 ImmutableList.of()); // required query params
     }
 
@@ -930,6 +931,195 @@ public class Ds3ModelFixtures {
                 ImmutableList.of(
                         new Ds3Param("FullDetails", "void", false),
                         new Ds3Param("Operation", "com.spectralogic.s3.server.request.rest.RestOperationType", false)) //required params
+        );
+    }
+
+    /**
+     * Retrieves the 4.0.0 contract request for ClearSuspectBlobAzureTargetsRequestHandler
+     */
+    public static Ds3Request clearSuspectBlobAzureTargetsRequest() {
+        return new Ds3Request(
+                "com.spectralogic.s3.server.handler.reqhandler.spectrads3.degradation.ClearSuspectBlobAzureTargetsRequestHandler",
+                HttpVerb.DELETE,
+                Classification.spectrads3,
+                null,
+                null,
+                Action.BULK_DELETE,
+                Resource.SUSPECT_BLOB_AZURE_TARGET,
+                ResourceType.NON_SINGLETON,
+                null,
+                false,
+                null, // ds3ResponseCodes are in the Contract, but are currently omitted
+                ImmutableList.of(FORCE_PARAM), //optional params
+                ImmutableList.of() //required params
+        );
+    }
+
+    /**
+     * Retrieves the 4.0.0 contract request for ClearSuspectBlobPoolsRequestHandler
+     */
+    public static Ds3Request clearSuspectBlobPoolsRequest() {
+        return new Ds3Request(
+                "com.spectralogic.s3.server.handler.reqhandler.spectrads3.degradation.ClearSuspectBlobPoolsRequestHandler",
+                HttpVerb.DELETE,
+                Classification.spectrads3,
+                null,
+                null,
+                Action.BULK_DELETE,
+                Resource.SUSPECT_BLOB_POOL,
+                ResourceType.NON_SINGLETON,
+                null,
+                false,
+                null, // ds3ResponseCodes are in the Contract, but are currently omitted
+                ImmutableList.of(FORCE_PARAM), //optional params
+                ImmutableList.of() //required params
+        );
+    }
+
+    /**
+     * Retrieves the 4.0.0 contract request for ClearSuspectBlobS3TargetsRequestHandler
+     */
+    public static Ds3Request clearSuspectBlobS3TargetsRequest() {
+        return new Ds3Request(
+                "com.spectralogic.s3.server.handler.reqhandler.spectrads3.degradation.ClearSuspectBlobS3TargetsRequestHandler",
+                HttpVerb.DELETE,
+                Classification.spectrads3,
+                null,
+                null,
+                Action.BULK_DELETE,
+                Resource.SUSPECT_BLOB_S3_TARGET,
+                ResourceType.NON_SINGLETON,
+                null,
+                false,
+                null, // ds3ResponseCodes are in the Contract, but are currently omitted
+                ImmutableList.of(FORCE_PARAM), //optional params
+                ImmutableList.of() //required params
+        );
+    }
+
+    /**
+     * Retrieves the 4.0.0 contract request for ClearSuspectBlobTapesRequestHandler
+     */
+    public static Ds3Request clearSuspectBlobTapesRequest() {
+        return new Ds3Request(
+                "com.spectralogic.s3.server.handler.reqhandler.spectrads3.degradation.ClearSuspectBlobTapesRequestHandler",
+                HttpVerb.DELETE,
+                Classification.spectrads3,
+                null,
+                null,
+                Action.BULK_DELETE,
+                Resource.SUSPECT_BLOB_TAPE,
+                ResourceType.NON_SINGLETON,
+                null,
+                false,
+                null, // ds3ResponseCodes are in the Contract, but are currently omitted
+                ImmutableList.of(FORCE_PARAM), //optional params
+                ImmutableList.of() //required params
+        );
+    }
+
+    /**
+     * Retrieves the 4.0.0 contract request for MarkSuspectBlobAzureTargetsAsDegradedRequestHandler
+     */
+    public static Ds3Request markSuspectBlobAzureTargetsAsDegradedRequest() {
+        return new Ds3Request(
+                "com.spectralogic.s3.server.handler.reqhandler.spectrads3.degradation.MarkSuspectBlobAzureTargetsAsDegradedRequestHandler",
+                HttpVerb.PUT,
+                Classification.spectrads3,
+                null,
+                null,
+                Action.BULK_MODIFY,
+                Resource.SUSPECT_BLOB_AZURE_TARGET,
+                ResourceType.NON_SINGLETON,
+                null,
+                false,
+                null, // ds3ResponseCodes are in the Contract, but are currently omitted
+                ImmutableList.of(FORCE_PARAM), //optional params
+                ImmutableList.of() //required params
+        );
+    }
+
+    /**
+     * Retrieves the 4.0.0 contract request for MarkSuspectBlobDs3TargetsAsDegradedRequestHandler
+     */
+    public static Ds3Request markSuspectBlobDs3TargetsAsDegradedRequest() {
+        return new Ds3Request(
+                "com.spectralogic.s3.server.handler.reqhandler.spectrads3.degradation.MarkSuspectBlobDs3TargetsAsDegradedRequestHandler",
+                HttpVerb.PUT,
+                Classification.spectrads3,
+                null,
+                null,
+                Action.BULK_MODIFY,
+                Resource.SUSPECT_BLOB_DS3_TARGET,
+                ResourceType.NON_SINGLETON,
+                null,
+                false,
+                null, // ds3ResponseCodes are in the Contract, but are currently omitted
+                ImmutableList.of(FORCE_PARAM), //optional params
+                ImmutableList.of() //required params
+        );
+    }
+
+    /**
+     * Retrieves the 4.0.0 contract request for MarkSuspectBlobPoolsAsDegradedRequestHandler
+     */
+    public static Ds3Request markSuspectBlobPoolsAsDegradedRequest() {
+        return new Ds3Request(
+                "com.spectralogic.s3.server.handler.reqhandler.spectrads3.degradation.MarkSuspectBlobPoolsAsDegradedRequestHandler",
+                HttpVerb.PUT,
+                Classification.spectrads3,
+                null,
+                null,
+                Action.BULK_MODIFY,
+                Resource.SUSPECT_BLOB_POOL,
+                ResourceType.NON_SINGLETON,
+                null,
+                false,
+                null, // ds3ResponseCodes are in the Contract, but are currently omitted
+                ImmutableList.of(FORCE_PARAM), //optional params
+                ImmutableList.of() //required params
+        );
+    }
+
+    /**
+     * Retrieves the 4.0.0 contract request for MarkSuspectBlobS3TargetsAsDegradedRequestHandler
+     */
+    public static Ds3Request markSuspectBlobS3TargetsAsDegradedRequest() {
+        return new Ds3Request(
+                "com.spectralogic.s3.server.handler.reqhandler.spectrads3.degradation.MarkSuspectBlobS3TargetsAsDegradedRequestHandler",
+                HttpVerb.PUT,
+                Classification.spectrads3,
+                null,
+                null,
+                Action.BULK_MODIFY,
+                Resource.SUSPECT_BLOB_S3_TARGET,
+                ResourceType.NON_SINGLETON,
+                null,
+                false,
+                null, // ds3ResponseCodes are in the Contract, but are currently omitted
+                ImmutableList.of(FORCE_PARAM), //optional params
+                ImmutableList.of() //required params
+        );
+    }
+
+    /**
+     * Retrieves the 4.0.0 contract request for MarkSuspectBlobTapesAsDegradedRequestHandler
+     */
+    public static Ds3Request markSuspectBlobTapesAsDegradedRequest() {
+        return new Ds3Request(
+                "com.spectralogic.s3.server.handler.reqhandler.spectrads3.degradation.MarkSuspectBlobTapesAsDegradedRequestHandler",
+                HttpVerb.PUT,
+                Classification.spectrads3,
+                null,
+                null,
+                Action.BULK_MODIFY,
+                Resource.SUSPECT_BLOB_TAPE,
+                ResourceType.NON_SINGLETON,
+                null,
+                false,
+                null, // ds3ResponseCodes are in the Contract, but are currently omitted
+                ImmutableList.of(FORCE_PARAM), //optional params
+                ImmutableList.of() //required params
         );
     }
 }

--- a/ds3-autogen-utils/src/main/java/com/spectralogic/ds3autogen/utils/Ds3RequestClassificationUtil.java
+++ b/ds3-autogen-utils/src/main/java/com/spectralogic/ds3autogen/utils/Ds3RequestClassificationUtil.java
@@ -372,4 +372,138 @@ public final class Ds3RequestClassificationUtil {
                 && paramListContainsParam(request.getOptionalQueryParams(), "PageOffset", "int")
                 && paramListContainsParam(request.getOptionalQueryParams(), "PageStartMarker", "java.util.UUID");
     }
+
+    /**
+     * Determines if a Ds3Request has the payload: <Ids><id>id1</id><id>id2</id>...</Ids>
+     *
+     * @return true if request is one of the following:
+     *   com.spectralogic.s3.server.handler.reqhandler.spectrads3.degradation.ClearSuspectBlobAzureTargetsRequestHandler
+     *   com.spectralogic.s3.server.handler.reqhandler.spectrads3.degradation.ClearSuspectBlobPoolsRequestHandler
+     *   com.spectralogic.s3.server.handler.reqhandler.spectrads3.degradation.ClearSuspectBlobS3TargetsRequestHandler
+     *   com.spectralogic.s3.server.handler.reqhandler.spectrads3.degradation.ClearSuspectBlobTapesRequestHandler
+     *   com.spectralogic.s3.server.handler.reqhandler.spectrads3.degradation.MarkSuspectBlobAzureTargetsAsDegradedRequestHandler
+     *   com.spectralogic.s3.server.handler.reqhandler.spectrads3.degradation.MarkSuspectBlobDs3TargetsAsDegradedRequestHandler
+     *   com.spectralogic.s3.server.handler.reqhandler.spectrads3.degradation.MarkSuspectBlobPoolsAsDegradedRequestHandler
+     *   com.spectralogic.s3.server.handler.reqhandler.spectrads3.degradation.MarkSuspectBlobS3TargetsAsDegradedRequestHandler
+     *   com.spectralogic.s3.server.handler.reqhandler.spectrads3.degradation.MarkSuspectBlobTapesAsDegradedRequestHandler
+     */
+    public static boolean hasIdsRequestPayload(final Ds3Request ds3Request) {
+        return isClearSuspectBlobAzureTargetsRequest(ds3Request)
+                || isClearSuspectBlobPoolsRequest(ds3Request)
+                || isClearSuspectBlobS3TargetsRequest(ds3Request)
+                || isClearSuspectBlobTapesRequest(ds3Request)
+                || isMarkSuspectBlobAzureTargetsAsDegradedRequest(ds3Request)
+                || isMarkSuspectBlobDs3TargetsAsDegradedRequest(ds3Request)
+                || isMarkSuspectBlobPoolsAsDegradedRequest(ds3Request)
+                || isMarkSuspectBlobS3TargetsAsDegradedRequest(ds3Request)
+                || isMarkSuspectBlobTapesAsDegradedRequest(ds3Request);
+    }
+
+    /**
+     * Determines if a Ds3Request is the SpectraDs3 command ClearSuspectBlobAzureTargetsRequestHandler
+     */
+    static boolean isClearSuspectBlobAzureTargetsRequest(final Ds3Request ds3Request) {
+        return ds3Request.getClassification() == Classification.spectrads3
+                && ds3Request.getAction() == Action.BULK_DELETE
+                && ds3Request.getHttpVerb() == HttpVerb.DELETE
+                && !ds3Request.getIncludeInPath()
+                && ds3Request.getResource() == Resource.SUSPECT_BLOB_AZURE_TARGET
+                && ds3Request.getResourceType() == ResourceType.NON_SINGLETON;
+    }
+
+    /**
+     * Determines if a Ds3Request is the SpectraDs3 command ClearSuspectBlobPoolsRequestHandler
+     */
+    static boolean isClearSuspectBlobPoolsRequest(final Ds3Request ds3Request) {
+        return ds3Request.getClassification() == Classification.spectrads3
+                && ds3Request.getAction() == Action.BULK_DELETE
+                && ds3Request.getHttpVerb() == HttpVerb.DELETE
+                && !ds3Request.getIncludeInPath()
+                && ds3Request.getResource() == Resource.SUSPECT_BLOB_POOL
+                && ds3Request.getResourceType() == ResourceType.NON_SINGLETON;
+    }
+
+    /**
+     * Determines if a Ds3Request is the SpectraDs3 command ClearSuspectBlobS3TargetsRequestHandler
+     */
+    static boolean isClearSuspectBlobS3TargetsRequest(final Ds3Request ds3Request) {
+        return ds3Request.getClassification() == Classification.spectrads3
+                && ds3Request.getAction() == Action.BULK_DELETE
+                && ds3Request.getHttpVerb() == HttpVerb.DELETE
+                && !ds3Request.getIncludeInPath()
+                && ds3Request.getResource() == Resource.SUSPECT_BLOB_S3_TARGET
+                && ds3Request.getResourceType() == ResourceType.NON_SINGLETON;
+    }
+
+    /**
+     * Determines if a Ds3Request is the SpectraDs3 command ClearSuspectBlobTapesRequestHandler
+     */
+    static boolean isClearSuspectBlobTapesRequest(final Ds3Request ds3Request) {
+        return ds3Request.getClassification() == Classification.spectrads3
+                && ds3Request.getAction() == Action.BULK_DELETE
+                && ds3Request.getHttpVerb() == HttpVerb.DELETE
+                && !ds3Request.getIncludeInPath()
+                && ds3Request.getResource() == Resource.SUSPECT_BLOB_TAPE
+                && ds3Request.getResourceType() == ResourceType.NON_SINGLETON;
+    }
+
+    /**
+     * Determines if a Ds3Request is the SpectraDs3 command MarkSuspectBlobAzureTargetsAsDegradedRequestHandler
+     */
+    static boolean isMarkSuspectBlobAzureTargetsAsDegradedRequest(final Ds3Request ds3Request) {
+        return ds3Request.getClassification() == Classification.spectrads3
+                && ds3Request.getAction() == Action.BULK_MODIFY
+                && ds3Request.getHttpVerb() == HttpVerb.PUT
+                && !ds3Request.getIncludeInPath()
+                && ds3Request.getResource() == Resource.SUSPECT_BLOB_AZURE_TARGET
+                && ds3Request.getResourceType() == ResourceType.NON_SINGLETON;
+    }
+
+    /**
+     * Determines if a Ds3Request is the SpectraDs3 command MarkSuspectBlobDs3TargetsAsDegradedRequestHandler
+     */
+    static boolean isMarkSuspectBlobDs3TargetsAsDegradedRequest(final Ds3Request ds3Request) {
+        return ds3Request.getClassification() == Classification.spectrads3
+                && ds3Request.getAction() == Action.BULK_MODIFY
+                && ds3Request.getHttpVerb() == HttpVerb.PUT
+                && !ds3Request.getIncludeInPath()
+                && ds3Request.getResource() == Resource.SUSPECT_BLOB_DS3_TARGET
+                && ds3Request.getResourceType() == ResourceType.NON_SINGLETON;
+    }
+
+    /**
+     * Determines if a Ds3Request is the SpectraDs3 command MarkSuspectBlobPoolsAsDegradedRequestHandler
+     */
+    static boolean isMarkSuspectBlobPoolsAsDegradedRequest(final Ds3Request ds3Request) {
+        return ds3Request.getClassification() == Classification.spectrads3
+                && ds3Request.getAction() == Action.BULK_MODIFY
+                && ds3Request.getHttpVerb() == HttpVerb.PUT
+                && !ds3Request.getIncludeInPath()
+                && ds3Request.getResource() == Resource.SUSPECT_BLOB_POOL
+                && ds3Request.getResourceType() == ResourceType.NON_SINGLETON;
+    }
+
+    /**
+     * Determines if a Ds3Request is the SpectraDs3 command MarkSuspectBlobS3TargetsAsDegradedRequestHandler
+     */
+    static boolean isMarkSuspectBlobS3TargetsAsDegradedRequest(final Ds3Request ds3Request) {
+        return ds3Request.getClassification() == Classification.spectrads3
+                && ds3Request.getAction() == Action.BULK_MODIFY
+                && ds3Request.getHttpVerb() == HttpVerb.PUT
+                && !ds3Request.getIncludeInPath()
+                && ds3Request.getResource() == Resource.SUSPECT_BLOB_S3_TARGET
+                && ds3Request.getResourceType() == ResourceType.NON_SINGLETON;
+    }
+
+    /**
+     * Determines if a Ds3Request is the SpectraDs3 command MarkSuspectBlobTapesAsDegradedRequestHandler
+     */
+    static boolean isMarkSuspectBlobTapesAsDegradedRequest(final Ds3Request ds3Request) {
+        return ds3Request.getClassification() == Classification.spectrads3
+                && ds3Request.getAction() == Action.BULK_MODIFY
+                && ds3Request.getHttpVerb() == HttpVerb.PUT
+                && !ds3Request.getIncludeInPath()
+                && ds3Request.getResource() == Resource.SUSPECT_BLOB_TAPE
+                && ds3Request.getResourceType() == ResourceType.NON_SINGLETON;
+    }
 }

--- a/ds3-autogen-utils/src/test/java/com/spectralogic/ds3autogen/utils/Ds3RequestClassificationUtil_Test.java
+++ b/ds3-autogen-utils/src/test/java/com/spectralogic/ds3autogen/utils/Ds3RequestClassificationUtil_Test.java
@@ -574,4 +574,293 @@ public class Ds3RequestClassificationUtil_Test {
         assertFalse(isGetObjectsWithFullDetails(getRequestSpectraS3GetObject()));
         assertFalse(isGetObjectsWithFullDetails(getObjectsDetailsRequest()));
     }
+
+    @Test
+    public void isClearSuspectBlobAzureTargetsRequest_Test() {
+        assertTrue(isClearSuspectBlobAzureTargetsRequest(clearSuspectBlobAzureTargetsRequest()));
+
+        assertFalse(isClearSuspectBlobAzureTargetsRequest(clearSuspectBlobPoolsRequest()));
+        assertFalse(isClearSuspectBlobAzureTargetsRequest(clearSuspectBlobS3TargetsRequest()));
+        assertFalse(isClearSuspectBlobAzureTargetsRequest(clearSuspectBlobTapesRequest()));
+        assertFalse(isClearSuspectBlobAzureTargetsRequest(markSuspectBlobAzureTargetsAsDegradedRequest()));
+        assertFalse(isClearSuspectBlobAzureTargetsRequest(markSuspectBlobDs3TargetsAsDegradedRequest()));
+        assertFalse(isClearSuspectBlobAzureTargetsRequest(markSuspectBlobPoolsAsDegradedRequest()));
+        assertFalse(isClearSuspectBlobAzureTargetsRequest(markSuspectBlobS3TargetsAsDegradedRequest()));
+        assertFalse(isClearSuspectBlobAzureTargetsRequest(markSuspectBlobTapesAsDegradedRequest()));
+
+        assertFalse(isClearSuspectBlobAzureTargetsRequest(getObjectsWithFullDetailsRequest()));
+        assertFalse(isClearSuspectBlobAzureTargetsRequest(getCompleteMultipartUploadRequest()));
+        assertFalse(isClearSuspectBlobAzureTargetsRequest(getCreateMultiPartUploadPart()));
+        assertFalse(isClearSuspectBlobAzureTargetsRequest(getRequestGetJob()));
+        assertFalse(isClearSuspectBlobAzureTargetsRequest(getRequestAmazonS3GetObject()));
+        assertFalse(isClearSuspectBlobAzureTargetsRequest(getRequestDeleteNotification()));
+        assertFalse(isClearSuspectBlobAzureTargetsRequest(getRequestCreateNotification()));
+        assertFalse(isClearSuspectBlobAzureTargetsRequest(getRequestGetNotification()));
+        assertFalse(isClearSuspectBlobAzureTargetsRequest(getRequestVerifyPhysicalPlacement()));
+        assertFalse(isClearSuspectBlobAzureTargetsRequest(getRequestBulkGet()));
+        assertFalse(isClearSuspectBlobAzureTargetsRequest(getRequestMultiFileDelete()));
+        assertFalse(isClearSuspectBlobAzureTargetsRequest(getRequestCreateObject()));
+        assertFalse(isClearSuspectBlobAzureTargetsRequest(getRequestSpectraS3GetObject()));
+        assertFalse(isClearSuspectBlobAzureTargetsRequest(getObjectsDetailsRequest()));
+    }
+
+    @Test
+    public void isClearSuspectBlobPoolsRequest_Test() {
+        assertTrue(isClearSuspectBlobPoolsRequest(clearSuspectBlobPoolsRequest()));
+
+        assertFalse(isClearSuspectBlobPoolsRequest(clearSuspectBlobAzureTargetsRequest()));
+        assertFalse(isClearSuspectBlobPoolsRequest(clearSuspectBlobS3TargetsRequest()));
+        assertFalse(isClearSuspectBlobPoolsRequest(clearSuspectBlobTapesRequest()));
+        assertFalse(isClearSuspectBlobPoolsRequest(markSuspectBlobAzureTargetsAsDegradedRequest()));
+        assertFalse(isClearSuspectBlobPoolsRequest(markSuspectBlobDs3TargetsAsDegradedRequest()));
+        assertFalse(isClearSuspectBlobPoolsRequest(markSuspectBlobPoolsAsDegradedRequest()));
+        assertFalse(isClearSuspectBlobPoolsRequest(markSuspectBlobS3TargetsAsDegradedRequest()));
+        assertFalse(isClearSuspectBlobPoolsRequest(markSuspectBlobTapesAsDegradedRequest()));
+
+        assertFalse(isClearSuspectBlobPoolsRequest(getObjectsWithFullDetailsRequest()));
+        assertFalse(isClearSuspectBlobPoolsRequest(getCompleteMultipartUploadRequest()));
+        assertFalse(isClearSuspectBlobPoolsRequest(getCreateMultiPartUploadPart()));
+        assertFalse(isClearSuspectBlobPoolsRequest(getRequestGetJob()));
+        assertFalse(isClearSuspectBlobPoolsRequest(getRequestAmazonS3GetObject()));
+        assertFalse(isClearSuspectBlobPoolsRequest(getRequestDeleteNotification()));
+        assertFalse(isClearSuspectBlobPoolsRequest(getRequestCreateNotification()));
+        assertFalse(isClearSuspectBlobPoolsRequest(getRequestGetNotification()));
+        assertFalse(isClearSuspectBlobPoolsRequest(getRequestVerifyPhysicalPlacement()));
+        assertFalse(isClearSuspectBlobPoolsRequest(getRequestBulkGet()));
+        assertFalse(isClearSuspectBlobPoolsRequest(getRequestMultiFileDelete()));
+        assertFalse(isClearSuspectBlobPoolsRequest(getRequestCreateObject()));
+        assertFalse(isClearSuspectBlobPoolsRequest(getRequestSpectraS3GetObject()));
+        assertFalse(isClearSuspectBlobPoolsRequest(getObjectsDetailsRequest()));
+    }
+
+    @Test
+    public void isClearSuspectBlobS3TargetsRequest_Test() {
+        assertTrue(isClearSuspectBlobS3TargetsRequest(clearSuspectBlobS3TargetsRequest()));
+
+        assertFalse(isClearSuspectBlobS3TargetsRequest(clearSuspectBlobAzureTargetsRequest()));
+        assertFalse(isClearSuspectBlobS3TargetsRequest(clearSuspectBlobPoolsRequest()));
+        assertFalse(isClearSuspectBlobS3TargetsRequest(clearSuspectBlobTapesRequest()));
+        assertFalse(isClearSuspectBlobS3TargetsRequest(markSuspectBlobAzureTargetsAsDegradedRequest()));
+        assertFalse(isClearSuspectBlobS3TargetsRequest(markSuspectBlobDs3TargetsAsDegradedRequest()));
+        assertFalse(isClearSuspectBlobS3TargetsRequest(markSuspectBlobPoolsAsDegradedRequest()));
+        assertFalse(isClearSuspectBlobS3TargetsRequest(markSuspectBlobS3TargetsAsDegradedRequest()));
+        assertFalse(isClearSuspectBlobS3TargetsRequest(markSuspectBlobTapesAsDegradedRequest()));
+
+        assertFalse(isClearSuspectBlobS3TargetsRequest(getObjectsWithFullDetailsRequest()));
+        assertFalse(isClearSuspectBlobS3TargetsRequest(getCompleteMultipartUploadRequest()));
+        assertFalse(isClearSuspectBlobS3TargetsRequest(getCreateMultiPartUploadPart()));
+        assertFalse(isClearSuspectBlobS3TargetsRequest(getRequestGetJob()));
+        assertFalse(isClearSuspectBlobS3TargetsRequest(getRequestAmazonS3GetObject()));
+        assertFalse(isClearSuspectBlobS3TargetsRequest(getRequestDeleteNotification()));
+        assertFalse(isClearSuspectBlobS3TargetsRequest(getRequestCreateNotification()));
+        assertFalse(isClearSuspectBlobS3TargetsRequest(getRequestGetNotification()));
+        assertFalse(isClearSuspectBlobS3TargetsRequest(getRequestVerifyPhysicalPlacement()));
+        assertFalse(isClearSuspectBlobS3TargetsRequest(getRequestBulkGet()));
+        assertFalse(isClearSuspectBlobS3TargetsRequest(getRequestMultiFileDelete()));
+        assertFalse(isClearSuspectBlobS3TargetsRequest(getRequestCreateObject()));
+        assertFalse(isClearSuspectBlobS3TargetsRequest(getRequestSpectraS3GetObject()));
+        assertFalse(isClearSuspectBlobS3TargetsRequest(getObjectsDetailsRequest()));
+    }
+
+    @Test
+    public void isClearSuspectBlobTapesRequest_Test() {
+        assertTrue(isClearSuspectBlobTapesRequest(clearSuspectBlobTapesRequest()));
+
+        assertFalse(isClearSuspectBlobTapesRequest(clearSuspectBlobAzureTargetsRequest()));
+        assertFalse(isClearSuspectBlobTapesRequest(clearSuspectBlobPoolsRequest()));
+        assertFalse(isClearSuspectBlobTapesRequest(clearSuspectBlobS3TargetsRequest()));
+        assertFalse(isClearSuspectBlobTapesRequest(markSuspectBlobAzureTargetsAsDegradedRequest()));
+        assertFalse(isClearSuspectBlobTapesRequest(markSuspectBlobDs3TargetsAsDegradedRequest()));
+        assertFalse(isClearSuspectBlobTapesRequest(markSuspectBlobPoolsAsDegradedRequest()));
+        assertFalse(isClearSuspectBlobTapesRequest(markSuspectBlobS3TargetsAsDegradedRequest()));
+        assertFalse(isClearSuspectBlobTapesRequest(markSuspectBlobTapesAsDegradedRequest()));
+
+        assertFalse(isClearSuspectBlobTapesRequest(getObjectsWithFullDetailsRequest()));
+        assertFalse(isClearSuspectBlobTapesRequest(getCompleteMultipartUploadRequest()));
+        assertFalse(isClearSuspectBlobTapesRequest(getCreateMultiPartUploadPart()));
+        assertFalse(isClearSuspectBlobTapesRequest(getRequestGetJob()));
+        assertFalse(isClearSuspectBlobTapesRequest(getRequestAmazonS3GetObject()));
+        assertFalse(isClearSuspectBlobTapesRequest(getRequestDeleteNotification()));
+        assertFalse(isClearSuspectBlobTapesRequest(getRequestCreateNotification()));
+        assertFalse(isClearSuspectBlobTapesRequest(getRequestGetNotification()));
+        assertFalse(isClearSuspectBlobTapesRequest(getRequestVerifyPhysicalPlacement()));
+        assertFalse(isClearSuspectBlobTapesRequest(getRequestBulkGet()));
+        assertFalse(isClearSuspectBlobTapesRequest(getRequestMultiFileDelete()));
+        assertFalse(isClearSuspectBlobTapesRequest(getRequestCreateObject()));
+        assertFalse(isClearSuspectBlobTapesRequest(getRequestSpectraS3GetObject()));
+        assertFalse(isClearSuspectBlobTapesRequest(getObjectsDetailsRequest()));
+    }
+
+    @Test
+    public void isMarkSuspectBlobAzureTargetsAsDegradedRequest_Test() {
+        assertTrue(isMarkSuspectBlobAzureTargetsAsDegradedRequest(markSuspectBlobAzureTargetsAsDegradedRequest()));
+
+        assertFalse(isMarkSuspectBlobAzureTargetsAsDegradedRequest(clearSuspectBlobAzureTargetsRequest()));
+        assertFalse(isMarkSuspectBlobAzureTargetsAsDegradedRequest(clearSuspectBlobPoolsRequest()));
+        assertFalse(isMarkSuspectBlobAzureTargetsAsDegradedRequest(clearSuspectBlobS3TargetsRequest()));
+        assertFalse(isMarkSuspectBlobAzureTargetsAsDegradedRequest(clearSuspectBlobTapesRequest()));
+        assertFalse(isMarkSuspectBlobAzureTargetsAsDegradedRequest(markSuspectBlobDs3TargetsAsDegradedRequest()));
+        assertFalse(isMarkSuspectBlobAzureTargetsAsDegradedRequest(markSuspectBlobPoolsAsDegradedRequest()));
+        assertFalse(isMarkSuspectBlobAzureTargetsAsDegradedRequest(markSuspectBlobS3TargetsAsDegradedRequest()));
+        assertFalse(isMarkSuspectBlobAzureTargetsAsDegradedRequest(markSuspectBlobTapesAsDegradedRequest()));
+
+        assertFalse(isMarkSuspectBlobAzureTargetsAsDegradedRequest(getObjectsWithFullDetailsRequest()));
+        assertFalse(isMarkSuspectBlobAzureTargetsAsDegradedRequest(getCompleteMultipartUploadRequest()));
+        assertFalse(isMarkSuspectBlobAzureTargetsAsDegradedRequest(getCreateMultiPartUploadPart()));
+        assertFalse(isMarkSuspectBlobAzureTargetsAsDegradedRequest(getRequestGetJob()));
+        assertFalse(isMarkSuspectBlobAzureTargetsAsDegradedRequest(getRequestAmazonS3GetObject()));
+        assertFalse(isMarkSuspectBlobAzureTargetsAsDegradedRequest(getRequestDeleteNotification()));
+        assertFalse(isMarkSuspectBlobAzureTargetsAsDegradedRequest(getRequestCreateNotification()));
+        assertFalse(isMarkSuspectBlobAzureTargetsAsDegradedRequest(getRequestGetNotification()));
+        assertFalse(isMarkSuspectBlobAzureTargetsAsDegradedRequest(getRequestVerifyPhysicalPlacement()));
+        assertFalse(isMarkSuspectBlobAzureTargetsAsDegradedRequest(getRequestBulkGet()));
+        assertFalse(isMarkSuspectBlobAzureTargetsAsDegradedRequest(getRequestMultiFileDelete()));
+        assertFalse(isMarkSuspectBlobAzureTargetsAsDegradedRequest(getRequestCreateObject()));
+        assertFalse(isMarkSuspectBlobAzureTargetsAsDegradedRequest(getRequestSpectraS3GetObject()));
+        assertFalse(isMarkSuspectBlobAzureTargetsAsDegradedRequest(getObjectsDetailsRequest()));
+    }
+
+    @Test
+    public void isMarkSuspectBlobDs3TargetsAsDegradedRequest_Test() {
+        assertTrue(isMarkSuspectBlobDs3TargetsAsDegradedRequest(markSuspectBlobDs3TargetsAsDegradedRequest()));
+
+        assertFalse(isMarkSuspectBlobDs3TargetsAsDegradedRequest(clearSuspectBlobAzureTargetsRequest()));
+        assertFalse(isMarkSuspectBlobDs3TargetsAsDegradedRequest(clearSuspectBlobPoolsRequest()));
+        assertFalse(isMarkSuspectBlobDs3TargetsAsDegradedRequest(clearSuspectBlobS3TargetsRequest()));
+        assertFalse(isMarkSuspectBlobDs3TargetsAsDegradedRequest(clearSuspectBlobTapesRequest()));
+        assertFalse(isMarkSuspectBlobDs3TargetsAsDegradedRequest(markSuspectBlobAzureTargetsAsDegradedRequest()));
+        assertFalse(isMarkSuspectBlobDs3TargetsAsDegradedRequest(markSuspectBlobPoolsAsDegradedRequest()));
+        assertFalse(isMarkSuspectBlobDs3TargetsAsDegradedRequest(markSuspectBlobS3TargetsAsDegradedRequest()));
+        assertFalse(isMarkSuspectBlobDs3TargetsAsDegradedRequest(markSuspectBlobTapesAsDegradedRequest()));
+
+        assertFalse(isMarkSuspectBlobDs3TargetsAsDegradedRequest(getObjectsWithFullDetailsRequest()));
+        assertFalse(isMarkSuspectBlobDs3TargetsAsDegradedRequest(getCompleteMultipartUploadRequest()));
+        assertFalse(isMarkSuspectBlobDs3TargetsAsDegradedRequest(getCreateMultiPartUploadPart()));
+        assertFalse(isMarkSuspectBlobDs3TargetsAsDegradedRequest(getRequestGetJob()));
+        assertFalse(isMarkSuspectBlobDs3TargetsAsDegradedRequest(getRequestAmazonS3GetObject()));
+        assertFalse(isMarkSuspectBlobDs3TargetsAsDegradedRequest(getRequestDeleteNotification()));
+        assertFalse(isMarkSuspectBlobDs3TargetsAsDegradedRequest(getRequestCreateNotification()));
+        assertFalse(isMarkSuspectBlobDs3TargetsAsDegradedRequest(getRequestGetNotification()));
+        assertFalse(isMarkSuspectBlobDs3TargetsAsDegradedRequest(getRequestVerifyPhysicalPlacement()));
+        assertFalse(isMarkSuspectBlobDs3TargetsAsDegradedRequest(getRequestBulkGet()));
+        assertFalse(isMarkSuspectBlobDs3TargetsAsDegradedRequest(getRequestMultiFileDelete()));
+        assertFalse(isMarkSuspectBlobDs3TargetsAsDegradedRequest(getRequestCreateObject()));
+        assertFalse(isMarkSuspectBlobDs3TargetsAsDegradedRequest(getRequestSpectraS3GetObject()));
+        assertFalse(isMarkSuspectBlobDs3TargetsAsDegradedRequest(getObjectsDetailsRequest()));
+    }
+
+    @Test
+    public void isMarkSuspectBlobPoolsAsDegradedRequest_Test() {
+        assertTrue(isMarkSuspectBlobPoolsAsDegradedRequest(markSuspectBlobPoolsAsDegradedRequest()));
+
+        assertFalse(isMarkSuspectBlobPoolsAsDegradedRequest(clearSuspectBlobAzureTargetsRequest()));
+        assertFalse(isMarkSuspectBlobPoolsAsDegradedRequest(clearSuspectBlobPoolsRequest()));
+        assertFalse(isMarkSuspectBlobPoolsAsDegradedRequest(clearSuspectBlobS3TargetsRequest()));
+        assertFalse(isMarkSuspectBlobPoolsAsDegradedRequest(clearSuspectBlobTapesRequest()));
+        assertFalse(isMarkSuspectBlobPoolsAsDegradedRequest(markSuspectBlobAzureTargetsAsDegradedRequest()));
+        assertFalse(isMarkSuspectBlobPoolsAsDegradedRequest(markSuspectBlobDs3TargetsAsDegradedRequest()));
+        assertFalse(isMarkSuspectBlobPoolsAsDegradedRequest(markSuspectBlobS3TargetsAsDegradedRequest()));
+        assertFalse(isMarkSuspectBlobPoolsAsDegradedRequest(markSuspectBlobTapesAsDegradedRequest()));
+
+        assertFalse(isMarkSuspectBlobPoolsAsDegradedRequest(getObjectsWithFullDetailsRequest()));
+        assertFalse(isMarkSuspectBlobPoolsAsDegradedRequest(getCompleteMultipartUploadRequest()));
+        assertFalse(isMarkSuspectBlobPoolsAsDegradedRequest(getCreateMultiPartUploadPart()));
+        assertFalse(isMarkSuspectBlobPoolsAsDegradedRequest(getRequestGetJob()));
+        assertFalse(isMarkSuspectBlobPoolsAsDegradedRequest(getRequestAmazonS3GetObject()));
+        assertFalse(isMarkSuspectBlobPoolsAsDegradedRequest(getRequestDeleteNotification()));
+        assertFalse(isMarkSuspectBlobPoolsAsDegradedRequest(getRequestCreateNotification()));
+        assertFalse(isMarkSuspectBlobPoolsAsDegradedRequest(getRequestGetNotification()));
+        assertFalse(isMarkSuspectBlobPoolsAsDegradedRequest(getRequestVerifyPhysicalPlacement()));
+        assertFalse(isMarkSuspectBlobPoolsAsDegradedRequest(getRequestBulkGet()));
+        assertFalse(isMarkSuspectBlobPoolsAsDegradedRequest(getRequestMultiFileDelete()));
+        assertFalse(isMarkSuspectBlobPoolsAsDegradedRequest(getRequestCreateObject()));
+        assertFalse(isMarkSuspectBlobPoolsAsDegradedRequest(getRequestSpectraS3GetObject()));
+        assertFalse(isMarkSuspectBlobPoolsAsDegradedRequest(getObjectsDetailsRequest()));
+    }
+
+    @Test
+    public void isMarkSuspectBlobS3TargetsAsDegradedRequest_Test() {
+        assertTrue(isMarkSuspectBlobS3TargetsAsDegradedRequest(markSuspectBlobS3TargetsAsDegradedRequest()));
+
+        assertFalse(isMarkSuspectBlobS3TargetsAsDegradedRequest(clearSuspectBlobAzureTargetsRequest()));
+        assertFalse(isMarkSuspectBlobS3TargetsAsDegradedRequest(clearSuspectBlobPoolsRequest()));
+        assertFalse(isMarkSuspectBlobS3TargetsAsDegradedRequest(clearSuspectBlobS3TargetsRequest()));
+        assertFalse(isMarkSuspectBlobS3TargetsAsDegradedRequest(clearSuspectBlobTapesRequest()));
+        assertFalse(isMarkSuspectBlobS3TargetsAsDegradedRequest(markSuspectBlobAzureTargetsAsDegradedRequest()));
+        assertFalse(isMarkSuspectBlobS3TargetsAsDegradedRequest(markSuspectBlobDs3TargetsAsDegradedRequest()));
+        assertFalse(isMarkSuspectBlobS3TargetsAsDegradedRequest(markSuspectBlobPoolsAsDegradedRequest()));
+        assertFalse(isMarkSuspectBlobS3TargetsAsDegradedRequest(markSuspectBlobTapesAsDegradedRequest()));
+
+        assertFalse(isMarkSuspectBlobS3TargetsAsDegradedRequest(getObjectsWithFullDetailsRequest()));
+        assertFalse(isMarkSuspectBlobS3TargetsAsDegradedRequest(getCompleteMultipartUploadRequest()));
+        assertFalse(isMarkSuspectBlobS3TargetsAsDegradedRequest(getCreateMultiPartUploadPart()));
+        assertFalse(isMarkSuspectBlobS3TargetsAsDegradedRequest(getRequestGetJob()));
+        assertFalse(isMarkSuspectBlobS3TargetsAsDegradedRequest(getRequestAmazonS3GetObject()));
+        assertFalse(isMarkSuspectBlobS3TargetsAsDegradedRequest(getRequestDeleteNotification()));
+        assertFalse(isMarkSuspectBlobS3TargetsAsDegradedRequest(getRequestCreateNotification()));
+        assertFalse(isMarkSuspectBlobS3TargetsAsDegradedRequest(getRequestGetNotification()));
+        assertFalse(isMarkSuspectBlobS3TargetsAsDegradedRequest(getRequestVerifyPhysicalPlacement()));
+        assertFalse(isMarkSuspectBlobS3TargetsAsDegradedRequest(getRequestBulkGet()));
+        assertFalse(isMarkSuspectBlobS3TargetsAsDegradedRequest(getRequestMultiFileDelete()));
+        assertFalse(isMarkSuspectBlobS3TargetsAsDegradedRequest(getRequestCreateObject()));
+        assertFalse(isMarkSuspectBlobS3TargetsAsDegradedRequest(getRequestSpectraS3GetObject()));
+        assertFalse(isMarkSuspectBlobS3TargetsAsDegradedRequest(getObjectsDetailsRequest()));
+    }
+
+    @Test
+    public void isMarkSuspectBlobTapesAsDegradedRequest_Test() {
+        assertTrue(isMarkSuspectBlobTapesAsDegradedRequest(markSuspectBlobTapesAsDegradedRequest()));
+
+        assertFalse(isMarkSuspectBlobTapesAsDegradedRequest(clearSuspectBlobAzureTargetsRequest()));
+        assertFalse(isMarkSuspectBlobTapesAsDegradedRequest(clearSuspectBlobPoolsRequest()));
+        assertFalse(isMarkSuspectBlobTapesAsDegradedRequest(clearSuspectBlobS3TargetsRequest()));
+        assertFalse(isMarkSuspectBlobTapesAsDegradedRequest(clearSuspectBlobTapesRequest()));
+        assertFalse(isMarkSuspectBlobTapesAsDegradedRequest(markSuspectBlobAzureTargetsAsDegradedRequest()));
+        assertFalse(isMarkSuspectBlobTapesAsDegradedRequest(markSuspectBlobDs3TargetsAsDegradedRequest()));
+        assertFalse(isMarkSuspectBlobTapesAsDegradedRequest(markSuspectBlobPoolsAsDegradedRequest()));
+        assertFalse(isMarkSuspectBlobTapesAsDegradedRequest(markSuspectBlobS3TargetsAsDegradedRequest()));
+
+        assertFalse(isMarkSuspectBlobTapesAsDegradedRequest(getObjectsWithFullDetailsRequest()));
+        assertFalse(isMarkSuspectBlobTapesAsDegradedRequest(getCompleteMultipartUploadRequest()));
+        assertFalse(isMarkSuspectBlobTapesAsDegradedRequest(getCreateMultiPartUploadPart()));
+        assertFalse(isMarkSuspectBlobTapesAsDegradedRequest(getRequestGetJob()));
+        assertFalse(isMarkSuspectBlobTapesAsDegradedRequest(getRequestAmazonS3GetObject()));
+        assertFalse(isMarkSuspectBlobTapesAsDegradedRequest(getRequestDeleteNotification()));
+        assertFalse(isMarkSuspectBlobTapesAsDegradedRequest(getRequestCreateNotification()));
+        assertFalse(isMarkSuspectBlobTapesAsDegradedRequest(getRequestGetNotification()));
+        assertFalse(isMarkSuspectBlobTapesAsDegradedRequest(getRequestVerifyPhysicalPlacement()));
+        assertFalse(isMarkSuspectBlobTapesAsDegradedRequest(getRequestBulkGet()));
+        assertFalse(isMarkSuspectBlobTapesAsDegradedRequest(getRequestMultiFileDelete()));
+        assertFalse(isMarkSuspectBlobTapesAsDegradedRequest(getRequestCreateObject()));
+        assertFalse(isMarkSuspectBlobTapesAsDegradedRequest(getRequestSpectraS3GetObject()));
+        assertFalse(isMarkSuspectBlobTapesAsDegradedRequest(getObjectsDetailsRequest()));
+    }
+
+    @Test
+    public void hasIdsRequestPayload_Test() {
+        assertTrue(hasIdsRequestPayload(clearSuspectBlobAzureTargetsRequest()));
+        assertTrue(hasIdsRequestPayload(clearSuspectBlobPoolsRequest()));
+        assertTrue(hasIdsRequestPayload(clearSuspectBlobS3TargetsRequest()));
+        assertTrue(hasIdsRequestPayload(clearSuspectBlobTapesRequest()));
+        assertTrue(hasIdsRequestPayload(markSuspectBlobAzureTargetsAsDegradedRequest()));
+        assertTrue(hasIdsRequestPayload(markSuspectBlobDs3TargetsAsDegradedRequest()));
+        assertTrue(hasIdsRequestPayload(markSuspectBlobPoolsAsDegradedRequest()));
+        assertTrue(hasIdsRequestPayload(markSuspectBlobS3TargetsAsDegradedRequest()));
+        assertTrue(hasIdsRequestPayload(markSuspectBlobTapesAsDegradedRequest()));
+
+        assertFalse(hasIdsRequestPayload(getObjectsWithFullDetailsRequest()));
+        assertFalse(hasIdsRequestPayload(getCompleteMultipartUploadRequest()));
+        assertFalse(hasIdsRequestPayload(getCreateMultiPartUploadPart()));
+        assertFalse(hasIdsRequestPayload(getRequestGetJob()));
+        assertFalse(hasIdsRequestPayload(getRequestAmazonS3GetObject()));
+        assertFalse(hasIdsRequestPayload(getRequestDeleteNotification()));
+        assertFalse(hasIdsRequestPayload(getRequestCreateNotification()));
+        assertFalse(hasIdsRequestPayload(getRequestGetNotification()));
+        assertFalse(hasIdsRequestPayload(getRequestVerifyPhysicalPlacement()));
+        assertFalse(hasIdsRequestPayload(getRequestBulkGet()));
+        assertFalse(hasIdsRequestPayload(getRequestMultiFileDelete()));
+        assertFalse(hasIdsRequestPayload(getRequestCreateObject()));
+        assertFalse(hasIdsRequestPayload(getRequestSpectraS3GetObject()));
+        assertFalse(hasIdsRequestPayload(getObjectsDetailsRequest()));
+    }
 }


### PR DESCRIPTION
**Changes**
- Added util `hasIdsRequestPayload` to determine if a Ds3Request accepts a payload of Ids
- Special cased Ds3Requests in the Java module for taking in the ids request payload
  - Generated code can be found in https://github.com/SpectraLogic/ds3_java_sdk/pull/489