### PR TITLE
SA-192: Special cased requests with payload ids in Go module

### DIFF
--- a/ds3-autogen-go/src/main/java/com/spectralogic/ds3autogen/go/GoCodeGenerator.java
+++ b/ds3-autogen-go/src/main/java/com/spectralogic/ds3autogen/go/GoCodeGenerator.java
@@ -150,6 +150,9 @@ public class GoCodeGenerator implements CodeGenerator {
         if (isBulkRequest(ds3Request) || isPhysicalPlacementRequest(ds3Request) || isEjectStorageDomainBlobsRequest(ds3Request)) {
             return new RequiredObjectsPayloadGenerator();
         }
+        if (hasIdsRequestPayload(ds3Request)) {
+            return new IdsPayloadRequestGenerator();
+        }
         if (hasStringRequestPayload(ds3Request)) {
             return new StringRequestPayloadGenerator();
         }
@@ -178,7 +181,8 @@ public class GoCodeGenerator implements CodeGenerator {
                 || isEjectStorageDomainBlobsRequest(ds3Request)
                 || hasStringRequestPayload(ds3Request)
                 || isCompleteMultiPartUploadRequest(ds3Request)
-                || isMultiFileDeleteRequest(ds3Request)) {
+                || isMultiFileDeleteRequest(ds3Request)
+                || hasIdsRequestPayload(ds3Request)) {
             return config.getTemplate("request/request_with_stream.ftl");
         }
         return config.getTemplate("request/request_template.ftl");

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/request/IdsPayloadRequestGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/request/IdsPayloadRequestGenerator.kt
@@ -1,0 +1,36 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.go.generators.request
+
+import com.spectralogic.ds3autogen.api.models.Arguments
+import com.spectralogic.ds3autogen.go.models.request.Variable
+
+class IdsPayloadRequestGenerator : RequestPayloadGenerator() {
+
+    /**
+     * Retrieves the ids request payload
+     */
+    override fun getPayloadConstructorArg(): Arguments {
+        return Arguments("[]string", "ids")
+    }
+
+    /**
+     * Retrieves the struct assignment for the ids request payload
+     */
+    override fun getStructAssignmentVariable(): Variable {
+        return Variable("content", "buildIdListPayload(ids)")
+    }
+}

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoCodeGenerator_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoCodeGenerator_Test.java
@@ -66,6 +66,17 @@ public class GoCodeGenerator_Test {
         // Request with CompleteMultipartUpload request payload
         assertThat(getRequestGenerator(getCompleteMultipartUploadRequest()), instanceOf(PartsRequestPayloadGenerator.class));
 
+        // Requests with ids payload
+        assertThat(getRequestGenerator(clearSuspectBlobAzureTargetsRequest()), instanceOf(IdsPayloadRequestGenerator.class));
+        assertThat(getRequestGenerator(clearSuspectBlobPoolsRequest()), instanceOf(IdsPayloadRequestGenerator.class));
+        assertThat(getRequestGenerator(clearSuspectBlobS3TargetsRequest()), instanceOf(IdsPayloadRequestGenerator.class));
+        assertThat(getRequestGenerator(clearSuspectBlobTapesRequest()), instanceOf(IdsPayloadRequestGenerator.class));
+        assertThat(getRequestGenerator(markSuspectBlobAzureTargetsAsDegradedRequest()), instanceOf(IdsPayloadRequestGenerator.class));
+        assertThat(getRequestGenerator(markSuspectBlobDs3TargetsAsDegradedRequest()), instanceOf(IdsPayloadRequestGenerator.class));
+        assertThat(getRequestGenerator(markSuspectBlobPoolsAsDegradedRequest()), instanceOf(IdsPayloadRequestGenerator.class));
+        assertThat(getRequestGenerator(markSuspectBlobS3TargetsAsDegradedRequest()), instanceOf(IdsPayloadRequestGenerator.class));
+        assertThat(getRequestGenerator(markSuspectBlobTapesAsDegradedRequest()), instanceOf(IdsPayloadRequestGenerator.class));
+
         // Non-special cased requests
         assertThat(getRequestGenerator(getGetBlobPersistence()), instanceOf(BaseRequestGenerator.class));
         assertThat(getRequestGenerator(getRequestBulkPut()), instanceOf(BaseRequestGenerator.class));

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTests.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTests.java
@@ -37,7 +37,7 @@ import static org.mockito.Mockito.mock;
 public class GoFunctionalTests {
 
     private final static Logger LOG = LoggerFactory.getLogger(GoFunctionalTests.class);
-    private final static GeneratedCodeLogger CODE_LOGGER = new GeneratedCodeLogger(FileTypeToLog.RESPONSE, LOG);
+    private final static GeneratedCodeLogger CODE_LOGGER = new GeneratedCodeLogger(FileTypeToLog.REQUEST, LOG);
 
     @Test
     public void simpleRequestNoPayload() throws IOException, TemplateModelException {
@@ -893,5 +893,53 @@ public class GoFunctionalTests {
         assertTrue(client.contains("func (client *Client) PutObject(request *models.PutObjectRequest) (*models.PutObjectResponse, error) {"));
         assertTrue(client.contains("networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.netLayer), client.clientPolicy.maxRetries)"));
         assertTrue(client.contains("response, requestErr := networkRetryDecorator.Invoke(request)"));
+    }
+
+    @Test
+    public void clearSuspectBlobAzureTargetsSpectraS3() throws IOException, TemplateModelException {
+        final String requestName = "ClearSuspectBlobAzureTargetsSpectraS3Request";
+        final FileUtils fileUtils = mock(FileUtils.class);
+        final GoTestCodeUtil codeGenerator = new GoTestCodeUtil(fileUtils, requestName);
+
+        codeGenerator.generateCode(fileUtils, "/input/clearSuspectBlobAzureTargetsSpectraS3.xml");
+
+        // Verify Request file was generated
+        final String requestCode = codeGenerator.getRequestCode();
+        CODE_LOGGER.logFile(requestCode, FileTypeToLog.REQUEST);
+        assertTrue(hasContent(requestCode));
+
+        assertTrue(requestCode.contains("\"net/url\""));
+        assertTrue(requestCode.contains("\"net/http\""));
+        assertTrue(requestCode.contains("\"ds3/networking\""));
+
+        assertTrue(requestCode.contains("type ClearSuspectBlobAzureTargetsSpectraS3Request struct {"));
+        assertTrue(requestCode.contains("content networking.ReaderWithSizeDecorator"));
+
+        assertTrue(requestCode.contains("func NewClearSuspectBlobAzureTargetsSpectraS3Request(ids []string) *ClearSuspectBlobAzureTargetsSpectraS3Request {"));
+        assertTrue(requestCode.contains("content: buildIdListPayload(ids),"));
+
+        assertTrue(requestCode.contains("func (clearSuspectBlobAzureTargetsSpectraS3Request *ClearSuspectBlobAzureTargetsSpectraS3Request) WithForce() *ClearSuspectBlobAzureTargetsSpectraS3Request {"));
+        assertTrue(requestCode.contains("clearSuspectBlobAzureTargetsSpectraS3Request.queryParams.Set(\"force\", \"\")"));
+
+        assertTrue(requestCode.contains("return networking.DELETE"));
+        assertTrue(requestCode.contains("return \"/_rest_/suspect_blob_azure_target\""));
+
+        assertTrue(requestCode.contains("func (clearSuspectBlobAzureTargetsSpectraS3Request *ClearSuspectBlobAzureTargetsSpectraS3Request) GetContentStream() networking.ReaderWithSizeDecorator {"));
+        assertTrue(requestCode.contains("return clearSuspectBlobAzureTargetsSpectraS3Request.content"));
+
+        // Verify Response file was generated
+        final String responseCode = codeGenerator.getResponseCode();
+        CODE_LOGGER.logFile(responseCode, FileTypeToLog.RESPONSE);
+        assertTrue(hasContent(responseCode));
+
+        // Verify response payload type file was not generated
+        final String typeCode = codeGenerator.getTypeCode();
+        CODE_LOGGER.logFile(typeCode, FileTypeToLog.MODEL);
+        assertTrue(isEmpty(typeCode));
+
+        // Verify that the client code was generated
+        final String client = codeGenerator.getClientCode(HttpVerb.GET);
+        CODE_LOGGER.logFile(client, FileTypeToLog.CLIENT);
+        assertTrue(hasContent(client));
     }
 }

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/request/IdsPayloadRequestGenerator_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/request/IdsPayloadRequestGenerator_Test.java
@@ -1,0 +1,42 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.go.generators.request;
+
+import com.spectralogic.ds3autogen.api.models.Arguments;
+import com.spectralogic.ds3autogen.go.models.request.Variable;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class IdsPayloadRequestGenerator_Test {
+
+    private final IdsPayloadRequestGenerator generator = new IdsPayloadRequestGenerator();
+
+    @Test
+    public void getPayloadConstructorArgTest() {
+        final Arguments result = generator.getPayloadConstructorArg();
+        assertThat(result.getName(), is("ids"));
+        assertThat(result.getType(), is("[]string"));
+    }
+
+    @Test
+    public void getStructAssignmentVariableTest() {
+        final Variable result = generator.getStructAssignmentVariable();
+        assertThat(result.getName(), is("content"));
+        assertThat(result.getAssignment(), is("buildIdListPayload(ids)"));
+    }
+}

--- a/ds3-autogen-go/src/test/resources/input/clearSuspectBlobAzureTargetsSpectraS3.xml
+++ b/ds3-autogen-go/src/test/resources/input/clearSuspectBlobAzureTargetsSpectraS3.xml
@@ -1,0 +1,35 @@
+<Data>
+    <Contract>
+        <RequestHandlers>
+            <RequestHandler Classification="spectrads3" Name="com.spectralogic.s3.server.handler.reqhandler.spectrads3.degradation.ClearSuspectBlobAzureTargetsRequestHandler">
+                <Request Action="BULK_DELETE" HttpVerb="DELETE" IncludeIdInPath="false" Resource="SUSPECT_BLOB_AZURE_TARGET" ResourceType="NON_SINGLETON">
+                    <OptionalQueryParams>
+                        <Param Name="Force" Type="void"/>
+                    </OptionalQueryParams>
+                    <RequiredQueryParams/>
+                </Request>
+                <ResponseCodes>
+                    <ResponseCode>
+                        <Code>204</Code>
+                        <ResponseTypes>
+                            <ResponseType Type="null"/>
+                        </ResponseTypes>
+                    </ResponseCode>
+                    <ResponseCode>
+                        <Code>400</Code>
+                        <ResponseTypes>
+                            <ResponseType Type="com.spectralogic.s3.server.domain.HttpErrorResultApiBean"/>
+                        </ResponseTypes>
+                    </ResponseCode>
+                    <ResponseCode>
+                        <Code>409</Code>
+                        <ResponseTypes>
+                            <ResponseType Type="com.spectralogic.s3.server.domain.HttpErrorResultApiBean"/>
+                        </ResponseTypes>
+                    </ResponseCode>
+                </ResponseCodes>
+                <Version>1.F51C99474F629A2CFD5CDB6BC5CB7C6D</Version>
+            </RequestHandler>
+        </RequestHandlers>
+    </Contract>
+</Data>


### PR DESCRIPTION
**Changes**
- Special cased generated Go request handlers with payload of ids to take in `ids []string` and convert it into proper xml payload using utility `buildIdListPayload`

**Sample Generated Code**
```
package models

import (
    "net/url"
    "net/http"
    "ds3/networking"
)

type ClearSuspectBlobAzureTargetsSpectraS3Request struct {
    content networking.ReaderWithSizeDecorator
    queryParams *url.Values
}

func NewClearSuspectBlobAzureTargetsSpectraS3Request(ids []string) *ClearSuspectBlobAzureTargetsSpectraS3Request {
    queryParams := &url.Values{}

    return &ClearSuspectBlobAzureTargetsSpectraS3Request{
        content: buildIdListPayload(ids),
        queryParams: queryParams,
    }
}



func (clearSuspectBlobAzureTargetsSpectraS3Request *ClearSuspectBlobAzureTargetsSpectraS3Request) WithForce() *ClearSuspectBlobAzureTargetsSpectraS3Request {
    clearSuspectBlobAzureTargetsSpectraS3Request.queryParams.Set("force", "")
    return clearSuspectBlobAzureTargetsSpectraS3Request
}

func (ClearSuspectBlobAzureTargetsSpectraS3Request) Verb() networking.HttpVerb {
    return networking.DELETE
}

func (clearSuspectBlobAzureTargetsSpectraS3Request *ClearSuspectBlobAzureTargetsSpectraS3Request) Path() string {
    return "/_rest_/suspect_blob_azure_target"
}

func (clearSuspectBlobAzureTargetsSpectraS3Request *ClearSuspectBlobAzureTargetsSpectraS3Request) QueryParams() *url.Values {
    return clearSuspectBlobAzureTargetsSpectraS3Request.queryParams
}

func (ClearSuspectBlobAzureTargetsSpectraS3Request) GetChecksum() networking.Checksum {
    return networking.NewNoneChecksum()
}
func (ClearSuspectBlobAzureTargetsSpectraS3Request) Header() *http.Header {
    return &http.Header{}
}

func (clearSuspectBlobAzureTargetsSpectraS3Request *ClearSuspectBlobAzureTargetsSpectraS3Request) GetContentStream() networking.ReaderWithSizeDecorator {
    return clearSuspectBlobAzureTargetsSpectraS3Request.content
}
```