### PR TITLE
PYTHONSDK-79: Updated python and python3 code to have 4 space per indent

### DIFF
--- a/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/helpers/PythonHelper.java
+++ b/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/helpers/PythonHelper.java
@@ -28,7 +28,7 @@ import static com.spectralogic.ds3autogen.utils.ConverterUtil.isEmpty;
 public final class PythonHelper {
 
     private final static PythonHelper pythonHelper = new PythonHelper();
-    private final static String PYTHON_INDENT = "  ";
+    private final static String PYTHON_INDENT = "    ";
 
     private PythonHelper() {
         //pass

--- a/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/model/type/TypeElement.java
+++ b/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/model/type/TypeElement.java
@@ -33,7 +33,7 @@ public class TypeElement implements TypeContent {
 
     public String toPythonCode() {
         final StringBuilder builder = new StringBuilder();
-        builder.append("'").append(capFirst(xmlTag)).append("' : ").append(typeModel);
+        builder.append("'").append(capFirst(xmlTag)).append("': ").append(typeModel);
         if (!typeModel.equals("None")) {
             builder.append("()");
         }

--- a/ds3-autogen-python/src/main/resources/tmpls/python/commands/all_commands.ftl
+++ b/ds3-autogen-python/src/main/resources/tmpls/python/commands/all_commands.ftl
@@ -7,74 +7,83 @@ from abc import ABCMeta
 import posixpath
 from ds3network import *
 
+
 <#include "create_client.ftl">
+
 
 # Models
 
+
 <#include "static_classes.ftl" />
+
 
 # Type Descriptors
 
-<#include "types/type_descriptor.ftl" />
 
+<#include "types/type_descriptor.ftl" />
 <#include "types/static_type_descriptors.ftl" />
+
 
 <#include "types/parser_function.ftl" />
 
+
 # Request Handlers
 
+
 class AbstractRequest(object):
-  __metaclass__ = ABCMeta
-  def __init__(self):
-    self.path = '/'
-    self.http_verb = HttpVerb.GET
-    self.query_params = {}
-    self.headers = {}
-    self.body = None
+    __metaclass__ = ABCMeta
+
+    def __init__(self):
+        self.path = '/'
+        self.http_verb = HttpVerb.GET
+        self.query_params = {}
+        self.headers = {}
+        self.body = None
+
 
 <#include "requests/request.ftl" />
-
 # Response Handlers
 
+
 class AbstractResponse(object):
-  __metaclass__ = ABCMeta
-  def __init__(self, response, request):
-    self.request = request
-    self.response = response
-    self.result = None
-    self.meta_data = None
-    self.process_response(response)
-    self.process_meta_data(response)
+    __metaclass__ = ABCMeta
 
-  def process_meta_data(self, response):
-    headers = response.getheaders()
-    if not headers:
-      return
-    meta_data = {}
-    for header in headers:
-      if header[0].startswith('x-amz-meta-'):
-        values = header[1].split(',')
-        meta_data[header[0][11:]] = values
-    self.meta_data = meta_data
+    def __init__(self, response, request):
+        self.request = request
+        self.response = response
+        self.result = None
+        self.meta_data = None
+        self.process_response(response)
+        self.process_meta_data(response)
 
-  def process_response(self, response):
-    # this method must be implemented
-    raise NotImplementedError("Request Implemented")
+    def process_meta_data(self, response):
+        headers = response.getheaders()
+        if not headers:
+            return
+        meta_data = {}
+        for header in headers:
+            if header[0].startswith('x-amz-meta-'):
+                values = header[1].split(',')
+                meta_data[header[0][11:]] = values
+        self.meta_data = meta_data
 
-  def __check_status_codes__(self, expected_codes):
-    if self.response.status not in expected_codes:
-      err = "Return Code: Expected %s - Received %s" % (expected_codes, self.response.status)
-      ds3_error = XmlSerializer().to_ds3error(self.response.read(), self.response.status, self.response.reason)
-      raise RequestFailed(err, ds3_error)
+    def process_response(self, response):
+        # this method must be implemented
+        raise NotImplementedError("Request Implemented")
 
-  def parse_int_header(self, key, headers):
-    if not headers:
-      return None
-    for header in headers:
-      if header[0] == key:
-        return int(header[1])
-    return None
+    def __check_status_codes__(self, expected_codes):
+        if self.response.status not in expected_codes:
+            err = "Return Code: Expected %s - Received %s" % (expected_codes, self.response.status)
+            ds3_error = XmlSerializer().to_ds3error(self.response.read(), self.response.status, self.response.reason)
+            raise RequestFailed(err, ds3_error)
+
+    def parse_int_header(self, key, headers):
+        if not headers:
+            return None
+        for header in headers:
+            if header[0] == key:
+                return int(header[1])
+        return None
 
 <#include "responses/response.ftl" />
-
 <#include "client/client_class.ftl" />

--- a/ds3-autogen-python/src/main/resources/tmpls/python/commands/client/client_class.ftl
+++ b/ds3-autogen-python/src/main/resources/tmpls/python/commands/client/client_class.ftl
@@ -1,15 +1,14 @@
 class Client(object):
-  def __init__(self, endpoint, credentials, proxy=None):
-    self.net_client = NetworkClient(endpoint, credentials)
-    if proxy is not None:
-      self.net_client = self.net_client.with_proxy(proxy)
+    def __init__(self, endpoint, credentials, proxy=None):
+        self.net_client = NetworkClient(endpoint, credentials)
+        if proxy is not None:
+            self.net_client = self.net_client.with_proxy(proxy)
 
-  def get_net_client(self):
-    return self.net_client
+    def get_net_client(self):
+        return self.net_client
 
 <#list clientCommands as cmd>
-  ${cmd.documentation}
-  def ${cmd.commandName}(self, request):
-    return ${cmd.responseName}(self.net_client.get_response(request), request)
-
+    ${cmd.documentation}
+    def ${cmd.commandName}(self, request):
+        return ${cmd.responseName}(self.net_client.get_response(request), request)
 </#list>

--- a/ds3-autogen-python/src/main/resources/tmpls/python/commands/create_client.ftl
+++ b/ds3-autogen-python/src/main/resources/tmpls/python/commands/create_client.ftl
@@ -1,18 +1,19 @@
 def createClientFromEnv():
-  """Build a Client from environment variables.
+    """
+    Build a Client from environment variables.
 
-     Required: DS3_ACCESS_KEY, DS3_SECRET_KEY, DS3_ENDPOINT
+    Required: DS3_ACCESS_KEY, DS3_SECRET_KEY, DS3_ENDPOINT
 
-     Optional: http_proxy
-  """
-  access_key = os.environ.get('DS3_ACCESS_KEY')
-  secret_key = os.environ.get('DS3_SECRET_KEY')
-  endpoint = os.environ.get('DS3_ENDPOINT')
-  proxy = os.environ.get('http_proxy')
+    Optional: http_proxy
+    """
+    access_key = os.environ.get('DS3_ACCESS_KEY')
+    secret_key = os.environ.get('DS3_SECRET_KEY')
+    endpoint = os.environ.get('DS3_ENDPOINT')
+    proxy = os.environ.get('http_proxy')
 
-  if None in (access_key, secret_key, endpoint):
-    raise Exception('Required environment variables are not set: DS3_ACCESS_KEY, DS3_SECRET_KEY, DS3_ENDPOINT')
+    if None in (access_key, secret_key, endpoint):
+        raise Exception('Required environment variables are not set: DS3_ACCESS_KEY, DS3_SECRET_KEY, DS3_ENDPOINT')
 
-  creds = Credentials(access_key, secret_key)
-  client = Client(endpoint, creds, proxy)
-  return client
+    creds = Credentials(access_key, secret_key)
+    client = Client(endpoint, creds, proxy)
+    return client

--- a/ds3-autogen-python/src/main/resources/tmpls/python/commands/requests/request.ftl
+++ b/ds3-autogen-python/src/main/resources/tmpls/python/commands/requests/request.ftl
@@ -1,25 +1,23 @@
 <#list requests as request>
 class ${request.name}(AbstractRequest):
-  ${request.documentation}
-  def __init__(${pythonHelper.toRequestInitList(request.constructorParams)}):
-    super(${request.name}, self).__init__()
-    <#list request.assignments as arg>
-    self.${arg} = ${arg}
-    </#list>
-    <#list request.queryParams as arg>
-    self.query_params['${arg.getName()}'] = ${arg.getAssignment()}
-    </#list>
+    ${request.documentation}
+    def __init__(${pythonHelper.toRequestInitList(request.constructorParams)}):
+        super(${request.name}, self).__init__()
+        <#list request.assignments as arg>
+        self.${arg} = ${arg}
+        </#list>
+        <#list request.queryParams as arg>
+        self.query_params['${arg.getName()}'] = ${arg.getAssignment()}
+        </#list>
+        <#if request.additionalContent??>
+        ${request.additionalContent}
+        </#if>
+        <#list request.optionalArgs as arg>
+        if ${helper.camelToUnderscore(arg.name)} is not None:
+            self.query_params['${helper.camelToUnderscore(arg.name)}'] = ${helper.camelToUnderscore(arg.name)}
+        </#list>
+        self.path = ${request.path}
+        self.http_verb = HttpVerb.${request.httpVerb}
 
-    <#if request.additionalContent??>
-    ${request.additionalContent}
-    </#if>
-
-    <#list request.optionalArgs as arg>
-    if ${helper.camelToUnderscore(arg.name)} is not None:
-      self.query_params['${helper.camelToUnderscore(arg.name)}'] = ${helper.camelToUnderscore(arg.name)}
-    </#list>
-
-    self.path = ${request.path}
-    self.http_verb = HttpVerb.${request.httpVerb}
 
 </#list>

--- a/ds3-autogen-python/src/main/resources/tmpls/python/commands/responses/response.ftl
+++ b/ds3-autogen-python/src/main/resources/tmpls/python/commands/responses/response.ftl
@@ -1,8 +1,9 @@
 <#list responses as response>
 class ${response.name}(AbstractResponse):
-  ${response.initResponseCode}
-  def process_response(self, response):
-    self.__check_status_codes__([${pythonHelper.toCommaSeparatedList(response.codes)}])
-    ${response.parseResponseCode}
+    ${response.initResponseCode}
+    def process_response(self, response):
+        self.__check_status_codes__([${pythonHelper.toCommaSeparatedList(response.codes)}])
+        ${response.parseResponseCode}
+
 
 </#list>

--- a/ds3-autogen-python/src/main/resources/tmpls/python/commands/static_classes.ftl
+++ b/ds3-autogen-python/src/main/resources/tmpls/python/commands/static_classes.ftl
@@ -1,86 +1,92 @@
 class HeadRequestStatus(object):
-  """Head bucket and head object return values"""
-  EXISTS = 'EXISTS'  # 200
-  NOTAUTHORIZED = 'NOTAUTHORIZED' # 403
-  DOESNTEXIST = 'DOESNTEXIST' # 404
-  UNKNOWN = 'UNKNOWN'
+    """Head bucket and head object return values"""
+    EXISTS = 'EXISTS'  # 200
+    NOTAUTHORIZED = 'NOTAUTHORIZED'  # 403
+    DOESNTEXIST = 'DOESNTEXIST'  # 404
+    UNKNOWN = 'UNKNOWN'
+
 
 class FileObject(object):
-  def __init__(self, name, size=None):
-    self.name = name
-    self.size = size
+    def __init__(self, name, size=None):
+        self.name = name
+        self.size = size
 
-  def to_xml(self):
-    xml_object = xmldom.Element('Object')
-    xml_object.set('Name', posixpath.normpath(self.name))
-    if self.size is not None:
-      xml_object.set('Size', str(self.size))
-    return xml_object
+    def to_xml(self):
+        xml_object = xmldom.Element('Object')
+        xml_object.set('Name', posixpath.normpath(self.name))
+        if self.size is not None:
+            xml_object.set('Size', str(self.size))
+        return xml_object
+
 
 class FileObjectList(object):
-  def __init__(self, object_list):
-    for obj in object_list:
-      if not isinstance(obj, FileObject):
-        raise TypeError("FileObjectList should only contain type: FileObject")
-    self.object_list = object_list
+    def __init__(self, object_list):
+        for obj in object_list:
+            if not isinstance(obj, FileObject):
+                raise TypeError("FileObjectList should only contain type: FileObject")
+        self.object_list = object_list
 
-  def to_xml(self):
-    xml_object_list = xmldom.Element('Objects')
-    for obj in self.object_list:
-      xml_object_list.append(obj.to_xml())
-    return xml_object_list
+    def to_xml(self):
+        xml_object_list = xmldom.Element('Objects')
+        for obj in self.object_list:
+            xml_object_list.append(obj.to_xml())
+        return xml_object_list
+
 
 class DeleteObject(object):
-  def __init__(self, key):
-    self.key = key
+    def __init__(self, key):
+        self.key = key
 
-  def to_xml(self):
-    xml_key = xmldom.Element('Key')
-    xml_key.text = self.key
+    def to_xml(self):
+        xml_key = xmldom.Element('Key')
+        xml_key.text = self.key
 
-    xml_object = xmldom.Element('Object')
-    xml_object.append(xml_key)
-    return xml_object
+        xml_object = xmldom.Element('Object')
+        xml_object.append(xml_key)
+        return xml_object
+
 
 class DeleteObjectList(object):
-  def __init__(self, object_list):
-    for obj in object_list:
-      if not isinstance(obj, DeleteObject):
-        raise TypeError("DeleteObjectList should only contain type: DeleteObject")
-    self.object_list = object_list
+    def __init__(self, object_list):
+        for obj in object_list:
+            if not isinstance(obj, DeleteObject):
+                raise TypeError("DeleteObjectList should only contain type: DeleteObject")
+        self.object_list = object_list
 
-  def to_xml(self):
-    xml_object_list = xmldom.Element('Delete')
-    for obj in self.object_list:
-      xml_object_list.append(obj.to_xml())
-    return xml_object_list
+    def to_xml(self):
+        xml_object_list = xmldom.Element('Delete')
+        for obj in self.object_list:
+            xml_object_list.append(obj.to_xml())
+        return xml_object_list
+
 
 class Part(object):
-  def __init__(self, part_number, etag):
-    self.part_number = str(part_number)
-    self.etag = etag
+    def __init__(self, part_number, etag):
+        self.part_number = str(part_number)
+        self.etag = etag
 
-  def to_xml(self):
-    xml_part_number = xmldom.Element('PartNumber')
-    xml_part_number.text = self.part_number
+    def to_xml(self):
+        xml_part_number = xmldom.Element('PartNumber')
+        xml_part_number.text = self.part_number
 
-    xml_etag = xmldom.Element('ETag')
-    xml_etag.text = self.etag
+        xml_etag = xmldom.Element('ETag')
+        xml_etag.text = self.etag
 
-    xml_part = xmldom.Element('Part')
-    xml_part.append(xml_part_number)
-    xml_part.append(xml_etag)
-    return xml_part
+        xml_part = xmldom.Element('Part')
+        xml_part.append(xml_part_number)
+        xml_part.append(xml_etag)
+        return xml_part
+
 
 class PartList(object):
-  def __init__(self, part_list):
-    for part in part_list:
-      if not isinstance(part, Part):
-        raise TypeError("PartList should only contain type: Part")
-    self.part_list = part_list
+    def __init__(self, part_list):
+        for part in part_list:
+            if not isinstance(part, Part):
+                raise TypeError("PartList should only contain type: Part")
+        self.part_list = part_list
 
-  def to_xml(self):
-    xml_part_list = xmldom.Element('CompleteMultipartUpload')
-    for part in self.part_list:
-      xml_part_list.append(part.to_xml())
-    return xml_part_list
+    def to_xml(self):
+        xml_part_list = xmldom.Element('CompleteMultipartUpload')
+        for part in self.part_list:
+            xml_part_list.append(part.to_xml())
+        return xml_part_list

--- a/ds3-autogen-python/src/main/resources/tmpls/python/commands/types/parser_function.ftl
+++ b/ds3-autogen-python/src/main/resources/tmpls/python/commands/types/parser_function.ftl
@@ -1,51 +1,51 @@
 def parseModel(root, model):
 
-  if root.tag is 'Data':
-    children = list(root.iter())
-    if not children:
-      return None
-    else:
-      root = children[0]
+    if root.tag is 'Data':
+        children = list(root.iter())
+        if not children:
+            return None
+        else:
+            root = children[0]
 
-  if root is None:
-    raise TypeError('Nothing to parse: root node is None')
+    if root is None:
+        raise TypeError('Nothing to parse: root node is None')
 
-  # Primitive type
-  if model is None:
-    return root.text
+    # Primitive type
+    if model is None:
+        return root.text
 
-  result = {}
-  # Adds attributes to the result model
-  for attr in model.attributes:
-    temp = root.attrib.get(attr)
-    if temp is not None:
-      result[attr] = temp
-    else:
-      result[attr] = None
+    result = {}
+    # Adds attributes to the result model
+    for attr in model.attributes:
+        temp = root.attrib.get(attr)
+        if temp is not None:
+            result[attr] = temp
+        else:
+            result[attr] = None
 
-  # Adds child xmlNodes to the result model
-  for elmt in model.elements:
-    xmlElement = root.find(elmt)
-    if xmlElement is not None:
-      result[elmt] = parseModel(xmlElement, model.elements[elmt])
-    else:
-      result[elmt] = None
+    # Adds child xmlNodes to the result model
+    for elmt in model.elements:
+        xmlElement = root.find(elmt)
+        if xmlElement is not None:
+            result[elmt] = parseModel(xmlElement, model.elements[elmt])
+        else:
+            result[elmt] = None
 
-  # Adds lists of child xmlNodes to the result model
-  for elmt in model.element_lists:
-    xmlElements = None
-    if elmt[1] is None:
-      # No encapsulating node
-      xmlElements = root.findall(elmt[0])
-    else:
-      # Get nodes from within encapsulating node
-      encapsNode = root.find(elmt[1])
-      if encapsNode is not None:
-        xmlElements = encapsNode.findall(elmt[0])
+    # Adds lists of child xmlNodes to the result model
+    for elmt in model.element_lists:
+        xmlElements = None
+        if elmt[1] is None:
+            # No encapsulating node
+            xmlElements = root.findall(elmt[0])
+        else:
+            # Get nodes from within encapsulating node
+            encapsNode = root.find(elmt[1])
+            if encapsNode is not None:
+                xmlElements = encapsNode.findall(elmt[0])
 
-    tempList = []
-    for xmlElmt in xmlElements:
-      tempList.append(parseModel(xmlElmt, elmt[2]))
-    result[elmt[0] + 'List'] = tempList
+        tempList = []
+        for xmlElmt in xmlElements:
+            tempList.append(parseModel(xmlElmt, elmt[2]))
+        result[elmt[0] + 'List'] = tempList
 
-  return result
+    return result

--- a/ds3-autogen-python/src/main/resources/tmpls/python/commands/types/static_type_descriptors.ftl
+++ b/ds3-autogen-python/src/main/resources/tmpls/python/commands/types/static_type_descriptors.ftl
@@ -1,7 +1,7 @@
 class CommonPrefixes(object):
-  def __init__(self):
-    self.attributes = []
-    self.elements = {
-      'Prefix' : None
-    }
-    self.element_lists = {}
+    def __init__(self):
+        self.attributes = []
+        self.elements = {
+            'Prefix' : None
+        }
+        self.element_lists = {}

--- a/ds3-autogen-python/src/main/resources/tmpls/python/commands/types/type_descriptor.ftl
+++ b/ds3-autogen-python/src/main/resources/tmpls/python/commands/types/type_descriptor.ftl
@@ -1,8 +1,9 @@
 <#list typeDescriptors as type>
 class ${type.name}(object):
-  def __init__(self):
-    self.attributes = [${pythonHelper.toCommaSeparatedLines(type.attributes, 3)}]
-    self.elements = {${pythonHelper.toCommaSeparatedLines(type.elements, 3)}}
-    self.element_lists = {${pythonHelper.toCommaSeparatedLines(type.elementLists, 3)}}
+    def __init__(self):
+        self.attributes = [${pythonHelper.toCommaSeparatedLines(type.attributes, 3)}]
+        self.elements = {${pythonHelper.toCommaSeparatedLines(type.elements, 3)}}
+        self.element_lists = {${pythonHelper.toCommaSeparatedLines(type.elementLists, 3)}}
+
 
 </#list>

--- a/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/PythonCodeGenerator_Test.java
+++ b/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/PythonCodeGenerator_Test.java
@@ -133,7 +133,7 @@ public class PythonCodeGenerator_Test {
         assertThat(result.getAttributes().size(), is(0));
         assertThat(result.getElementLists().size(), is(0));
         assertThat(result.getElements().size(), is(1));
-        assertThat(result.getElements().get(0), is("'ElementName' : None"));
+        assertThat(result.getElements().get(0), is("'ElementName': None"));
     }
 
     @Test
@@ -181,7 +181,7 @@ public class PythonCodeGenerator_Test {
         assertThat(result.getCodes().size(), is(1));
 
         final String expectedParseResponse = "if self.response.status == 200:\n" +
-                "      self.result = parseModel(xmldom.fromstring(response.read()), ListBucketResult())";
+                "            self.result = parseModel(xmldom.fromstring(response.read()), ListBucketResult())";
         assertThat(result.getParseResponseCode(), is(expectedParseResponse));
     }
 

--- a/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/PythonFunctionalTests.java
+++ b/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/PythonFunctionalTests.java
@@ -257,14 +257,14 @@ public class PythonFunctionalTests {
 
         assertTrue(ds3Code.contains("self.__check_status_codes__([200, 403, 404])"));
         assertTrue(ds3Code.contains("self.status_code = self.response.status\n" +
-                "    if self.response.status == 200:\n" +
-                "      self.result = HeadRequestStatus.EXISTS\n" +
-                "    elif self.response.status == 403:\n" +
-                "      self.result = HeadRequestStatus.NOTAUTHORIZED\n" +
-                "    elif self.response.status == 404:\n" +
-                "      self.result = HeadRequestStatus.DOESNTEXIST\n" +
-                "    else:\n" +
-                "      self.result = HeadRequestStatus.UNKNOWN"));
+                "        if self.response.status == 200:\n" +
+                "            self.result = HeadRequestStatus.EXISTS\n" +
+                "        elif self.response.status == 403:\n" +
+                "            self.result = HeadRequestStatus.NOTAUTHORIZED\n" +
+                "        elif self.response.status == 404:\n" +
+                "            self.result = HeadRequestStatus.DOESNTEXIST\n" +
+                "        else:\n" +
+                "            self.result = HeadRequestStatus.UNKNOWN"));
 
         assertTrue(ds3Code.contains("class HeadRequestStatus(object):"));
 
@@ -290,14 +290,14 @@ public class PythonFunctionalTests {
 
         assertTrue(ds3Code.contains("self.__check_status_codes__([200, 403, 404])"));
         assertTrue(ds3Code.contains("self.status_code = self.response.status\n" +
-                "    if self.response.status == 200:\n" +
-                "      self.result = HeadRequestStatus.EXISTS\n" +
-                "    elif self.response.status == 403:\n" +
-                "      self.result = HeadRequestStatus.NOTAUTHORIZED\n" +
-                "    elif self.response.status == 404:\n" +
-                "      self.result = HeadRequestStatus.DOESNTEXIST\n" +
-                "    else:\n" +
-                "      self.result = HeadRequestStatus.UNKNOWN"));
+                "        if self.response.status == 200:\n" +
+                "            self.result = HeadRequestStatus.EXISTS\n" +
+                "        elif self.response.status == 403:\n" +
+                "            self.result = HeadRequestStatus.NOTAUTHORIZED\n" +
+                "        elif self.response.status == 404:\n" +
+                "            self.result = HeadRequestStatus.DOESNTEXIST\n" +
+                "        else:\n" +
+                "            self.result = HeadRequestStatus.UNKNOWN"));
 
         assertTrue(ds3Code.contains("class HeadRequestStatus(object):"));
 

--- a/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/generators/client/BaseClientGenerator_Test.java
+++ b/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/generators/client/BaseClientGenerator_Test.java
@@ -50,8 +50,8 @@ public class BaseClientGenerator_Test {
     @Test
     public void toDocumentation_Test() {
         final String expected = "'''\n" +
-                "  This is how you use test one request\n" +
-                "  '''\n";
+                "    This is how you use test one request\n" +
+                "    '''\n";
 
         final Ds3DocSpec docSpec = getTestDocSpec();
         assertThat(toDocumentation("com.test.TestOneRequest", docSpec), is(expected));

--- a/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/generators/request/BaseRequestGenerator_Test.java
+++ b/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/generators/request/BaseRequestGenerator_Test.java
@@ -262,10 +262,10 @@ public class BaseRequestGenerator_Test {
     @Test
     public void toDocumentation_Test() {
         final String expected = "'''\n" +
-                "  This is how you use test one request\n" +
-                "  `param_one` This is how you use param one\n" +
-                "  `does_not_exist` \n" +
-                "  '''\n";
+                "    This is how you use test one request\n" +
+                "    `param_one` This is how you use param one\n" +
+                "    `does_not_exist` \n" +
+                "    '''\n";
 
         final Ds3DocSpec docSpec = new Ds3DocSpecImpl(
                 ImmutableMap.of(

--- a/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/generators/request/GetObjectRequestGenerator_Test.java
+++ b/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/generators/request/GetObjectRequestGenerator_Test.java
@@ -32,7 +32,7 @@ public class GetObjectRequestGenerator_Test {
     @Test
     public void getAdditionalContent_Test() {
         final String expected = "self.offset = offset\n" +
-                "    self.stream = stream\n";
+                "        self.stream = stream\n";
         final String result = generator.getAdditionalContent(null, null);
         assertThat(result, is(expected));
     }

--- a/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/generators/request/ObjectsPayloadGenerator_Test.java
+++ b/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/generators/request/ObjectsPayloadGenerator_Test.java
@@ -33,9 +33,9 @@ public class ObjectsPayloadGenerator_Test {
     @Test
     public void getAdditionalContent_OptionalFileObjectList_Test() {
         final String expected = "if object_list is not None:\n" +
-                "      if not isinstance(object_list, FileObjectList):\n" +
-                "        raise TypeError('com.spectralogic.s3.server.handler.reqhandler.spectrads3.tape.EjectStorageDomainRequestHandler should have request payload of type: FileObjectList')\n" +
-                "      self.body = xmldom.tostring(object_list.to_xml())\n";
+                "            if not isinstance(object_list, FileObjectList):\n" +
+                "                raise TypeError('com.spectralogic.s3.server.handler.reqhandler.spectrads3.tape.EjectStorageDomainRequestHandler should have request payload of type: FileObjectList')\n" +
+                "            self.body = xmldom.tostring(object_list.to_xml())\n";
         final Ds3Request request = getEjectStorageDomainBlobsRequest();
         final String result = generator.getAdditionalContent(request, request.getName());
         assertThat(result, is(expected));
@@ -44,9 +44,9 @@ public class ObjectsPayloadGenerator_Test {
     @Test
     public void getAdditionalContent_RequiredFileObjectList_Test() {
         final String expected = "if object_list is not None:\n" +
-                "      if not isinstance(object_list, FileObjectList):\n" +
-                "        raise TypeError('com.spectralogic.s3.server.handler.reqhandler.spectrads3.job.CreateGetJobRequestHandler should have request payload of type: FileObjectList')\n" +
-                "      self.body = xmldom.tostring(object_list.to_xml())\n";
+                "            if not isinstance(object_list, FileObjectList):\n" +
+                "                raise TypeError('com.spectralogic.s3.server.handler.reqhandler.spectrads3.job.CreateGetJobRequestHandler should have request payload of type: FileObjectList')\n" +
+                "            self.body = xmldom.tostring(object_list.to_xml())\n";
         final Ds3Request request = getRequestBulkGet();
         final String result = generator.getAdditionalContent(request, request.getName());
         assertThat(result, is(expected));
@@ -55,9 +55,9 @@ public class ObjectsPayloadGenerator_Test {
     @Test
     public void getAdditionalContent_RequiredDeleteObjectList_Test() {
         final String expected = "if object_list is not None:\n" +
-                "      if not isinstance(object_list, DeleteObjectList):\n" +
-                "        raise TypeError('com.spectralogic.s3.server.handler.reqhandler.amazons3.DeleteObjectsRequestHandler should have request payload of type: DeleteObjectList')\n" +
-                "      self.body = xmldom.tostring(object_list.to_xml())\n";
+                "            if not isinstance(object_list, DeleteObjectList):\n" +
+                "                raise TypeError('com.spectralogic.s3.server.handler.reqhandler.amazons3.DeleteObjectsRequestHandler should have request payload of type: DeleteObjectList')\n" +
+                "            self.body = xmldom.tostring(object_list.to_xml())\n";
         final Ds3Request request = getRequestMultiFileDelete();
         final String result = generator.getAdditionalContent(request, request.getName());
         assertThat(result, is(expected));
@@ -66,9 +66,9 @@ public class ObjectsPayloadGenerator_Test {
     @Test
     public void getAdditionalContent_RequiredPartList_Test() {
         final String expected = "if part_list is not None:\n" +
-                "      if not isinstance(part_list, PartList):\n" +
-                "        raise TypeError('com.spectralogic.s3.server.handler.reqhandler.amazons3.CompleteMultiPartUploadRequestHandler should have request payload of type: PartList')\n" +
-                "      self.body = xmldom.tostring(part_list.to_xml())\n";
+                "            if not isinstance(part_list, PartList):\n" +
+                "                raise TypeError('com.spectralogic.s3.server.handler.reqhandler.amazons3.CompleteMultiPartUploadRequestHandler should have request payload of type: PartList')\n" +
+                "            self.body = xmldom.tostring(part_list.to_xml())\n";
         final Ds3Request request = getCompleteMultipartUploadRequest();
         final String result = generator.getAdditionalContent(request, request.getName());
         assertThat(result, is(expected));
@@ -83,9 +83,9 @@ public class ObjectsPayloadGenerator_Test {
     @Test
     public void toPayloadAssignment_Test() {
         final String expected = "if PayloadName is not None:\n" +
-                "      if not isinstance(PayloadName, PayloadType):\n" +
-                "        raise TypeError('RequestName should have request payload of type: PayloadType')\n" +
-                "      self.body = xmldom.tostring(PayloadName.to_xml())\n";
+                "            if not isinstance(PayloadName, PayloadType):\n" +
+                "                raise TypeError('RequestName should have request payload of type: PayloadType')\n" +
+                "            self.body = xmldom.tostring(PayloadName.to_xml())\n";
 
         final String result = toPayloadAssignment("RequestName", "PayloadName", "PayloadType");
         assertThat(result, is(expected));

--- a/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/generators/request/PutObjectRequestGenerator_Test.java
+++ b/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/generators/request/PutObjectRequestGenerator_Test.java
@@ -61,13 +61,13 @@ public class PutObjectRequestGenerator_Test {
     @Test
     public void getAdditionalContent_Test() {
         final String expected = "if headers is not None:\n" +
-                "      for key, val in headers.iteritems():\n" +
-                "        if val:\n" +
-                "          self.headers[key] = val\n" +
-                "    self.headers['Content-Length'] = length\n" +
-                "    self.object_name = typeCheckString(object_name)\n" +
-                "    object_data = StreamWithLength(stream, length)\n" +
-                "    self.body = object_data\n";
+                "            for key, val in headers.iteritems():\n" +
+                "                if val:\n" +
+                "                    self.headers[key] = val\n" +
+                "        self.headers['Content-Length'] = length\n" +
+                "        self.object_name = typeCheckString(object_name)\n" +
+                "        object_data = StreamWithLength(stream, length)\n" +
+                "        self.body = object_data\n";
         final String result = generator.getAdditionalContent(null, null);
         assertThat(result, is(expected));
     }

--- a/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/generators/response/BaseResponseGenerator_Test.java
+++ b/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/generators/response/BaseResponseGenerator_Test.java
@@ -95,7 +95,7 @@ public class BaseResponseGenerator_Test {
     @Test
     public void toParseResponsePayload_NoNameToMarshal_Test() {
         final String expected = "if self.response.status == 200:\n" +
-                "      self.result = parseModel(xmldom.fromstring(response.read()), ListBucketResult())";
+                "            self.result = parseModel(xmldom.fromstring(response.read()), ListBucketResult())";
 
         final Ds3Request request = getBucketRequest();
         assertThat(generator.toParseResponsePayload(request), is(expected));
@@ -104,7 +104,7 @@ public class BaseResponseGenerator_Test {
     @Test
     public void toParseResponsePayload_WithNameToMarshal_Test() {
         final String expected = "if self.response.status == 200:\n" +
-                "      self.result = parseModel(xmldom.fromstring(response.read()), JobWithChunksApiBean())";
+                "            self.result = parseModel(xmldom.fromstring(response.read()), JobWithChunksApiBean())";
 
         final Ds3Request request = getRequestGetJob();
         assertThat(generator.toParseResponsePayload(request), is(expected));

--- a/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/generators/response/GetObjectResponseGenerator_Test.java
+++ b/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/generators/response/GetObjectResponseGenerator_Test.java
@@ -27,14 +27,14 @@ public class GetObjectResponseGenerator_Test {
     @Test
     public void toParseResponsePayload_Test() {
         final String expected = "stream = self.request.stream\n" +
-                "    try:\n" +
-                "      bytes_read = response.read()\n" +
-                "      while bytes_read:\n" +
-                "        stream.write(bytes_read)\n" +
-                "        bytes_read = response.read()\n" +
-                "    finally:\n" +
-                "      stream.close()\n" +
-                "      response.close()\n";
+                "        try:\n" +
+                "            bytes_read = response.read()\n" +
+                "            while bytes_read:\n" +
+                "                stream.write(bytes_read)\n" +
+                "                bytes_read = response.read()\n" +
+                "        finally:\n" +
+                "            stream.close()\n" +
+                "            response.close()\n";
         final String result = generator.toParseResponsePayload(null);
         assertThat(result, is(expected));
     }

--- a/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/generators/response/HeadResponseGenerator_Test.java
+++ b/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/generators/response/HeadResponseGenerator_Test.java
@@ -32,14 +32,14 @@ public class HeadResponseGenerator_Test {
     @Test
     public void toParseResponsePayload_Test() {
         final String expected = "self.status_code = self.response.status\n" +
-                "    if self.response.status == 200:\n" +
-                "      self.result = HeadRequestStatus.EXISTS\n" +
-                "    elif self.response.status == 403:\n" +
-                "      self.result = HeadRequestStatus.NOTAUTHORIZED\n" +
-                "    elif self.response.status == 404:\n" +
-                "      self.result = HeadRequestStatus.DOESNTEXIST\n" +
-                "    else:\n" +
-                "      self.result = HeadRequestStatus.UNKNOWN";
+                "        if self.response.status == 200:\n" +
+                "            self.result = HeadRequestStatus.EXISTS\n" +
+                "        elif self.response.status == 403:\n" +
+                "            self.result = HeadRequestStatus.NOTAUTHORIZED\n" +
+                "        elif self.response.status == 404:\n" +
+                "            self.result = HeadRequestStatus.DOESNTEXIST\n" +
+                "        else:\n" +
+                "            self.result = HeadRequestStatus.UNKNOWN";
         assertThat(generator.toParseResponsePayload(null), is(expected));
         assertThat(generator.toParseResponsePayload(getHeadObjectRequest()), is(expected));
     }

--- a/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/generators/response/PaginationResponseGenerator_Test.java
+++ b/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/generators/response/PaginationResponseGenerator_Test.java
@@ -29,18 +29,18 @@ public class PaginationResponseGenerator_Test {
     @Test
     public void toInitResponse_Test() {
         final String expected = "def __init__(self, response, request):\n" +
-                "    self.paging_truncated = None\n" +
-                "    self.paging_total_result_count = None\n" +
-                "    super(self.__class__, self).__init__(response, request)\n";
+                "        self.paging_truncated = None\n" +
+                "        self.paging_total_result_count = None\n" +
+                "        super(self.__class__, self).__init__(response, request)\n";
         assertThat(generator.toInitResponse(), is(expected));
     }
 
     @Test
     public void toParseResponsePayload_GetObjects_Test() {
         final String expected = "if self.response.status == 200:\n" +
-                "      self.result = parseModel(xmldom.fromstring(response.read()), array())\n" +
-                "      self.paging_truncated = self.parse_int_header('page-truncated', response.getheaders())\n" +
-                "      self.paging_total_result_count = self.parse_int_header('total-result-count', response.getheaders())";
+                "            self.result = parseModel(xmldom.fromstring(response.read()), array())\n" +
+                "            self.paging_truncated = self.parse_int_header('page-truncated', response.getheaders())\n" +
+                "            self.paging_total_result_count = self.parse_int_header('total-result-count', response.getheaders())";
 
         final Ds3Request ds3Request = getObjectsDetailsRequest();
         assertThat(generator.toParseResponsePayload(ds3Request), is(expected));

--- a/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/generators/type/BaseTypeGenerator_Test.java
+++ b/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/generators/type/BaseTypeGenerator_Test.java
@@ -212,19 +212,19 @@ public class BaseTypeGenerator_Test {
     @Test
     public void toElement_NullMap_Test() {
         final TypeElement result = toElement(createDs3Element(), null);
-        assertThat(result.toPythonCode(), is("'Element' : None"));
+        assertThat(result.toPythonCode(), is("'Element': None"));
     }
 
     @Test
     public void toElement_EmptyMap_Test() {
         final TypeElement result = toElement(createDs3Element(), ImmutableMap.of());
-        assertThat(result.toPythonCode(), is("'Element' : None"));
+        assertThat(result.toPythonCode(), is("'Element': None"));
     }
 
     @Test
     public void toElement_Test() {
         final TypeElement result = toElement(createDs3Element(), createTestTypeMap());
-        assertThat(result.toPythonCode(), is("'Element' : ElementType()"));
+        assertThat(result.toPythonCode(), is("'Element': ElementType()"));
     }
 
     @Test
@@ -243,7 +243,7 @@ public class BaseTypeGenerator_Test {
     public void toElements_Test() {
         final ImmutableList<String> result = toElements(createDs3Elements(), createTestTypeMap());
         assertThat(result.size(), is(1));
-        assertThat(result.get(0), is("'Element' : ElementType()"));
+        assertThat(result.get(0), is("'Element': ElementType()"));
     }
 
     @Test

--- a/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/helpers/PythonHelper_Test.java
+++ b/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/helpers/PythonHelper_Test.java
@@ -47,9 +47,9 @@ public class PythonHelper_Test {
     public void pythonIndent_Test() {
         assertThat(pythonIndent(-1), is(""));
         assertThat(pythonIndent(0), is(""));
-        assertThat(pythonIndent(1), is("  "));
-        assertThat(pythonIndent(2), is("    "));
-        assertThat(pythonIndent(3), is("      "));
+        assertThat(pythonIndent(1), is("    "));
+        assertThat(pythonIndent(2), is("        "));
+        assertThat(pythonIndent(3), is("            "));
     }
 
     @Test
@@ -66,7 +66,7 @@ public class PythonHelper_Test {
 
     @Test
     public void toTypeContentLines_Attribute_Test() {
-        final String expected = "\n  Line1,\n  Line2\n";
+        final String expected = "\n    Line1,\n    Line2\n";
         final ImmutableList<String> typeContents = ImmutableList.of("Line1", "Line2");
 
         final String result = toCommaSeparatedLines(typeContents, 1);

--- a/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/model/response/ResponsesToPythonCode_Test.java
+++ b/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/model/response/ResponsesToPythonCode_Test.java
@@ -30,7 +30,7 @@ public class ResponsesToPythonCode_Test {
     @Test
     public void baseParsePayload_PrimitiveType_Test() {
         final String expected = "if self.response.status == 200:\n" +
-                "      self.result = parseModel(xmldom.fromstring(response.read()), None)";
+                "            self.result = parseModel(xmldom.fromstring(response.read()), None)";
 
         assertThat(new BaseParsePayload("None", 200).toPythonCode(), is(expected));
     }
@@ -38,7 +38,7 @@ public class ResponsesToPythonCode_Test {
     @Test
     public void baseParsePayloadType_WithType_Test() {
         final String expected = "if self.response.status == 200:\n" +
-                "      self.result = parseModel(xmldom.fromstring(response.read()), TestType())";
+                "            self.result = parseModel(xmldom.fromstring(response.read()), TestType())";
 
         assertThat(new BaseParsePayload("TestType", 200).toPythonCode(), is(expected));
     }

--- a/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/model/type/TypesToPythonCode_Test.java
+++ b/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/model/type/TypesToPythonCode_Test.java
@@ -29,8 +29,8 @@ public class TypesToPythonCode_Test {
 
     @Test
     public void typeElement_Test() {
-        assertThat(new TypeElement("XmlTag", "None").toPythonCode(), is("'XmlTag' : None"));
-        assertThat(new TypeElement("XmlTag", "TypeModel").toPythonCode(), is("'XmlTag' : TypeModel()"));
+        assertThat(new TypeElement("XmlTag", "None").toPythonCode(), is("'XmlTag': None"));
+        assertThat(new TypeElement("XmlTag", "TypeModel").toPythonCode(), is("'XmlTag': TypeModel()"));
     }
 
     @Test

--- a/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/utils/PythonDocGeneratorUtil_Test.java
+++ b/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/utils/PythonDocGeneratorUtil_Test.java
@@ -39,7 +39,7 @@ public class PythonDocGeneratorUtil_Test {
 
     @Test
     public void toParamDocs_Test() {
-        final String expected = "  `param_one` Descriptor for param one\n";
+        final String expected = "    `param_one` Descriptor for param one\n";
         final String result = toParamDocs("param_one", "Descriptor for param one", 1);
         assertThat(result, is(expected));
     }
@@ -59,8 +59,8 @@ public class PythonDocGeneratorUtil_Test {
     @Test
     public void toParamListDocs_FullList_Test() throws IOException {
         final String expected =
-                "  `param_one` This is how you use param one\n" +
-                "  `does_not_exist` \n";
+                "    `param_one` This is how you use param one\n" +
+                "    `does_not_exist` \n";
 
         final ImmutableList<String> params = ImmutableList.of("param_one", "does_not_exist");
         final String result = toParamListDocs(params, getTestDocSpec(), 1);
@@ -76,10 +76,10 @@ public class PythonDocGeneratorUtil_Test {
     @Test
     public void toConstructorDocs_Test() throws IOException {
         final String expected = "'''\n" +
-                "  This is how you use test one request\n" +
-                "  `param_one` This is how you use param one\n" +
-                "  `does_not_exist` \n" +
-                "  '''\n";
+                "    This is how you use test one request\n" +
+                "    `param_one` This is how you use param one\n" +
+                "    `does_not_exist` \n" +
+                "    '''\n";
 
         final ImmutableList<String> params = ImmutableList.of("param_one", "does_not_exist");
         final String result = toConstructorDocs("TestOneRequest", params, getTestDocSpec(), 1);
@@ -95,8 +95,8 @@ public class PythonDocGeneratorUtil_Test {
     @Test
     public void toCommandDocs_Test() throws IOException {
         final String expected = "'''\n" +
-                "  This is how you use test one request\n" +
-                "  '''\n";
+                "    This is how you use test one request\n" +
+                "    '''\n";
 
         final String result = toCommandDocs("TestOneRequest", getTestDocSpec(), 1);
         assertThat(result, is(expected));

--- a/ds3-autogen-python3/src/main/resources/tmpls/python3/commands/p3_all_commands.ftl
+++ b/ds3-autogen-python3/src/main/resources/tmpls/python3/commands/p3_all_commands.ftl
@@ -7,71 +7,79 @@ from abc import ABCMeta
 import posixpath
 from .ds3network import *
 
+
 <#include "../../python/commands/create_client.ftl">
+
 
 # Models
 
+
 <#include "../../python/commands/static_classes.ftl" />
+
 
 # Type Descriptors
 
-<#include "../../python/commands/types/type_descriptor.ftl" />
 
+<#include "../../python/commands/types/type_descriptor.ftl" />
 <#include "../../python/commands/types/static_type_descriptors.ftl" />
+
 
 <#include "../../python/commands/types/parser_function.ftl" />
 
+
 # Request Handlers
 
+
 class AbstractRequest(object, metaclass=ABCMeta):
-  def __init__(self):
-    self.path = '/'
-    self.http_verb = HttpVerb.GET
-    self.query_params = {}
-    self.headers = {}
-    self.body = None
+    def __init__(self):
+        self.path = '/'
+        self.http_verb = HttpVerb.GET
+        self.query_params = {}
+        self.headers = {}
+        self.body = None
+
 
 <#include "../../python/commands/requests/request.ftl" />
-
 # Response Handlers
 
+
 class AbstractResponse(object, metaclass=ABCMeta):
-  def __init__(self, response, request):
-    self.request = request
-    self.response = response
-    self.result = None
-    self.meta_data = None
-    self.process_response(response)
-    self.process_meta_data(response)
+    def __init__(self, response, request):
+        self.request = request
+        self.response = response
+        self.result = None
+        self.meta_data = None
+        self.process_response(response)
+        self.process_meta_data(response)
 
-  def process_meta_data(self, response):
-    headers = response.getheaders()
-    if not headers:
-      return
-    meta_data = {}
-    for header in headers:
-      if header[0].startswith('x-amz-meta-'):
-        values = header[1].split(',')
-        meta_data[header[0][11:]] = values
-    self.meta_data = meta_data
+    def process_meta_data(self, response):
+        headers = response.getheaders()
+        if not headers:
+            return
+        meta_data = {}
+        for header in headers:
+            if header[0].startswith('x-amz-meta-'):
+                values = header[1].split(',')
+                meta_data[header[0][11:]] = values
+        self.meta_data = meta_data
 
-  def process_response(self, response):
-    # this method must be implemented
-    raise NotImplementedError("Request Implemented")
+    def process_response(self, response):
+        # this method must be implemented
+        raise NotImplementedError("Request Implemented")
 
-  def __check_status_codes__(self, expected_codes):
-    if self.response.status not in expected_codes:
-      err = "Return Code: Expected %s - Received %s" % (expected_codes, self.response.status)
-      ds3_error = XmlSerializer().to_ds3error(self.response.read(), self.response.status, self.response.reason)
-      raise RequestFailed(err, ds3_error)
+    def __check_status_codes__(self, expected_codes):
+        if self.response.status not in expected_codes:
+            err = "Return Code: Expected %s - Received %s" % (expected_codes, self.response.status)
+            ds3_error = XmlSerializer().to_ds3error(self.response.read(), self.response.status, self.response.reason)
+            raise RequestFailed(err, ds3_error)
 
-  def parse_int_header(self, key, headers):
-    if not headers:
-      return None
-    for header in headers:
-      if header[0].lower() == key.lower():
-        return int(header[1])
-    return None
+    def parse_int_header(self, key, headers):
+        if not headers:
+            return None
+        for header in headers:
+            if header[0].lower() == key.lower():
+                return int(header[1])
+        return None
 
 <#include "../../python/commands/responses/response.ftl" />
 

--- a/ds3-autogen-python3/src/test/java/com/spectralogic/ds3autogen/python3/generators/request/P3PutObjectRequestGenerator_Test.java
+++ b/ds3-autogen-python3/src/test/java/com/spectralogic/ds3autogen/python3/generators/request/P3PutObjectRequestGenerator_Test.java
@@ -28,13 +28,13 @@ public class P3PutObjectRequestGenerator_Test {
     @Test
     public void getAdditionalContent_Test() {
         final String expected = "if headers is not None:\n" +
-                "      for key, val in headers.items():\n" +
-                "        if val:\n" +
-                "          self.headers[key] = val\n" +
-                "    self.headers['Content-Length'] = length\n" +
-                "    self.object_name = typeCheckString(object_name)\n" +
-                "    object_data = StreamWithLength(stream, length)\n" +
-                "    self.body = object_data\n";
+                "            for key, val in headers.items():\n" +
+                "                if val:\n" +
+                "                    self.headers[key] = val\n" +
+                "        self.headers['Content-Length'] = length\n" +
+                "        self.object_name = typeCheckString(object_name)\n" +
+                "        object_data = StreamWithLength(stream, length)\n" +
+                "        self.body = object_data\n";
         final String result = generator.getAdditionalContent(getRequestCreateObject(), "PutObjectRequest");
         assertThat(result, is(expected));
     }


### PR DESCRIPTION
**Changes**
- Updating the generated python code to have 4 spaces (was 2 spaces) per indent
- Updated generation of lists to remove unnecessary space before `:` to get rid of IDE warning
  - ex: `'DataPolicyId' : None` -> `'DataPolicyId': None`

Generates the code in PRs:
https://github.com/SpectraLogic/ds3_python_sdk/pull/117
https://github.com/SpectraLogic/ds3_python3_sdk/pull/13