### PR TITLE
SA-210: Updated java constructors to have nonnullable streams and channels

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,8 @@ subprojects {
         testCompile 'junit:junit:4.12'
         testCompile 'org.hamcrest:hamcrest-library:1.3'
         testCompile 'org.slf4j:slf4j-simple:1.7.12'
+        testCompile 'org.assertj:assertj-core:3.8.0'
+        testCompile 'org.assertj:assertj-guava:3.1.0'
     }
 }
 

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/requestmodels/BulkRequestGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/requestmodels/BulkRequestGenerator.java
@@ -20,6 +20,8 @@ import com.google.common.collect.ImmutableSet;
 import com.spectralogic.ds3autogen.api.models.Arguments;
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3Request;
 import com.spectralogic.ds3autogen.api.models.docspec.Ds3DocSpec;
+import com.spectralogic.ds3autogen.java.models.ConstructorParam;
+import com.spectralogic.ds3autogen.java.models.Precondition;
 import com.spectralogic.ds3autogen.java.models.RequestConstructor;
 import com.spectralogic.ds3autogen.java.models.Variable;
 import com.spectralogic.ds3autogen.java.models.withconstructor.BaseWithConstructor;
@@ -28,6 +30,8 @@ import com.spectralogic.ds3autogen.java.models.withconstructor.MaxUploadSizeWith
 import com.spectralogic.ds3autogen.java.models.withconstructor.VoidWithConstructor;
 import com.spectralogic.ds3autogen.utils.collections.GuavaCollectors;
 
+import static com.spectralogic.ds3autogen.java.utils.CommonRequestGeneratorUtils.toConstructorParams;
+import static com.spectralogic.ds3autogen.java.utils.CommonRequestGeneratorUtils.toPreconditions;
 import static com.spectralogic.ds3autogen.java.utils.JavaDocGenerator.toConstructorDocs;
 import static com.spectralogic.ds3autogen.utils.ConverterUtil.isEmpty;
 
@@ -109,14 +113,20 @@ public class BulkRequestGenerator extends BaseRequestGenerator {
             final String requestName,
             final Ds3DocSpec docSpec) {
         final ImmutableList<Arguments> constructorArguments = toConstructorArgumentsList(ds3Request);
+
         final ImmutableList<String> argNames = constructorArguments.stream()
                 .map(Arguments::getName)
                 .collect(GuavaCollectors.immutableList());
 
+        final ImmutableList<ConstructorParam> constructorParams = toConstructorParams(constructorArguments);
+
+        final ImmutableList<Precondition> preconditions = toPreconditions(constructorParams);
+
         final RequestConstructor constructor = new RequestConstructor(
-                constructorArguments,
+                constructorParams,
                 toConstructorAssignmentList(constructorArguments),
                 toQueryParamsList(ds3Request),
+                preconditions,
                 toConstructorDocs(requestName, argNames, docSpec, 1));
 
         return ImmutableList.of(constructor);

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/requestmodels/CreateNotificationRequestGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/requestmodels/CreateNotificationRequestGenerator.java
@@ -19,12 +19,12 @@ import com.google.common.collect.ImmutableList;
 import com.spectralogic.ds3autogen.api.models.Arguments;
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3Request;
 import com.spectralogic.ds3autogen.api.models.docspec.Ds3DocSpec;
-import com.spectralogic.ds3autogen.java.models.QueryParam;
-import com.spectralogic.ds3autogen.java.models.RequestConstructor;
-import com.spectralogic.ds3autogen.java.models.Variable;
+import com.spectralogic.ds3autogen.java.models.*;
 import com.spectralogic.ds3autogen.utils.collections.GuavaCollectors;
 
 import static com.spectralogic.ds3autogen.java.utils.CommonRequestGeneratorUtils.argsToQueryParams;
+import static com.spectralogic.ds3autogen.java.utils.CommonRequestGeneratorUtils.toConstructorParams;
+import static com.spectralogic.ds3autogen.java.utils.CommonRequestGeneratorUtils.toPreconditions;
 import static com.spectralogic.ds3autogen.java.utils.JavaDocGenerator.toConstructorDocs;
 import static com.spectralogic.ds3autogen.utils.ConverterUtil.isEmpty;
 
@@ -89,10 +89,15 @@ public class CreateNotificationRequestGenerator extends BaseRequestGenerator {
                 .map(Arguments::getName)
                 .collect(GuavaCollectors.immutableList());
 
+        final ImmutableList<ConstructorParam> constructorParams = toConstructorParams(constructorArguments);
+
+        final ImmutableList<Precondition> preconditions = toPreconditions(constructorParams);
+
         final RequestConstructor constructor = new RequestConstructor(
-                constructorArguments,
+                constructorParams,
                 toConstructorAssignmentList(constructorArguments),
                 toQueryParamsList(ds3Request),
+                preconditions,
                 toConstructorDocs(requestName, argNames, docSpec, 1));
 
         return ImmutableList.of(constructor);

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/requestmodels/CreateObjectRequestGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/requestmodels/CreateObjectRequestGenerator.java
@@ -19,12 +19,16 @@ import com.google.common.collect.ImmutableList;
 import com.spectralogic.ds3autogen.api.models.Arguments;
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3Request;
 import com.spectralogic.ds3autogen.api.models.docspec.Ds3DocSpec;
+import com.spectralogic.ds3autogen.java.models.ConstructorParam;
+import com.spectralogic.ds3autogen.java.models.Precondition;
 import com.spectralogic.ds3autogen.java.models.QueryParam;
 import com.spectralogic.ds3autogen.java.models.RequestConstructor;
 import com.spectralogic.ds3autogen.java.utils.CommonRequestGeneratorUtils;
 import com.spectralogic.ds3autogen.utils.collections.GuavaCollectors;
 
 import static com.spectralogic.ds3autogen.java.utils.CommonRequestGeneratorUtils.argsToQueryParams;
+import static com.spectralogic.ds3autogen.java.utils.CommonRequestGeneratorUtils.toConstructorParams;
+import static com.spectralogic.ds3autogen.java.utils.CommonRequestGeneratorUtils.toPreconditions;
 import static com.spectralogic.ds3autogen.java.utils.JavaDocGenerator.toConstructorDocs;
 import static com.spectralogic.ds3autogen.utils.Helper.removeVoidArguments;
 import static com.spectralogic.ds3autogen.utils.RequestConverterUtil.getRequiredArgsFromRequestHeader;
@@ -146,12 +150,17 @@ public class CreateObjectRequestGenerator extends BaseRequestGenerator {
                 .map(Arguments::getName)
                 .collect(GuavaCollectors.immutableList());
 
+        final ImmutableList<ConstructorParam> constructorParams = toConstructorParams(updatedArgs);
+
+        final ImmutableList<Precondition> preconditions = toPreconditions(constructorParams);
+
         return new RequestConstructor(
                 true,
                 additionalLines,
-                updatedArgs,
+                constructorParams,
                 updatedArgs,
                 ImmutableList.of(),
+                preconditions,
                 toConstructorDocs(requestName, argNames, docSpec, 1));
     }
 }

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/requestmodels/GetObjectRequestGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/requestmodels/GetObjectRequestGenerator.java
@@ -20,15 +20,13 @@ import com.spectralogic.ds3autogen.api.models.Arguments;
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3Request;
 import com.spectralogic.ds3autogen.api.models.docspec.Ds3DocSpec;
 import com.spectralogic.ds3autogen.api.models.enums.Classification;
-import com.spectralogic.ds3autogen.java.models.QueryParam;
-import com.spectralogic.ds3autogen.java.models.RequestConstructor;
-import com.spectralogic.ds3autogen.java.models.Variable;
+import com.spectralogic.ds3autogen.java.models.*;
 import com.spectralogic.ds3autogen.utils.collections.GuavaCollectors;
 
 import static com.spectralogic.ds3autogen.java.utils.CommonRequestGeneratorUtils.argsToQueryParams;
+import static com.spectralogic.ds3autogen.java.utils.CommonRequestGeneratorUtils.toConstructorParams;
+import static com.spectralogic.ds3autogen.java.utils.CommonRequestGeneratorUtils.toPreconditions;
 import static com.spectralogic.ds3autogen.java.utils.JavaDocGenerator.toConstructorDocs;
-import static com.spectralogic.ds3autogen.utils.Helper.removeVoidArguments;
-import static com.spectralogic.ds3autogen.utils.RequestConverterUtil.getRequiredArgsFromRequestHeader;
 
 public class GetObjectRequestGenerator extends BaseRequestGenerator {
 
@@ -111,12 +109,17 @@ public class GetObjectRequestGenerator extends BaseRequestGenerator {
                 .map(Arguments::getName)
                 .collect(GuavaCollectors.immutableList());
 
+        final ImmutableList<ConstructorParam> constructorParams = toConstructorParams(updatedConstructorArgs);
+
+        final ImmutableList<Precondition> preconditions = toPreconditions(constructorParams);
+
         return new RequestConstructor(
                 true,
                 ImmutableList.of(),
-                updatedConstructorArgs,
+                constructorParams,
                 updatedConstructorArgs,
                 queryParams,
+                preconditions,
                 toConstructorDocs(requestName, argNames, docSpec, 1));
     }
 
@@ -144,10 +147,15 @@ public class GetObjectRequestGenerator extends BaseRequestGenerator {
                 .map(Arguments::getName)
                 .collect(GuavaCollectors.immutableList());
 
+        final ImmutableList<ConstructorParam> constructorParams = toConstructorParams(updatedConstructorArgs);
+
+        final ImmutableList<Precondition> preconditions = toPreconditions(constructorParams);
+
         return new RequestConstructor(
-                updatedConstructorArgs,
+                constructorParams,
                 updatedConstructorArgs,
                 queryParamsBuilder.build(),
+                preconditions,
                 toConstructorDocs(requestName, argNames, docSpec, 1));
     }
 
@@ -181,12 +189,17 @@ public class GetObjectRequestGenerator extends BaseRequestGenerator {
 
         final ImmutableList<String> additionalLines = ImmutableList.of("this.channel = Channels.newChannel(stream);");
 
+        final ImmutableList<ConstructorParam> constructorParams = toConstructorParams(updatedConstructorArgs);
+
+        final ImmutableList<Precondition> preconditions = toPreconditions(constructorParams);
+
         return new RequestConstructor(
                 false,
                 additionalLines,
-                updatedConstructorArgs,
+                constructorParams,
                 assignmentsBuilder.build(),
                 queryParamsBuilder.build(),
+                preconditions,
                 toConstructorDocs(requestName, argNames, docSpec, 1));
     }
 }

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/requestmodels/MultiFileDeleteRequestGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/requestmodels/MultiFileDeleteRequestGenerator.java
@@ -19,10 +19,14 @@ import com.google.common.collect.ImmutableList;
 import com.spectralogic.ds3autogen.api.models.Arguments;
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3Request;
 import com.spectralogic.ds3autogen.api.models.docspec.Ds3DocSpec;
+import com.spectralogic.ds3autogen.java.models.ConstructorParam;
+import com.spectralogic.ds3autogen.java.models.Precondition;
 import com.spectralogic.ds3autogen.java.models.QueryParam;
 import com.spectralogic.ds3autogen.java.models.RequestConstructor;
 import com.spectralogic.ds3autogen.utils.collections.GuavaCollectors;
 
+import static com.spectralogic.ds3autogen.java.utils.CommonRequestGeneratorUtils.toConstructorParams;
+import static com.spectralogic.ds3autogen.java.utils.CommonRequestGeneratorUtils.toPreconditions;
 import static com.spectralogic.ds3autogen.java.utils.JavaDocGenerator.toConstructorDocs;
 import static com.spectralogic.ds3autogen.utils.ConverterUtil.hasContent;
 
@@ -64,10 +68,15 @@ public class MultiFileDeleteRequestGenerator extends BaseRequestGenerator {
                 .map(Arguments::getName)
                 .collect(GuavaCollectors.immutableList());
 
+        final ImmutableList<ConstructorParam> constructorParams = toConstructorParams(updatedArgs);
+
+        final ImmutableList<Precondition> preconditions = toPreconditions(constructorParams);
+
         return new RequestConstructor(
-                updatedArgs,
+                constructorParams,
                 updatedArgs,
                 queryParams,
+                preconditions,
                 toConstructorDocs(requestName, argNames, docSpec, 1));
     }
 
@@ -96,12 +105,17 @@ public class MultiFileDeleteRequestGenerator extends BaseRequestGenerator {
                 .map(Arguments::getName)
                 .collect(GuavaCollectors.immutableList());
 
+        final ImmutableList<ConstructorParam> constructorParams = toConstructorParams(builder.build());
+
+        final ImmutableList<Precondition> preconditions = toPreconditions(constructorParams);
+
         return new RequestConstructor(
                 false,
                 additionalLines,
-                builder.build(),
+                constructorParams,
                 constructorArgs,
                 queryParams,
+                preconditions,
                 toConstructorDocs(requestName, argNames, docSpec, 1));
     }
 }

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/requestmodels/NotificationRequestGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/requestmodels/NotificationRequestGenerator.java
@@ -20,9 +20,13 @@ import com.google.common.collect.ImmutableSet;
 import com.spectralogic.ds3autogen.api.models.Arguments;
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3Request;
 import com.spectralogic.ds3autogen.api.models.docspec.Ds3DocSpec;
+import com.spectralogic.ds3autogen.java.models.ConstructorParam;
+import com.spectralogic.ds3autogen.java.models.Precondition;
 import com.spectralogic.ds3autogen.java.models.RequestConstructor;
 import com.spectralogic.ds3autogen.utils.collections.GuavaCollectors;
 
+import static com.spectralogic.ds3autogen.java.utils.CommonRequestGeneratorUtils.toConstructorParams;
+import static com.spectralogic.ds3autogen.java.utils.CommonRequestGeneratorUtils.toPreconditions;
 import static com.spectralogic.ds3autogen.java.utils.JavaDocGenerator.toConstructorDocs;
 import static com.spectralogic.ds3autogen.utils.Ds3RequestClassificationUtil.isDeleteNotificationRequest;
 import static com.spectralogic.ds3autogen.utils.Ds3RequestClassificationUtil.isGetNotificationRequest;
@@ -54,13 +58,17 @@ public class NotificationRequestGenerator extends BaseRequestGenerator {
     @Override
     public ImmutableList<String> getAllImports(
             final Ds3Request ds3Request,
-            final String packageName) {
+            final String packageName,
+            final ImmutableList<RequestConstructor> constructors) {
         final ImmutableSet.Builder<String> builder = ImmutableSet.builder();
 
         builder.add(getParentImport(ds3Request));
         builder.addAll(getImportsFromParamList(ds3Request.getRequiredQueryParams()));
         builder.addAll(getImportsFromParamList(ds3Request.getOptionalQueryParams()));
         builder.add("java.util.UUID");
+
+        builder.addAll(annotationImports(constructors));
+        builder.addAll(preconditionImports(constructors));
 
         return builder.build().asList();
     }
@@ -84,10 +92,15 @@ public class NotificationRequestGenerator extends BaseRequestGenerator {
                 .map(Arguments::getName)
                 .collect(GuavaCollectors.immutableList());
 
+        final ImmutableList<ConstructorParam> constructorParams = toConstructorParams(builder.build());
+
+        final ImmutableList<Precondition> preconditions = toPreconditions(constructorParams);
+
         final RequestConstructor constructor = new RequestConstructor(
-                builder.build(),
+                constructorParams,
                 constructorArgs,
                 toQueryParamsList(ds3Request),
+                preconditions,
                 toConstructorDocs(requestName, argNames, docSpec, 1));
 
         return ImmutableList.of(constructor);

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/requestmodels/RequestGeneratorUtils.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/requestmodels/RequestGeneratorUtils.java
@@ -35,7 +35,7 @@ public interface RequestGeneratorUtils {
      * Gets all the required imports that the Request will need in order to properly
      * generate the Java request code
      */
-    ImmutableList<String> getAllImports(final Ds3Request ds3Request, final String packageName);
+    ImmutableList<String> getAllImports(final Ds3Request ds3Request, final String packageName, final ImmutableList<RequestConstructor> constructors);
 
     /**
      * Returns the import for the parent class for the request

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/requestmodels/StreamRequestPayloadGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/requestmodels/StreamRequestPayloadGenerator.java
@@ -23,13 +23,11 @@ import com.spectralogic.ds3autogen.api.models.docspec.Ds3DocSpec;
 import com.spectralogic.ds3autogen.java.models.QueryParam;
 import com.spectralogic.ds3autogen.java.models.RequestConstructor;
 import com.spectralogic.ds3autogen.java.models.Variable;
-import com.spectralogic.ds3autogen.utils.RequestConverterUtil;
 
 import static com.spectralogic.ds3autogen.java.utils.CommonRequestGeneratorUtils.createChannelConstructor;
 import static com.spectralogic.ds3autogen.java.utils.CommonRequestGeneratorUtils.createInputStreamConstructor;
 import static com.spectralogic.ds3autogen.utils.Helper.removeVoidArguments;
 import static com.spectralogic.ds3autogen.utils.RequestConverterUtil.getRequiredArgsFromRequestHeader;
-import static com.spectralogic.ds3autogen.utils.RequestConverterUtil.isResourceAnArg;
 
 /**
  * Used to generate requests that have a payload which is specified by either
@@ -79,19 +77,12 @@ public class StreamRequestPayloadGenerator extends BaseRequestGenerator {
     @Override
     public ImmutableList<String> getAllImports(
             final Ds3Request ds3Request,
-            final String packageName) {
+            final String packageName,
+            final ImmutableList<RequestConstructor> constructors) {
         final ImmutableSet.Builder<String> builder = ImmutableSet.builder();
 
-        builder.add(getParentImport(ds3Request));
-        builder.addAll(getImportsFromParamList(ds3Request.getRequiredQueryParams()));
-        builder.addAll(getImportsFromParamList(ds3Request.getOptionalQueryParams()));
+        builder.addAll(commonImports(ds3Request, constructors));
 
-        if (isResourceAnArg(ds3Request.getResource(), ds3Request.getIncludeInPath())) {
-            if (RequestConverterUtil.isResourceId(ds3Request.getResource())) {
-                builder.add("java.util.UUID");
-            }
-            builder.add("com.google.common.net.UrlEscapers");
-        }
         builder.add("com.spectralogic.ds3client.utils.SeekableByteChannelInputStream");
         builder.add("java.nio.channels.SeekableByteChannel");
         builder.add("java.io.InputStream");

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/helpers/JavaHelper.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/helpers/JavaHelper.java
@@ -18,12 +18,10 @@ package com.spectralogic.ds3autogen.java.helpers;
 import com.google.common.collect.ImmutableList;
 import com.spectralogic.ds3autogen.api.models.Arguments;
 import com.spectralogic.ds3autogen.api.models.enums.Operation;
-import com.spectralogic.ds3autogen.java.models.AnnotationInfo;
-import com.spectralogic.ds3autogen.java.models.Element;
-import com.spectralogic.ds3autogen.java.models.EnumConstant;
-import com.spectralogic.ds3autogen.java.models.Variable;
+import com.spectralogic.ds3autogen.java.models.*;
 import com.spectralogic.ds3autogen.java.utils.ResponseAndParserUtils;
 import com.spectralogic.ds3autogen.utils.collections.GuavaCollectors;
+import com.spectralogic.ds3autogen.utils.comparators.CustomArgumentComparator;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -131,18 +129,16 @@ public final class JavaHelper {
     }
 
     /**
-     * Creates a comma separated parameter list from a list of Arguments.
+     * Creates a comma separated parameter list from a list of ConstructorParams.
      * Used for building Java constructors.
-     * @param requiredArguments List of Arguments
-     * @return Comma separated list of function parameters
      */
-    public static String constructorArgs(final ImmutableList<Arguments> requiredArguments) {
-        if (isEmpty(requiredArguments)) {
+    public static String constructorArgs(final ImmutableList<ConstructorParam> constructorParams) {
+        if (isEmpty(constructorParams)) {
             return "";
         }
-        return sortConstructorArgs(requiredArguments)
-                .stream()
-                .map(i -> "final " + getType(i) + " " + uncapFirst(i.getName()))
+        return constructorParams.stream()
+                .sorted(new CustomArgumentComparator())
+                .map(ConstructorParam::toJavaCode)
                 .collect(Collectors.joining(", "));
     }
 

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/RequestConstructor.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/RequestConstructor.java
@@ -21,7 +21,7 @@ import com.spectralogic.ds3autogen.api.models.Arguments;
 public class RequestConstructor {
 
     /** Constructor parameters */
-    private final ImmutableList<Arguments> parameters;
+    private final ImmutableList<ConstructorParam> parameters;
 
     /** Parameters that are assigned to self within constructor */
     private final ImmutableList<Arguments> assignments;
@@ -34,33 +34,39 @@ public class RequestConstructor {
 
     private final String documentation;
 
+    private final ImmutableList<Precondition> preconditions;
+
     public RequestConstructor(
-            final ImmutableList<Arguments> parameters,
+            final ImmutableList<ConstructorParam> parameters,
             final ImmutableList<Arguments> assignments,
             final ImmutableList<QueryParam> queryParams,
+            final ImmutableList<Precondition> preconditions,
             final String documentation) {
         this.parameters = parameters;
         this.assignments = assignments;
         this.queryParams = queryParams;
+        this.preconditions = preconditions;
         this.documentation = documentation;
     }
 
     public RequestConstructor(
             final boolean isDeprecated,
             final ImmutableList<String> additionalLines,
-            final ImmutableList<Arguments> parameters,
+            final ImmutableList<ConstructorParam> parameters,
             final ImmutableList<Arguments> assignments,
             final ImmutableList<QueryParam> queryParams,
+            final ImmutableList<Precondition> preconditions,
             final String documentation) {
         this.isDeprecated = isDeprecated;
         this.additionalLines = additionalLines;
         this.parameters = parameters;
         this.assignments = assignments;
         this.queryParams = queryParams;
+        this.preconditions = preconditions;
         this.documentation = documentation;
     }
 
-    public ImmutableList<Arguments> getParameters() {
+    public ImmutableList<ConstructorParam> getParameters() {
         return parameters;
     }
 
@@ -82,5 +88,9 @@ public class RequestConstructor {
 
     public String getDocumentation() {
         return documentation;
+    }
+
+    public ImmutableList<Precondition> getPreconditions() {
+        return preconditions;
     }
 }

--- a/ds3-autogen-java/src/main/kotlin/com/spectralogic/ds3autogen/java/models/ConstructorParam.kt
+++ b/ds3-autogen-java/src/main/kotlin/com/spectralogic/ds3autogen/java/models/ConstructorParam.kt
@@ -1,0 +1,45 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.java.models
+
+import com.spectralogic.ds3autogen.api.models.Arguments
+import com.spectralogic.ds3autogen.utils.ConverterUtil.hasContent
+
+open class ConstructorParam(
+        name: String,
+        type: String,
+        val annotation: String) : Arguments(type, name) {
+
+    /**
+     * Converts the param into a java constructor parameter with an optional annotation.
+     */
+    fun toJavaCode(): String {
+        if (hasContent(annotation)) {
+            return "@$annotation final $type " + name.decapitalize()
+        }
+        return "final $type " + name.decapitalize()
+    }
+}
+
+/**
+ * Represents a simple constructor parameter with no annotations
+ */
+class SimpleConstructorParam(name: String, type: String) : ConstructorParam(name, type, "")
+
+/**
+ * Represents a constructor parameter with the Nonnull annotation
+ */
+class NonnullConstructorParam(name: String, type: String) : ConstructorParam(name, type, "Nonnull")

--- a/ds3-autogen-java/src/main/kotlin/com/spectralogic/ds3autogen/java/models/Precondition.kt
+++ b/ds3-autogen-java/src/main/kotlin/com/spectralogic/ds3autogen/java/models/Precondition.kt
@@ -13,13 +13,23 @@
  * ****************************************************************************
  */
 
-apply plugin: 'kotlin'
+package com.spectralogic.ds3autogen.java.models
 
-dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    compile project(':ds3-autogen-api')
-    compile project(':ds3-autogen-utils')
-    testCompile project(':ds3-autogen-parser')
-    compile     'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.5.3'
-    compile     'com.fasterxml.jackson.datatype:jackson-datatype-guava:2.5.0'
+/**
+ * Represents a Java precondition. Used to perform certain input validation
+ * in Java request handler constructors.
+ */
+interface Precondition {
+    fun toJavaCode(): String
+}
+
+/**
+ * Represents a precondition check that a given parameter is not null.
+ */
+data class NotNullPrecondition(val name: String) : Precondition {
+
+    override fun toJavaCode(): String {
+        val paramName = name.decapitalize()
+        return "Preconditions.checkNotNull($paramName, \"$name may not be null.\");"
+    }
 }

--- a/ds3-autogen-java/src/main/kotlin/com/spectralogic/ds3autogen/java/models/Precondition.kt
+++ b/ds3-autogen-java/src/main/kotlin/com/spectralogic/ds3autogen/java/models/Precondition.kt
@@ -26,7 +26,7 @@ interface Precondition {
 /**
  * Represents a precondition check that a given parameter is not null.
  */
-data class NotNullPrecondition(val name: String) : Precondition {
+data class NotNullPrecondition(private val name: String) : Precondition {
 
     override fun toJavaCode(): String {
         val paramName = name.decapitalize()

--- a/ds3-autogen-java/src/main/resources/tmpls/java/request/bulk_request_template.ftl
+++ b/ds3-autogen-java/src/main/resources/tmpls/java/request/bulk_request_template.ftl
@@ -20,6 +20,9 @@ public class ${name} extends ${parentClass} {
     ${constructor.documentation}
     public ${name}(${javaHelper.constructorArgs(constructor.getParameters())}) {
         super(bucketName, objects);
+        <#list constructor.getPreconditions() as precondition>
+        ${precondition.toJavaCode()}
+        </#list>
         <#list constructor.getAssignments() as arg>
         this.${arg.getName()?uncap_first} = ${javaHelper.paramAssignmentRHS(arg)};
         </#list>

--- a/ds3-autogen-java/src/main/resources/tmpls/java/request/common/constructor.ftl
+++ b/ds3-autogen-java/src/main/resources/tmpls/java/request/common/constructor.ftl
@@ -1,6 +1,9 @@
     <#list constructors as constructor>
     ${constructor.documentation}
     public ${name}(${javaHelper.constructorArgs(constructor.getParameters())}) {
+        <#list constructor.getPreconditions() as precondition>
+        ${precondition.toJavaCode()}
+        </#list>
         <#list constructor.getAssignments() as arg>
         this.${arg.getName()?uncap_first} = ${javaHelper.paramAssignmentRHS(arg)};
         </#list>

--- a/ds3-autogen-java/src/main/resources/tmpls/java/request/create_notification_request_template.ftl
+++ b/ds3-autogen-java/src/main/resources/tmpls/java/request/create_notification_request_template.ftl
@@ -13,7 +13,9 @@ public class ${name} extends ${parentClass} {
     ${constructor.documentation}
     public ${name}(${javaHelper.constructorArgs(constructor.getParameters())}) {
         super(notificationEndPoint);
-
+        <#list constructor.getPreconditions() as precondition>
+        ${precondition.toJavaCode()}
+        </#list>
         <#list constructor.getAssignments() as arg>
         this.${arg.getName()?uncap_first} = ${arg.getName()?uncap_first};
         </#list>

--- a/ds3-autogen-java/src/main/resources/tmpls/java/request/create_object_template.ftl
+++ b/ds3-autogen-java/src/main/resources/tmpls/java/request/create_object_template.ftl
@@ -32,6 +32,9 @@ public class ${name} extends ${parentClass} {
     @Deprecated
     </#if>
     public ${name}(${javaHelper.constructorArgs(constructor.getParameters())}) {
+        <#list constructor.getPreconditions() as precondition>
+        ${precondition.toJavaCode()}
+        </#list>
         <#list constructor.getAssignments() as arg>
         this.${arg.getName()?uncap_first} = ${javaHelper.paramAssignmentRHS(arg)};
         </#list>

--- a/ds3-autogen-java/src/main/resources/tmpls/java/request/get_object_template.ftl
+++ b/ds3-autogen-java/src/main/resources/tmpls/java/request/get_object_template.ftl
@@ -31,6 +31,9 @@ public class ${name} extends ${parentClass} {
     @Deprecated
     </#if>
     public ${name}(${javaHelper.constructorArgs(constructor.getParameters())}) {
+        <#list constructor.getPreconditions() as precondition>
+        ${precondition.toJavaCode()}
+        </#list>
         <#list constructor.getAssignments() as arg>
         this.${arg.getName()?uncap_first} = ${javaHelper.paramAssignmentRHS(arg)};
         </#list>

--- a/ds3-autogen-java/src/main/resources/tmpls/java/request/ids_request_payload_template.ftl
+++ b/ds3-autogen-java/src/main/resources/tmpls/java/request/ids_request_payload_template.ftl
@@ -17,6 +17,9 @@ public class ${name} extends ${parentClass} {
     ${constructor.documentation}
     public ${name}(final List<String> ids) {
         super(ids);
+        <#list constructor.getPreconditions() as precondition>
+        ${precondition.toJavaCode()}
+        </#list>
         <#list constructor.getAssignments() as arg>
         this.${arg.getName()?uncap_first} = ${javaHelper.paramAssignmentRHS(arg)};
         </#list>

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaFunctionalTests.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaFunctionalTests.java
@@ -24,6 +24,9 @@ import com.spectralogic.ds3autogen.api.models.Arguments;
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3ApiSpec;
 import com.spectralogic.ds3autogen.api.models.enums.Operation;
 import com.spectralogic.ds3autogen.docspec.Ds3DocSpecEmptyImpl;
+import com.spectralogic.ds3autogen.java.models.ConstructorParam;
+import com.spectralogic.ds3autogen.java.models.NonnullConstructorParam;
+import com.spectralogic.ds3autogen.java.models.SimpleConstructorParam;
 import com.spectralogic.ds3autogen.java.models.parseresponse.BaseParseResponse;
 import com.spectralogic.ds3autogen.java.models.parseresponse.EmptyParseResponse;
 import com.spectralogic.ds3autogen.java.models.parseresponse.NullParseResponse;
@@ -43,6 +46,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.nio.file.Paths;
 
+import static com.spectralogic.ds3autogen.java.generators.requestmodels.BaseRequestGenerator.modifyConstructorParamTypes;
 import static com.spectralogic.ds3autogen.java.test.helpers.JavaCodeGeneratorTestHelper.*;
 import static com.spectralogic.ds3autogen.java.utils.TestHelper.*;
 import static com.spectralogic.ds3autogen.utils.ArgumentsUtil.modifyType;
@@ -1088,31 +1092,33 @@ public class JavaFunctionalTests {
         assertTrue(hasCopyright(requestGeneratedCode));
         assertTrue(hasPath("\"/\" + this.bucketName + \"/\" + this.objectName", requestGeneratedCode));
 
-        final ImmutableList<Arguments> commonConstructorArgs = ImmutableList.of(
-                new Arguments("String", "BucketName"),
-                new Arguments("String", "ObjectName"),
-                new Arguments("long", "Size"));
+        final ImmutableList<ConstructorParam> commonConstructorArgs = ImmutableList.of(
+                new SimpleConstructorParam("BucketName", "String"),
+                new SimpleConstructorParam("ObjectName", "String"),
+                new SimpleConstructorParam("Size", "long"));
 
-        final ImmutableList.Builder<Arguments> deprecatedBuilder = ImmutableList.builder();
+        final ImmutableList.Builder<ConstructorParam> deprecatedBuilder = ImmutableList.builder();
         deprecatedBuilder.addAll(commonConstructorArgs);
-        deprecatedBuilder.add(new Arguments("SeekableByteChannel", "Channel"));
-        assertTrue(hasConstructor(requestName, deprecatedBuilder.build(), requestGeneratedCode));
+        deprecatedBuilder.add(new NonnullConstructorParam("Channel", "SeekableByteChannel"));
+        assertTrue(hasConstructorWithAnnotations(requestName, deprecatedBuilder.build(), requestGeneratedCode));
 
-        final ImmutableList.Builder<Arguments> channelBuilder = ImmutableList.builder();
+        final ImmutableList.Builder<ConstructorParam> channelBuilder = ImmutableList.builder();
         channelBuilder.addAll(commonConstructorArgs);
-        channelBuilder.add(new Arguments("UUID", "Job"));
-        channelBuilder.add(new Arguments("long", "Offset"));
-        channelBuilder.add(new Arguments("SeekableByteChannel", "Channel"));
-        assertTrue(hasConstructor(requestName, channelBuilder.build(), requestGeneratedCode));
-        assertTrue(hasConstructor(requestName, modifyType(channelBuilder.build(), "UUID", "String"), requestGeneratedCode));
+        channelBuilder.add(new SimpleConstructorParam("Job", "UUID"));
+        channelBuilder.add(new SimpleConstructorParam("Offset", "long"));
+        channelBuilder.add(new NonnullConstructorParam("Channel", "SeekableByteChannel"));
+        assertTrue(hasConstructorWithAnnotations(requestName, channelBuilder.build(), requestGeneratedCode));
+        assertTrue(hasConstructorWithAnnotations(requestName,
+                modifyConstructorParamTypes(channelBuilder.build(), "UUID", "String"), requestGeneratedCode));
 
-        final ImmutableList.Builder<Arguments> streamBuilder = ImmutableList.builder();
+        final ImmutableList.Builder<ConstructorParam> streamBuilder = ImmutableList.builder();
         streamBuilder.addAll(commonConstructorArgs);
-        streamBuilder.add(new Arguments("UUID", "Job"));
-        streamBuilder.add(new Arguments("long", "Offset"));
-        streamBuilder.add(new Arguments("InputStream", "Stream"));
-        assertTrue(hasConstructor(requestName, streamBuilder.build(), requestGeneratedCode));
-        assertTrue(hasConstructor(requestName, modifyType(streamBuilder.build(), "UUID", "String"), requestGeneratedCode));
+        streamBuilder.add(new SimpleConstructorParam("Job", "UUID"));
+        streamBuilder.add(new SimpleConstructorParam("Offset", "long"));
+        streamBuilder.add(new NonnullConstructorParam("Stream", "InputStream"));
+        assertTrue(hasConstructorWithAnnotations(requestName, streamBuilder.build(), requestGeneratedCode));
+        assertTrue(hasConstructorWithAnnotations(requestName,
+                modifyConstructorParamTypes(streamBuilder.build(), "UUID", "String"), requestGeneratedCode));
 
         //Test the generated response
         final String responseGeneratedCode = testGeneratedCode.getResponseGeneratedCode();
@@ -1190,27 +1196,29 @@ public class JavaFunctionalTests {
         assertTrue(hasCopyright(requestGeneratedCode));
         assertTrue(hasPath("\"/\" + this.bucketName + \"/\" + this.objectName", requestGeneratedCode));
 
-        final ImmutableList<Arguments> constructorArgs = ImmutableList.of(
-                new Arguments("String", "BucketName"),
-                new Arguments("String", "ObjectName"),
-                new Arguments("WritableByteChannel", "Channel"));
-        assertTrue(hasConstructor(requestName, constructorArgs, requestGeneratedCode));
+        final ImmutableList<ConstructorParam> constructorArgs = ImmutableList.of(
+                new SimpleConstructorParam("BucketName", "String"),
+                new SimpleConstructorParam("ObjectName", "String"),
+                new NonnullConstructorParam("Channel", "WritableByteChannel"));
+        assertTrue(hasConstructorWithAnnotations(requestName, constructorArgs, requestGeneratedCode));
 
-        final ImmutableList.Builder<Arguments> builder = ImmutableList.builder();
+        final ImmutableList.Builder<ConstructorParam> builder = ImmutableList.builder();
         builder.addAll(constructorArgs);
-        builder.add(new Arguments("UUID", "Job"));
-        builder.add(new Arguments("long", "Offset"));
-        assertTrue(hasConstructor(requestName, builder.build(), requestGeneratedCode));
-        assertTrue(hasConstructor(requestName, modifyType(builder.build(), "UUID", "String"), requestGeneratedCode));
+        builder.add(new SimpleConstructorParam("Job", "UUID"));
+        builder.add(new SimpleConstructorParam("Offset", "long"));
+        assertTrue(hasConstructorWithAnnotations(requestName, builder.build(), requestGeneratedCode));
+        assertTrue(hasConstructorWithAnnotations(requestName,
+                modifyConstructorParamTypes(builder.build(), "UUID", "String"), requestGeneratedCode));
 
-        final ImmutableList<Arguments> streamConstructorArgs = ImmutableList.of(
-                new Arguments("String", "BucketName"),
-                new Arguments("String", "ObjectName"),
-                new Arguments("OutputStream", "Stream"),
-                new Arguments("UUID", "Job"),
-                new Arguments("long", "Offset"));
-        assertTrue(hasConstructor(requestName, streamConstructorArgs, requestGeneratedCode));
-        assertTrue(hasConstructor(requestName, modifyType(streamConstructorArgs, "UUID", "String"), requestGeneratedCode));
+        final ImmutableList<ConstructorParam> streamConstructorArgs = ImmutableList.of(
+                new SimpleConstructorParam("BucketName", "String"),
+                new SimpleConstructorParam("ObjectName", "String"),
+                new NonnullConstructorParam("Stream", "OutputStream"),
+                new SimpleConstructorParam("Job", "UUID"),
+                new SimpleConstructorParam("Offset", "long"));
+        assertTrue(hasConstructorWithAnnotations(requestName, streamConstructorArgs, requestGeneratedCode));
+        assertTrue(hasConstructorWithAnnotations(requestName,
+                modifyConstructorParamTypes(streamConstructorArgs, "UUID", "String"), requestGeneratedCode));
 
         assertTrue(requestGeneratedCode.contains("this.updateQueryParam(\"job\", job)"));
         assertTrue(requestGeneratedCode.contains("this.updateQueryParam(\"offset\", offset)"));
@@ -2414,24 +2422,26 @@ public class JavaFunctionalTests {
         assertTrue(doesNotHaveOperation(requestGeneratedCode));
         assertTrue(hasPath("\"/\" + this.bucketName + \"/\" + this.objectName", requestGeneratedCode));
 
-        final ImmutableList.Builder<Arguments> builder = ImmutableList.builder();
-        builder.add(new Arguments("String", "BucketName"));
-        builder.add(new Arguments("String", "ObjectName"));
-        builder.add(new Arguments("int", "PartNumber"));
-        builder.add(new Arguments("long", "Size"));
-        builder.add(new Arguments("UUID", "UploadId"));
+        final ImmutableList.Builder<ConstructorParam> builder = ImmutableList.builder();
+        builder.add(new SimpleConstructorParam("BucketName", "String"));
+        builder.add(new SimpleConstructorParam("ObjectName", "String"));
+        builder.add(new SimpleConstructorParam("PartNumber", "int"));
+        builder.add(new SimpleConstructorParam("Size", "long"));
+        builder.add(new SimpleConstructorParam("UploadId", "UUID"));
 
-        final ImmutableList.Builder<Arguments> channelBuilder = ImmutableList.builder();
+        final ImmutableList.Builder<ConstructorParam> channelBuilder = ImmutableList.builder();
         channelBuilder.addAll(builder.build());
-        channelBuilder.add(new Arguments("SeekableByteChannel", "Channel"));
-        assertTrue(hasConstructor(requestName, channelBuilder.build(), requestGeneratedCode));
-        assertTrue(hasConstructor(requestName, modifyType(channelBuilder.build(), "UUID", "String"), requestGeneratedCode));
+        channelBuilder.add(new NonnullConstructorParam("Channel", "SeekableByteChannel"));
+        assertTrue(hasConstructorWithAnnotations(requestName, channelBuilder.build(), requestGeneratedCode));
+        assertTrue(hasConstructorWithAnnotations(requestName,
+                modifyConstructorParamTypes(channelBuilder.build(), "UUID", "String"), requestGeneratedCode));
 
-        final ImmutableList.Builder<Arguments> streamBuilder = ImmutableList.builder();
+        final ImmutableList.Builder<ConstructorParam> streamBuilder = ImmutableList.builder();
         streamBuilder.addAll(builder.build());
-        streamBuilder.add(new Arguments("InputStream", "Stream"));
-        assertTrue(hasConstructor(requestName, channelBuilder.build(), requestGeneratedCode));
-        assertTrue(hasConstructor(requestName, modifyType(channelBuilder.build(), "UUID", "String"), requestGeneratedCode));
+        streamBuilder.add(new NonnullConstructorParam("Stream", "InputStream"));
+        assertTrue(hasConstructorWithAnnotations(requestName, channelBuilder.build(), requestGeneratedCode));
+        assertTrue(hasConstructorWithAnnotations(requestName,
+                modifyConstructorParamTypes(channelBuilder.build(), "UUID", "String"), requestGeneratedCode));
 
         //Test the generated response
         final String responseGeneratedCode = testGeneratedCode.getResponseGeneratedCode();

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/requestmodels/BaseRequestGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/requestmodels/BaseRequestGenerator_Test.java
@@ -23,7 +23,6 @@ import com.spectralogic.ds3autogen.api.models.apispec.Ds3Request;
 import com.spectralogic.ds3autogen.api.models.enums.*;
 import com.spectralogic.ds3autogen.docspec.Ds3DocSpecEmptyImpl;
 import com.spectralogic.ds3autogen.java.models.*;
-import com.spectralogic.ds3autogen.utils.collections.GuavaCollectors;
 import org.junit.Test;
 
 import static com.spectralogic.ds3autogen.java.generators.requestmodels.BaseRequestGenerator.*;
@@ -33,21 +32,15 @@ import static com.spectralogic.ds3autogen.java.utils.CommonRequestGeneratorUtils
 import static com.spectralogic.ds3autogen.testutil.Ds3ModelFixtures.*;
 import static com.spectralogic.ds3autogen.testutil.Ds3ModelPartialDataFixture.createDs3RequestTestData;
 import static com.spectralogic.ds3autogen.testutil.Ds3ModelPartialDataFixture.createEmptyDs3Request;
-import static com.spectralogic.ds3autogen.utils.ArgumentsUtil.getAllArgumentTypes;
-import static org.hamcrest.CoreMatchers.hasItem;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 public class BaseRequestGenerator_Test {
 
     private final static BaseRequestGenerator generator = new BaseRequestGenerator();
-
-    private static ImmutableList<String> getQueryParamTypes(final ImmutableList<QueryParam> params) {
-        return params.stream()
-                .map(QueryParam::getType)
-                .collect(GuavaCollectors.immutableList());
-    }
 
     private static final ImmutableList<Arguments> SIMPLE_ARGS = ImmutableList.of(
             new Arguments("String", "StringArg"),
@@ -353,12 +346,14 @@ public class BaseRequestGenerator_Test {
                 "com.spectralogic.ds3client.commands.spectrads3",
                 generator.toConstructorList(request, "", new Ds3DocSpecEmptyImpl()));
 
-        assertThat(result.size(), is(5));
-        assertTrue(result.contains("com.spectralogic.ds3client.commands.interfaces.AbstractRequest"));
-        assertTrue(result.contains("com.spectralogic.ds3client.models.JobRequestType"));
-        assertTrue(result.contains("com.spectralogic.ds3client.models.BlobStoreTaskPriority"));
-        assertTrue(result.contains("java.util.UUID"));
-        assertTrue(result.contains("com.google.common.net.UrlEscapers"));
+        assertThat(result)
+                .hasSize(5)
+                .contains(
+                        "com.spectralogic.ds3client.commands.interfaces.AbstractRequest",
+                        "com.spectralogic.ds3client.models.JobRequestType",
+                        "com.spectralogic.ds3client.models.BlobStoreTaskPriority",
+                        "java.util.UUID",
+                        "com.google.common.net.UrlEscapers");
     }
 
     @Test
@@ -484,9 +479,9 @@ public class BaseRequestGenerator_Test {
 
         final RequestConstructor result = convertUuidConstructorToStringConstructor(constructor);
 
-        result.getParameters().forEach(param -> assertThat(param.getType(), not("UUID")));
-        assertThat(getQueryParamTypes(result.getQueryParams()), not(hasItem("UUID")));
-        assertThat(getAllArgumentTypes(result.getAssignments()), not(hasItem("UUID")));
+        assertThat(result.getParameters()).extracting(ConstructorParam::getType).doesNotContain("UUID");
+        assertThat(result.getQueryParams()).extracting(QueryParam::getType).doesNotContain("UUID");
+        assertThat(result.getAssignments()).extracting(Arguments::getType).doesNotContain("UUID");
     }
 
     @Test
@@ -502,7 +497,7 @@ public class BaseRequestGenerator_Test {
         final RequestConstructor constructor = new RequestConstructor(params, args, argsToQueryParams(args), ImmutableList.of(), "");
 
         final ImmutableList<RequestConstructor> result = splitUuidConstructor(constructor);
-        assertThat(result.size(), is(1));
+        assertThat(result).hasSize(1);
     }
 
 
@@ -513,17 +508,15 @@ public class BaseRequestGenerator_Test {
         final RequestConstructor constructor = new RequestConstructor(SIMPLE_PARAMS, SIMPLE_ARGS, argsToQueryParams(SIMPLE_ARGS), ImmutableList.of(), "");
 
         final ImmutableList<RequestConstructor> result = splitUuidConstructor(constructor);
-        assertThat(result.size(), is(2));
+        assertThat(result).hasSize(2);
 
-        assertTrue(result.get(0).getParameters().stream()
-                .anyMatch(param -> param.getType().equals("UUID")));
+        assertThat(result.get(0).getParameters()).extracting(ConstructorParam::getType).contains("UUID");
+        assertThat(result.get(0).getQueryParams()).extracting(QueryParam::getType).contains("UUID");
+        assertThat(result.get(0).getAssignments()).extracting(Arguments::getType).contains("UUID");
 
-        assertThat(getQueryParamTypes(result.get(0).getQueryParams()), hasItem("UUID"));
-        assertThat(getAllArgumentTypes(result.get(0).getAssignments()), hasItem("UUID"));
-
-        result.get(1).getParameters().forEach(param -> assertThat(param.getType(), not("UUID")));
-        assertThat(getQueryParamTypes(result.get(1).getQueryParams()), not(hasItem("UUID")));
-        assertThat(getAllArgumentTypes(result.get(1).getAssignments()), not(hasItem("UUID")));
+        assertThat(result.get(1).getParameters()).extracting(ConstructorParam::getType).doesNotContain("UUID");
+        assertThat(result.get(1).getQueryParams()).extracting(QueryParam::getType).doesNotContain("UUID");
+        assertThat(result.get(1).getAssignments()).extracting(Arguments::getType).doesNotContain("UUID");
     }
 
     @Test
@@ -531,38 +524,36 @@ public class BaseRequestGenerator_Test {
         final RequestConstructor constructor = new RequestConstructor(SIMPLE_PARAMS, SIMPLE_ARGS, argsToQueryParams(SIMPLE_ARGS), ImmutableList.of(), "");
 
         final ImmutableList<RequestConstructor> result = splitAllUuidConstructors(ImmutableList.of(constructor));
-        assertThat(result.size(), is(2));
+        assertThat(result).hasSize(2);
 
-        assertTrue(result.get(0).getParameters().stream()
-                .anyMatch(param -> param.getType().equals("UUID")));
+        assertThat(result.get(0).getParameters()).extracting(ConstructorParam::getType).contains("UUID");
+        assertThat(result.get(0).getQueryParams()).extracting(QueryParam::getType).contains("UUID");
+        assertThat(result.get(0).getAssignments()).extracting(Arguments::getType).contains("UUID");
 
-        assertThat(getQueryParamTypes(result.get(0).getQueryParams()), hasItem("UUID"));
-        assertThat(getAllArgumentTypes(result.get(0).getAssignments()), hasItem("UUID"));
-
-        result.get(1).getParameters().forEach(param -> assertThat(param.getType(), not("UUID")));
-        assertThat(getQueryParamTypes(result.get(1).getQueryParams()), not(hasItem("UUID")));
-        assertThat(getAllArgumentTypes(result.get(1).getAssignments()), not(hasItem("UUID")));
+        assertThat(result.get(1).getParameters()).extracting(ConstructorParam::getType).doesNotContain("UUID");
+        assertThat(result.get(1).getQueryParams()).extracting(QueryParam::getType).doesNotContain("UUID");
+        assertThat(result.get(1).getAssignments()).extracting(Arguments::getType).doesNotContain("UUID");
     }
 
     @Test
     public void convertUuidClassVariable_Test() {
         final Variable uuidVar = convertUuidClassVariable(new Variable("UuidVar", "UUID", true));
-        assertThat(uuidVar.getType(), is("String"));
+        assertThat(uuidVar.getType()).isEqualTo("String");
 
         final Variable intVar = convertUuidClassVariable(new Variable("IntVar", "int", true));
-        assertThat(intVar.getType(), is("int"));
+        assertThat(intVar.getType()).isEqualTo("int");
     }
 
     @Test
     public void convertAllUuidClassVariables_NullList_Test() {
         final ImmutableList<Variable> result = convertAllUuidClassVariables(null);
-        assertThat(result.size(), is(0));
+        assertThat(result).hasSize(0);
     }
 
     @Test
     public void convertAllUuidClassVariables_EmptyList_Test() {
         final ImmutableList<Variable> result = convertAllUuidClassVariables(ImmutableList.of());
-        assertThat(result.size(), is(0));
+        assertThat(result).hasSize(0);
     }
 
     @Test
@@ -574,37 +565,34 @@ public class BaseRequestGenerator_Test {
                 new Variable("Var", "Integer", true));
 
         final ImmutableList<Variable> result = convertAllUuidClassVariables(variables);
-        assertThat(result.size(), is(4));
-        for (final Variable var : result) {
-            assertThat(var.getType(), not(is("UUID")));
-        }
+        assertThat(result).hasSize(4)
+                .extracting(Variable::getType).doesNotContain("UUID");
     }
 
     @Test
     public void splitUuidOptionalArgument_UUID_Test() {
         final ImmutableList<Arguments> result = splitUuidOptionalArgument(new Arguments("UUID", "Arg"));
-        assertThat(result.size(), is(2));
-        assertThat(result.get(0).getType(), is("UUID"));
-        assertThat(result.get(1).getType(), is("String"));
+        assertThat(result).hasSize(2)
+                .extracting(Arguments::getType).containsExactly("UUID", "String");
     }
 
     @Test
     public void splitUuidOptionalArgument_Test() {
         final ImmutableList<Arguments> result = splitUuidOptionalArgument(new Arguments("Integer", "Arg"));
-        assertThat(result.size(), is(1));
-        assertThat(result.get(0).getType(), is("Integer"));
+        assertThat(result).hasSize(1)
+                .extracting(Arguments::getType).containsExactly("Integer");
     }
 
     @Test
     public void splitAllUuidOptionalArguments_NullList_Test() {
         final ImmutableList<Arguments> result = splitAllUuidOptionalArguments(null);
-        assertThat(result.size(), is(0));
+        assertThat(result).hasSize(0);
     }
 
     @Test
     public void splitAllUuidOptionalArguments_EmptyList_Test() {
         final ImmutableList<Arguments> result = splitAllUuidOptionalArguments(ImmutableList.of());
-        assertThat(result.size(), is(0));
+        assertThat(result).hasSize(0);
     }
 
     @Test
@@ -614,20 +602,16 @@ public class BaseRequestGenerator_Test {
                 new Arguments("Integer", "Var2"));
 
         final ImmutableList<Arguments> result = splitAllUuidOptionalArguments(variables);
-        assertThat(result.size(), is(3));
-        assertThat(result.get(0).getName(), is("Var1"));
-        assertThat(result.get(0).getType(), is("UUID"));
-        assertThat(result.get(1).getName(), is("Var1"));
-        assertThat(result.get(1).getType(), is("String"));
-        assertThat(result.get(2).getName(), is("Var2"));
-        assertThat(result.get(2).getType(), is("Integer"));
+        assertThat(result).hasSize(3);
+        assertThat(result).extracting(Arguments::getName).containsExactly("Var1", "Var1", "Var2");
+        assertThat(result).extracting(Arguments::getType).containsExactly("UUID", "String", "Integer");
     }
 
     @Test
     public void resourceArgToString_Test() {
-        assertThat(resourceArgToString(new Arguments("UUID", "Arg")), is("arg"));
-        assertThat(resourceArgToString(new Arguments("String", "Arg")), is("arg"));
-        assertThat(resourceArgToString(new Arguments("Integer", "Arg")), is("String.valueOf(arg)"));
+        assertThat(resourceArgToString(new Arguments("UUID", "Arg"))).isEqualTo("arg");
+        assertThat(resourceArgToString(new Arguments("String", "Arg"))).isEqualTo("arg");
+        assertThat(resourceArgToString(new Arguments("Integer", "Arg"))).isEqualTo("String.valueOf(arg)");
     }
 
     @Test
@@ -735,7 +719,7 @@ public class BaseRequestGenerator_Test {
     @Test
     public void preconditionImportsNotIncludedTest() {
         final ImmutableList<String> result = preconditionImports(ImmutableList.of(EMPTY_REQUEST_CONSTRUCTOR));
-        assertThat(result.size(), is(0));
+        assertThat(result).hasSize(0);
     }
 
     @Test
@@ -745,14 +729,14 @@ public class BaseRequestGenerator_Test {
                 REQUEST_CONSTRUCTOR_WITH_STREAM);
 
         final ImmutableList<String> result = preconditionImports(constructors);
-        assertThat(result.size(), is(1));
-        assertThat(result, hasItem("com.google.common.base.Preconditions"));
+        assertThat(result).hasSize(1)
+                .contains("com.google.common.base.Preconditions");
     }
 
     @Test
     public void annotationImportsNotIncludedTest() {
         final ImmutableList<String> result = annotationImports(ImmutableList.of(EMPTY_REQUEST_CONSTRUCTOR));
-        assertThat(result.size(), is(0));
+        assertThat(result).hasSize(0);
     }
 
     @Test
@@ -762,8 +746,7 @@ public class BaseRequestGenerator_Test {
                 REQUEST_CONSTRUCTOR_WITH_STREAM);
 
         final ImmutableList<String> result = annotationImports(constructors);
-        assertThat(result.size(), is(1));
-        assertThat(result, hasItem("javax.annotation.Nonnull"));
+        assertThat(result).hasSize(1).contains("javax.annotation.Nonnull");
     }
 
     @Test
@@ -778,9 +761,8 @@ public class BaseRequestGenerator_Test {
                 "javax.annotation.Nonnull");
 
         final ImmutableList<String> result = generator.commonImports(request, ImmutableList.of(REQUEST_CONSTRUCTOR_WITH_STREAM));
-        assertThat(result.size(), is(expected.size()));
-
-        result.forEach(item -> assertThat(expected, hasItem(item)));
+        assertThat(result).hasSize(expected.size())
+                .containsAll(expected);
     }
 
     @Test
@@ -801,13 +783,13 @@ public class BaseRequestGenerator_Test {
 
         final ImmutableList<ConstructorParam> result = modifyConstructorParamTypes(constructorParams, "UUID", "String");
 
-        assertThat(result.size(), is(expected.size()));
+        assertThat(result).hasSize(expected.size());
 
         for (int i = 0; i < expected.size(); i++) {
-            assertThat(result.get(i).getName(), is(expected.get(i).getName()));
-            assertThat(result.get(i).getType(), is(expected.get(i).getType()));
-            assertThat(result.get(i).getAnnotation(), is(expected.get(i).getAnnotation()));
-            assertThat(result.get(i).toJavaCode(), is(expected.get(i).toJavaCode()));
+            assertThat(result.get(i).getName()).isEqualTo(expected.get(i).getName());
+            assertThat(result.get(i).getType()).isEqualTo(expected.get(i).getType());
+            assertThat(result.get(i).getAnnotation()).isEqualTo(expected.get(i).getAnnotation());
+            assertThat(result.get(i).toJavaCode()).isEqualTo(expected.get(i).toJavaCode());
         }
     }
 }

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/requestmodels/BulkRequestGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/requestmodels/BulkRequestGenerator_Test.java
@@ -20,6 +20,7 @@ import com.spectralogic.ds3autogen.api.models.Arguments;
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3Param;
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3Request;
 import com.spectralogic.ds3autogen.docspec.Ds3DocSpecEmptyImpl;
+import com.spectralogic.ds3autogen.java.models.ConstructorParam;
 import com.spectralogic.ds3autogen.java.models.QueryParam;
 import com.spectralogic.ds3autogen.java.models.RequestConstructor;
 import com.spectralogic.ds3autogen.java.models.Variable;
@@ -29,6 +30,7 @@ import static com.spectralogic.ds3autogen.java.generators.requestmodels.BulkRequ
 import static com.spectralogic.ds3autogen.java.test.helpers.RequestGeneratorTestHelper.createSimpleTestDs3Request;
 import static com.spectralogic.ds3autogen.java.test.helpers.RequestGeneratorTestHelper.createTestDs3ParamList;
 import static com.spectralogic.ds3autogen.testutil.Ds3ModelPartialDataFixture.createDs3RequestTestData;
+import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -90,24 +92,20 @@ public class BulkRequestGenerator_Test {
         assertThat(constructor.getAdditionalLines().size(), is(0));
         assertThat(constructor.isDeprecated(), is(false));
 
-        final ImmutableList<Arguments> constructorParams = constructor.getParameters();
-        assertThat(constructorParams.size(), is(4));
-        assertThat(constructorParams.get(0).getName(), is("MaxUploadSize"));
-        assertThat(constructorParams.get(1).getName(), is("Name"));
-        assertThat(constructorParams.get(2).getName(), is("Priority"));
-        assertThat(constructorParams.get(3).getName(), is("Objects"));
+        final ImmutableList<ConstructorParam> constructorParams = constructor.getParameters();
+        final ImmutableList<String> expectedParams = ImmutableList.of("MaxUploadSize", "Name", "Priority", "Objects");
+        assertThat(constructorParams.size(), is(expectedParams.size()));
+        constructorParams.forEach(param -> assertThat(expectedParams, hasItem(param.getName())));
 
         final ImmutableList<Arguments> constructorAssignments = constructor.getAssignments();
-        assertThat(constructorAssignments.size(), is(2));
-        assertThat(constructorAssignments.get(0).getName(), is("MaxUploadSize"));
-        assertThat(constructorAssignments.get(1).getName(), is("Name"));
+        final ImmutableList<String> expectedAssignments = ImmutableList.of("MaxUploadSize", "Name");
+        assertThat(constructorAssignments.size(), is(expectedAssignments.size()));
+        constructorAssignments.forEach(assignment -> assertThat(expectedAssignments, hasItem(assignment.getName())));
 
         final ImmutableList<QueryParam> queryParams = constructor.getQueryParams();
-        assertThat(queryParams.size(), is(4));
-        assertThat(queryParams.get(0).getName(), is("IgnoreNamingConflicts"));
-        assertThat(queryParams.get(1).getName(), is("MaxUploadSize"));
-        assertThat(queryParams.get(2).getName(), is("Name"));
-        assertThat(queryParams.get(3).getName(), is("Priority"));
+        final ImmutableList<String> expectedQueryParams = ImmutableList.of("IgnoreNamingConflicts", "MaxUploadSize", "Name", "Priority");
+        assertThat(queryParams.size(), is(expectedQueryParams.size()));
+        queryParams.forEach(param -> assertThat(expectedQueryParams, hasItem(param.getName())));
     }
 
     @Test

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/requestmodels/CreateNotificationRequestGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/requestmodels/CreateNotificationRequestGenerator_Test.java
@@ -20,6 +20,7 @@ import com.spectralogic.ds3autogen.api.models.Arguments;
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3Param;
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3Request;
 import com.spectralogic.ds3autogen.docspec.Ds3DocSpecEmptyImpl;
+import com.spectralogic.ds3autogen.java.models.ConstructorParam;
 import com.spectralogic.ds3autogen.java.models.QueryParam;
 import com.spectralogic.ds3autogen.java.models.RequestConstructor;
 import com.spectralogic.ds3autogen.java.models.Variable;
@@ -29,6 +30,7 @@ import static com.spectralogic.ds3autogen.java.generators.requestmodels.CreateNo
 import static com.spectralogic.ds3autogen.java.test.helpers.RequestGeneratorTestHelper.createSimpleTestDs3Request;
 import static com.spectralogic.ds3autogen.java.test.helpers.RequestGeneratorTestHelper.createTestDs3ParamList;
 import static com.spectralogic.ds3autogen.testutil.Ds3ModelPartialDataFixture.createDs3RequestTestData;
+import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -112,24 +114,19 @@ public class CreateNotificationRequestGenerator_Test {
         assertThat(constructor.getAdditionalLines().size(), is(0));
         assertThat(constructor.isDeprecated(), is(false));
 
-        final ImmutableList<Arguments> constructorParams = constructor.getParameters();
-        assertThat(constructorParams.size(), is(4));
-        assertThat(constructorParams.get(0).getName(), is("MaxUploadSize"));
-        assertThat(constructorParams.get(1).getName(), is("Name"));
-        assertThat(constructorParams.get(2).getName(), is("Priority"));
-        assertThat(constructorParams.get(3).getName(), is("NotificationEndPoint"));
+        final ImmutableList<ConstructorParam> constructorParams = constructor.getParameters();
+        final ImmutableList<String> expectedParams = ImmutableList.of("MaxUploadSize", "Name", "Priority", "NotificationEndPoint");
+        assertThat(constructorParams.size(), is(expectedParams.size()));
+        constructorParams.forEach(param -> assertThat(expectedParams, hasItem(param.getName())));
 
         final ImmutableList<Arguments> constructorAssignments = constructor.getAssignments();
-        assertThat(constructorAssignments.size(), is(3));
-        assertThat(constructorAssignments.get(0).getName(), is("MaxUploadSize"));
-        assertThat(constructorAssignments.get(1).getName(), is("Name"));
-        assertThat(constructorAssignments.get(2).getName(), is("Priority"));
+        final ImmutableList<String> expectedAssignments = ImmutableList.of("MaxUploadSize", "Name", "Priority");
+        assertThat(constructorAssignments.size(), is(expectedAssignments.size()));
+        constructorAssignments.forEach(assignment -> assertThat(expectedAssignments, hasItem(assignment.getName())));
 
         final ImmutableList<QueryParam> queryParams = constructor.getQueryParams();
-        assertThat(queryParams.size(), is(4));
-        assertThat(queryParams.get(0).getName(), is("IgnoreNamingConflicts"));
-        assertThat(queryParams.get(1).getName(), is("MaxUploadSize"));
-        assertThat(queryParams.get(2).getName(), is("Name"));
-        assertThat(queryParams.get(3).getName(), is("Priority"));
+        final ImmutableList<String> expectedQueryParams = ImmutableList.of("IgnoreNamingConflicts", "MaxUploadSize", "Name", "Priority");
+        assertThat(queryParams.size(), is(expectedQueryParams.size()));
+        queryParams.forEach(param -> assertThat(expectedQueryParams, hasItem(param.getName())));
     }
 }

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/requestmodels/CreateObjectRequestGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/requestmodels/CreateObjectRequestGenerator_Test.java
@@ -20,6 +20,7 @@ import com.spectralogic.ds3autogen.api.models.Arguments;
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3Param;
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3Request;
 import com.spectralogic.ds3autogen.docspec.Ds3DocSpecEmptyImpl;
+import com.spectralogic.ds3autogen.java.models.ConstructorParam;
 import com.spectralogic.ds3autogen.java.models.QueryParam;
 import com.spectralogic.ds3autogen.java.models.RequestConstructor;
 import org.junit.Test;
@@ -29,6 +30,7 @@ import static com.spectralogic.ds3autogen.java.test.helpers.RequestGeneratorTest
 import static com.spectralogic.ds3autogen.java.test.helpers.RequestGeneratorTestHelper.createTestDs3ParamList;
 import static com.spectralogic.ds3autogen.testutil.Ds3ModelFixtures.getRequestCreateObject;
 import static com.spectralogic.ds3autogen.testutil.Ds3ModelPartialDataFixture.createDs3RequestTestData;
+import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -79,19 +81,16 @@ public class CreateObjectRequestGenerator_Test {
                 constructor1.getAdditionalLines().get(0),
                 is("this.stream = new SeekableByteChannelInputStream(channel);"));
 
-        final ImmutableList<Arguments> constructorParams1 = constructor1.getParameters();
-        assertThat(constructorParams1.size(), is(4));
-        assertThat(constructorParams1.get(0).getName(), is("BucketName"));
-        assertThat(constructorParams1.get(1).getName(), is("ObjectName"));
-        assertThat(constructorParams1.get(2).getName(), is("Size"));
-        assertThat(constructorParams1.get(3).getName(), is("Channel"));
+        final ImmutableList<ConstructorParam> constructorParams1 = constructor1.getParameters();
+
+        final ImmutableList<String> expectedParamNames1 = ImmutableList.of("BucketName", "ObjectName", "Size", "Channel");
+
+        assertThat(constructorParams1.size(), is(expectedParamNames1.size()));
+        constructorParams1.forEach(param -> assertThat(expectedParamNames1, hasItem(param.getName())));
 
         final ImmutableList<Arguments> constructorAssignments1 = constructor1.getAssignments();
-        assertThat(constructorAssignments1.size(), is(4));
-        assertThat(constructorAssignments1.get(0).getName(), is("BucketName"));
-        assertThat(constructorAssignments1.get(1).getName(), is("ObjectName"));
-        assertThat(constructorAssignments1.get(2).getName(), is("Size"));
-        assertThat(constructorAssignments1.get(3).getName(), is("Channel"));
+        assertThat(constructorAssignments1.size(), is(expectedParamNames1.size()));
+        constructorAssignments1.forEach(param -> assertThat(expectedParamNames1, hasItem(param.getName())));
 
         final ImmutableList<QueryParam> queryParams1 = constructor1.getQueryParams();
         assertThat(queryParams1.size(), is(0));
@@ -104,23 +103,17 @@ public class CreateObjectRequestGenerator_Test {
                 constructor2.getAdditionalLines().get(0),
                 is("this.stream = new SeekableByteChannelInputStream(channel);"));
 
-        final ImmutableList<Arguments> constructorParams2 = constructor2.getParameters();
-        assertThat(constructorParams2.size(), is(6));
-        assertThat(constructorParams2.get(0).getName(), is("BucketName"));
-        assertThat(constructorParams2.get(1).getName(), is("ObjectName"));
-        assertThat(constructorParams2.get(2).getName(), is("Size"));
-        assertThat(constructorParams2.get(3).getName(), is("Job"));
-        assertThat(constructorParams2.get(4).getName(), is("Offset"));
-        assertThat(constructorParams2.get(5).getName(), is("Channel"));
+        final ImmutableList<ConstructorParam> constructorParams2 = constructor2.getParameters();
+
+        final ImmutableList<String> expectedParamNames2 = ImmutableList.of("BucketName", "ObjectName", "Size", "Channel", "Job", "Offset");
+
+        assertThat(constructorParams2.size(), is(expectedParamNames2.size()));
+        constructorParams2.forEach(param -> assertThat(expectedParamNames2, hasItem(param.getName())));
 
         final ImmutableList<Arguments> constructorAssignments2 = constructor2.getAssignments();
-        assertThat(constructorAssignments2.size(), is(6));
-        assertThat(constructorAssignments2.get(0).getName(), is("BucketName"));
-        assertThat(constructorAssignments2.get(1).getName(), is("ObjectName"));
-        assertThat(constructorAssignments2.get(2).getName(), is("Size"));
-        assertThat(constructorAssignments2.get(3).getName(), is("Job"));
-        assertThat(constructorAssignments2.get(4).getName(), is("Offset"));
-        assertThat(constructorAssignments2.get(5).getName(), is("Channel"));
+        assertThat(constructorAssignments2.size(), is(expectedParamNames2.size()));
+
+        constructorParams2.forEach(param -> assertThat(expectedParamNames2, hasItem(param.getName())));
 
         final ImmutableList<QueryParam> queryParams2 = constructor2.getQueryParams();
         assertThat(queryParams2.size(), is(2));
@@ -132,23 +125,15 @@ public class CreateObjectRequestGenerator_Test {
         assertThat(constructor3.isDeprecated(), is(false));
         assertThat(constructor3.getAdditionalLines().size(), is(0));
 
-        final ImmutableList<Arguments> constructorParams3 = constructor3.getParameters();
-        assertThat(constructorParams3.size(), is(6));
-        assertThat(constructorParams3.get(0).getName(), is("BucketName"));
-        assertThat(constructorParams3.get(1).getName(), is("ObjectName"));
-        assertThat(constructorParams3.get(2).getName(), is("Size"));
-        assertThat(constructorParams3.get(3).getName(), is("Job"));
-        assertThat(constructorParams3.get(4).getName(), is("Offset"));
-        assertThat(constructorParams3.get(5).getName(), is("Stream"));
+        final ImmutableList<String> expectedParamNames3 = ImmutableList.of("BucketName", "ObjectName", "Size", "Stream", "Job", "Offset");
+
+        final ImmutableList<ConstructorParam> constructorParams3 = constructor3.getParameters();
+        assertThat(constructorParams3.size(), is(expectedParamNames3.size()));
+        constructorParams3.forEach(param -> assertThat(expectedParamNames3, hasItem(param.getName())));
 
         final ImmutableList<Arguments> constructorAssignments3 = constructor3.getAssignments();
-        assertThat(constructorAssignments3.size(), is(6));
-        assertThat(constructorAssignments3.get(0).getName(), is("BucketName"));
-        assertThat(constructorAssignments3.get(1).getName(), is("ObjectName"));
-        assertThat(constructorAssignments3.get(2).getName(), is("Size"));
-        assertThat(constructorAssignments3.get(3).getName(), is("Job"));
-        assertThat(constructorAssignments3.get(4).getName(), is("Offset"));
-        assertThat(constructorAssignments3.get(5).getName(), is("Stream"));
+        assertThat(constructorAssignments3.size(), is(expectedParamNames3.size()));
+        constructorAssignments3.forEach(param -> assertThat(expectedParamNames3, hasItem(param.getName())));
 
         final ImmutableList<QueryParam> queryParams3 = constructor3.getQueryParams();
         assertThat(queryParams3.size(), is(2));
@@ -168,7 +153,7 @@ public class CreateObjectRequestGenerator_Test {
         assertThat(result.isDeprecated(), is(false));
         assertThat(result.getAdditionalLines().size(), is(0));
 
-        final ImmutableList<Arguments> params = result.getParameters();
+        final ImmutableList<ConstructorParam> params = result.getParameters();
         assertThat(params.size(), is(3));
         assertThat(params.get(0).getName(), is("Arg1"));
         assertThat(params.get(1).getName(), is("Arg2"));
@@ -200,7 +185,7 @@ public class CreateObjectRequestGenerator_Test {
                 result.getAdditionalLines().get(0),
                 is("this.stream = new SeekableByteChannelInputStream(channel);"));
 
-        final ImmutableList<Arguments> params = result.getParameters();
+        final ImmutableList<ConstructorParam> params = result.getParameters();
         assertThat(params.size(), is(3));
         assertThat(params.get(0).getName(), is("Arg1"));
         assertThat(params.get(1).getName(), is("Arg2"));
@@ -230,7 +215,7 @@ public class CreateObjectRequestGenerator_Test {
                 result.getAdditionalLines().get(0),
                 is("this.stream = new SeekableByteChannelInputStream(channel);"));
 
-        final ImmutableList<Arguments> params = result.getParameters();
+        final ImmutableList<ConstructorParam> params = result.getParameters();
         assertThat(params.size(), is(2));
         assertThat(params.get(0).getName(), is("Arg1"));
         assertThat(params.get(1).getName(), is("Channel"));

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/requestmodels/GetObjectRequestGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/requestmodels/GetObjectRequestGenerator_Test.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableList;
 import com.spectralogic.ds3autogen.api.models.Arguments;
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3Request;
 import com.spectralogic.ds3autogen.docspec.Ds3DocSpecEmptyImpl;
+import com.spectralogic.ds3autogen.java.models.ConstructorParam;
 import com.spectralogic.ds3autogen.java.models.QueryParam;
 import com.spectralogic.ds3autogen.java.models.RequestConstructor;
 import org.junit.Test;
@@ -28,8 +29,10 @@ import static com.spectralogic.ds3autogen.java.generators.requestmodels.GetObjec
 import static com.spectralogic.ds3autogen.java.generators.requestmodels.GetObjectRequestGenerator.createOutputStreamConstructor;
 import static com.spectralogic.ds3autogen.java.test.helpers.RequestGeneratorTestHelper.createSimpleTestDs3Request;
 import static com.spectralogic.ds3autogen.testutil.Ds3ModelFixtures.getRequestAmazonS3GetObject;
+import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 public class GetObjectRequestGenerator_Test {
 
@@ -60,17 +63,15 @@ public class GetObjectRequestGenerator_Test {
         assertThat(constructor1.isDeprecated(), is(true));
         assertThat(constructor1.getAdditionalLines().size(), is(0));
 
-        final ImmutableList<Arguments> constructorParams1 = constructor1.getParameters();
-        assertThat(constructorParams1.size(), is(3));
-        assertThat(constructorParams1.get(0).getName(), is("BucketName"));
-        assertThat(constructorParams1.get(1).getName(), is("ObjectName"));
-        assertThat(constructorParams1.get(2).getName(), is("Channel"));
+        final ImmutableList<ConstructorParam> constructorParams1 = constructor1.getParameters();
+        final ImmutableList<String> expectedNames1 = ImmutableList.of("BucketName", "ObjectName", "Channel");
+
+        assertThat(constructorParams1.size(), is(expectedNames1.size()));
+        constructorParams1.forEach(param -> assertThat(expectedNames1, hasItem(param.getName())));
 
         final ImmutableList<Arguments> constructorAssignments1 = constructor1.getAssignments();
-        assertThat(constructorAssignments1.size(), is(3));
-        assertThat(constructorAssignments1.get(0).getName(), is("BucketName"));
-        assertThat(constructorAssignments1.get(1).getName(), is("ObjectName"));
-        assertThat(constructorAssignments1.get(2).getName(), is("Channel"));
+        assertThat(constructorAssignments1.size(), is(expectedNames1.size()));
+        constructorAssignments1.forEach(assignment -> assertThat(expectedNames1, hasItem(assignment.getName())));
 
         final ImmutableList<QueryParam> queryParams1 = constructor1.getQueryParams();
         assertThat(queryParams1.size(), is(0));
@@ -80,41 +81,30 @@ public class GetObjectRequestGenerator_Test {
         assertThat(constructor2.isDeprecated(), is(false));
         assertThat(constructor2.getAdditionalLines().size(), is(0));
 
-        final ImmutableList<Arguments> constructorParams2 = constructor2.getParameters();
-        assertThat(constructorParams2.size(), is(5));
-        assertThat(constructorParams2.get(0).getName(), is("BucketName"));
-        assertThat(constructorParams2.get(1).getName(), is("ObjectName"));
-        assertThat(constructorParams2.get(2).getName(), is("Job"));
-        assertThat(constructorParams2.get(3).getName(), is("Offset"));
-        assertThat(constructorParams2.get(4).getName(), is("Channel"));
+        final ImmutableList<ConstructorParam> constructorParams2 = constructor2.getParameters();
+        final ImmutableList<String> expectedNames2 = ImmutableList.of("BucketName", "ObjectName", "Job", "Offset", "Channel");
+        assertThat(constructorParams2.size(), is(expectedNames2.size()));
+        constructorParams2.forEach(param -> assertThat(expectedNames2, hasItem(param.getName())));
 
         final ImmutableList<Arguments> constructorAssignments2 = constructor2.getAssignments();
-        assertThat(constructorAssignments2.size(), is(5));
-        assertThat(constructorAssignments2.get(0).getName(), is("BucketName"));
-        assertThat(constructorAssignments2.get(1).getName(), is("ObjectName"));
-        assertThat(constructorAssignments2.get(2).getName(), is("Job"));
-        assertThat(constructorAssignments2.get(3).getName(), is("Offset"));
-        assertThat(constructorAssignments2.get(4).getName(), is("Channel"));
+        assertThat(constructorAssignments2.size(), is(expectedNames2.size()));
+        constructorAssignments2.forEach(assignment -> assertThat(expectedNames2, hasItem(assignment.getName())));
 
         final ImmutableList<QueryParam> queryParams2 = constructor2.getQueryParams();
         assertThat(queryParams2.size(), is(2));
         assertThat(queryParams2.get(0).getName(), is("Job"));
         assertThat(queryParams2.get(1).getName(), is("Offset"));
 
-        //
         //Channel Constructor
         final RequestConstructor constructor3 = result.get(2);
         assertThat(constructor3.isDeprecated(), is(false));
         assertThat(constructor3.getAdditionalLines().size(), is(1));
         assertThat(constructor3.getAdditionalLines().get(0), is("this.channel = Channels.newChannel(stream);"));
 
-        final ImmutableList<Arguments> constructorParams3 = constructor3.getParameters();
-        assertThat(constructorParams3.size(), is(5));
-        assertThat(constructorParams3.get(0).getName(), is("BucketName"));
-        assertThat(constructorParams3.get(1).getName(), is("ObjectName"));
-        assertThat(constructorParams3.get(2).getName(), is("Job"));
-        assertThat(constructorParams3.get(3).getName(), is("Offset"));
-        assertThat(constructorParams3.get(4).getName(), is("Stream"));
+        final ImmutableList<ConstructorParam> constructorParams3 = constructor3.getParameters();
+        final ImmutableList<String> expectedNames3 = ImmutableList.of("BucketName", "ObjectName", "Job", "Offset", "Stream");
+        assertThat(constructorParams3.size(), is(expectedNames3.size()));
+        constructorParams3.forEach(param -> assertThat(expectedNames3, hasItem(param.getName())));
 
         final ImmutableList<Arguments> constructorAssignments3 = constructor3.getAssignments();
         assertThat(constructorAssignments3.size(), is(4));
@@ -140,7 +130,7 @@ public class GetObjectRequestGenerator_Test {
         assertThat(result.isDeprecated(), is(true));
         assertThat(result.getAdditionalLines().size(), is(0));
 
-        final ImmutableList<Arguments> params = result.getParameters();
+        final ImmutableList<ConstructorParam> params = result.getParameters();
         assertThat(params.size(), is(2));
         assertThat(params.get(0).getName(), is("Arg1"));
         assertThat(params.get(1).getName(), is("Channel"));
@@ -167,7 +157,7 @@ public class GetObjectRequestGenerator_Test {
         assertThat(result.isDeprecated(), is(false));
         assertThat(result.getAdditionalLines().size(), is(0));
 
-        final ImmutableList<Arguments> params = result.getParameters();
+        final ImmutableList<ConstructorParam> params = result.getParameters();
         assertThat(params.size(), is(3));
         assertThat(params.get(0).getName(), is("Arg1"));
         assertThat(params.get(1).getName(), is("Arg2"));
@@ -198,7 +188,7 @@ public class GetObjectRequestGenerator_Test {
         assertThat(result.getAdditionalLines().size(), is(1));
         assertThat(result.getAdditionalLines().get(0), is("this.channel = Channels.newChannel(stream);"));
 
-        final ImmutableList<Arguments> constructorParams = result.getParameters();
+        final ImmutableList<ConstructorParam> constructorParams = result.getParameters();
         assertThat(constructorParams.size(), is(3));
         assertThat(constructorParams.get(0).getName(), is("Arg1"));
         assertThat(constructorParams.get(1).getName(), is("Arg2"));

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/requestmodels/MultiFileDeleteRequestGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/requestmodels/MultiFileDeleteRequestGenerator_Test.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableList;
 import com.spectralogic.ds3autogen.api.models.Arguments;
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3Request;
 import com.spectralogic.ds3autogen.docspec.Ds3DocSpecEmptyImpl;
+import com.spectralogic.ds3autogen.java.models.ConstructorParam;
 import com.spectralogic.ds3autogen.java.models.QueryParam;
 import com.spectralogic.ds3autogen.java.models.RequestConstructor;
 import org.junit.Test;
@@ -45,7 +46,7 @@ public class MultiFileDeleteRequestGenerator_Test {
         assertThat(constructor1.isDeprecated(), is(false));
         assertThat(constructor1.getAdditionalLines().size(), is(0));
 
-        final ImmutableList<Arguments> constructorParams1 = constructor1.getParameters();
+        final ImmutableList<ConstructorParam> constructorParams1 = constructor1.getParameters();
         assertThat(constructorParams1.size(), is(2));
         assertThat(constructorParams1.get(0).getName(), is("BucketName"));
         assertThat(constructorParams1.get(1).getName(), is("Objects"));
@@ -67,7 +68,7 @@ public class MultiFileDeleteRequestGenerator_Test {
                 constructor2.getAdditionalLines().get(0),
                 is("this.objects = contentsToString(objs);"));
 
-        final ImmutableList<Arguments> constructorParams2 = constructor2.getParameters();
+        final ImmutableList<ConstructorParam> constructorParams2 = constructor2.getParameters();
         assertThat(constructorParams2.size(), is(2));
         assertThat(constructorParams2.get(0).getName(), is("BucketName"));
         assertThat(constructorParams2.get(1).getName(), is("Objs"));
@@ -92,7 +93,7 @@ public class MultiFileDeleteRequestGenerator_Test {
         assertThat(result.isDeprecated(), is(false));
         assertThat(result.getAdditionalLines().size(), is(0));
 
-        final ImmutableList<Arguments> params = result.getParameters();
+        final ImmutableList<ConstructorParam> params = result.getParameters();
         assertThat(params.size(), is(2));
         assertThat(params.get(0).getName(), is("Arg1"));
         assertThat(params.get(1).getName(), is("Objects"));
@@ -121,7 +122,7 @@ public class MultiFileDeleteRequestGenerator_Test {
                 result.getAdditionalLines().get(0),
                 is("this.objects = contentsToString(objs);"));
 
-        final ImmutableList<Arguments> params = result.getParameters();
+        final ImmutableList<ConstructorParam> params = result.getParameters();
         assertThat(params.size(), is(2));
         assertThat(params.get(0).getName(), is("Arg1"));
         assertThat(params.get(1).getName(), is("Objs"));

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/requestmodels/NotificationRequestGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/requestmodels/NotificationRequestGenerator_Test.java
@@ -16,9 +16,9 @@
 package com.spectralogic.ds3autogen.java.generators.requestmodels;
 
 import com.google.common.collect.ImmutableList;
-import com.spectralogic.ds3autogen.api.models.Arguments;
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3Request;
 import com.spectralogic.ds3autogen.docspec.Ds3DocSpecEmptyImpl;
+import com.spectralogic.ds3autogen.java.models.ConstructorParam;
 import com.spectralogic.ds3autogen.java.models.RequestConstructor;
 import org.junit.Test;
 
@@ -59,7 +59,8 @@ public class NotificationRequestGenerator_Test {
 
         final ImmutableList<String> result = generator.getAllImports(
                 request,
-                "com.spectralogic.ds3client.commands.spectrads3.notifications");
+                "com.spectralogic.ds3client.commands.spectrads3.notifications",
+                generator.toConstructorList(request, "", new Ds3DocSpecEmptyImpl()));
 
         assertThat(result.size(), is(2));
         assertTrue(result.contains("com.spectralogic.ds3client.commands.interfaces.AbstractDeleteNotificationRequest"));
@@ -72,7 +73,8 @@ public class NotificationRequestGenerator_Test {
 
         final ImmutableList<String> result = generator.getAllImports(
                 request,
-                "com.spectralogic.ds3client.commands.spectrads3.notifications");
+                "com.spectralogic.ds3client.commands.spectrads3.notifications",
+                generator.toConstructorList(request, "", new Ds3DocSpecEmptyImpl()));
 
         assertThat(result.size(), is(2));
         assertTrue(result.contains("com.spectralogic.ds3client.commands.interfaces.AbstractGetNotificationRequest"));
@@ -82,7 +84,10 @@ public class NotificationRequestGenerator_Test {
     @Test(expected = IllegalArgumentException.class)
     public void getAllImports_Exception_Test() {
         final Ds3Request request = createSimpleTestDs3Request();
-        generator.getAllImports(request, "com.spectralogic.ds3client.commands.spectrads3.notifications");
+        generator.getAllImports(
+                request,
+                "com.spectralogic.ds3client.commands.spectrads3.notifications",
+                generator.toConstructorList(request, "", new Ds3DocSpecEmptyImpl()));
     }
 
     @Test
@@ -96,7 +101,7 @@ public class NotificationRequestGenerator_Test {
         assertThat(constructor.getAdditionalLines().size(), is(0));
         assertThat(constructor.isDeprecated(), is(false));
 
-        final ImmutableList<Arguments> constructorParams = constructor.getParameters();
+        final ImmutableList<ConstructorParam> constructorParams = constructor.getParameters();
         assertThat(constructorParams.size(), is(1));
         assertThat(constructorParams.get(0).getName(), is("NotificationId"));
 

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/requestmodels/StreamRequestPayloadGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/requestmodels/StreamRequestPayloadGenerator_Test.java
@@ -17,6 +17,7 @@ package com.spectralogic.ds3autogen.java.generators.requestmodels;
 
 import com.google.common.collect.ImmutableList;
 import com.spectralogic.ds3autogen.api.models.Arguments;
+import com.spectralogic.ds3autogen.api.models.apispec.Ds3Request;
 import com.spectralogic.ds3autogen.docspec.Ds3DocSpecEmptyImpl;
 import com.spectralogic.ds3autogen.java.models.RequestConstructor;
 import com.spectralogic.ds3autogen.java.models.Variable;
@@ -48,26 +49,23 @@ public class StreamRequestPayloadGenerator_Test {
     public void toConstructorList_Test() {
         final ImmutableList<RequestConstructor> result = generator.toConstructorList(getCreateMultiPartUploadPart(), "", new Ds3DocSpecEmptyImpl());
         assertThat(result.size(), is(2));
-        assertThat(result.get(0).getParameters().size(), is(6));
-        assertThat(result.get(0).getParameters().get(0).getName(), is("BucketName"));
-        assertThat(result.get(0).getParameters().get(1).getName(), is("ObjectName"));
-        assertThat(result.get(0).getParameters().get(2).getName(), is("PartNumber"));
-        assertThat(result.get(0).getParameters().get(3).getName(), is("UploadId"));
-        assertThat(result.get(0).getParameters().get(4).getName(), is("Size"));
-        assertThat(result.get(0).getParameters().get(5).getName(), is("Channel"));
 
-        assertThat(result.get(1).getParameters().size(), is(6));
-        assertThat(result.get(1).getParameters().get(0).getName(), is("BucketName"));
-        assertThat(result.get(1).getParameters().get(1).getName(), is("ObjectName"));
-        assertThat(result.get(1).getParameters().get(2).getName(), is("PartNumber"));
-        assertThat(result.get(1).getParameters().get(3).getName(), is("UploadId"));
-        assertThat(result.get(1).getParameters().get(4).getName(), is("Size"));
-        assertThat(result.get(1).getParameters().get(5).getName(), is("Stream"));
+        final ImmutableList<String> expectedNamesChannel = ImmutableList.of("BucketName", "ObjectName", "PartNumber", "UploadId", "Size", "Channel");
+        assertThat(result.get(0).getParameters().size(), is(expectedNamesChannel.size()));
+        result.get(0).getParameters().forEach(param -> assertThat(expectedNamesChannel, hasItem(param.getName())));
+
+        final ImmutableList<String> expectedNamesStream = ImmutableList.of("BucketName", "ObjectName", "PartNumber", "UploadId", "Size", "Stream");
+        assertThat(result.get(1).getParameters().size(), is(expectedNamesStream.size()));
+        result.get(1).getParameters().forEach(param -> assertThat(expectedNamesStream, hasItem(param.getName())));
     }
 
     @Test
     public void getAllImports_Test() {
-        final ImmutableList<String> result = generator.getAllImports(getCreateMultiPartUploadPart(), "com.test.package");
+        final Ds3Request ds3Request = getCreateMultiPartUploadPart();
+        final ImmutableList<String> result = generator.getAllImports(
+                ds3Request,
+                "com.test.package",
+                generator.toConstructorList(ds3Request, "", new Ds3DocSpecEmptyImpl()));
         assertThat(result, hasItem("com.spectralogic.ds3client.utils.SeekableByteChannelInputStream"));
         assertThat(result, hasItem("java.nio.channels.SeekableByteChannel"));
         assertThat(result, hasItem("java.io.InputStream"));

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/helpers/JavaHelper_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/helpers/JavaHelper_Test.java
@@ -18,10 +18,7 @@ package com.spectralogic.ds3autogen.java.helpers;
 import com.google.common.collect.ImmutableList;
 import com.spectralogic.ds3autogen.api.models.Arguments;
 import com.spectralogic.ds3autogen.api.models.enums.Operation;
-import com.spectralogic.ds3autogen.java.models.AnnotationInfo;
-import com.spectralogic.ds3autogen.java.models.Element;
-import com.spectralogic.ds3autogen.java.models.EnumConstant;
-import com.spectralogic.ds3autogen.java.models.Variable;
+import com.spectralogic.ds3autogen.java.models.*;
 import org.junit.Test;
 
 import static com.spectralogic.ds3autogen.java.helpers.JavaHelper.*;
@@ -70,25 +67,25 @@ public class JavaHelper_Test {
     @Test
     public void constructorArgs_FullList_Test() {
         final String expectedResult = "final String bucketName, final String objectName, final Type1 arg1, final Type2 arg2, final Type3 arg3";
-        final ImmutableList<Arguments> arguments = ImmutableList.of(
-                new Arguments("Type1", "Arg1"),
-                new Arguments("Type3", "Arg3"),
-                new Arguments("String", "ObjectName"),
-                new Arguments("Type2", "Arg2"),
-                new Arguments("String", "BucketName"));
-        final String result = constructorArgs(arguments);
+        final ImmutableList<ConstructorParam> params = ImmutableList.of(
+                new SimpleConstructorParam("Arg1", "Type1"),
+                new SimpleConstructorParam("Arg3", "Type3"),
+                new SimpleConstructorParam("ObjectName", "String"),
+                new SimpleConstructorParam("Arg2", "Type2"),
+                new SimpleConstructorParam("BucketName", "String"));
+        final String result = constructorArgs(params);
         assertThat(result, is(expectedResult));
     }
 
     @Test
     public void constructorArgs_FullList_Test2() {
-        final String expectedResult = "final String bucketName, final String objectName, final SeekableByteChannel channel, final long size";
-        final ImmutableList<Arguments> arguments = ImmutableList.of(
-                new Arguments("SeekableByteChannel", "Channel"),
-                new Arguments("long", "Size"),
-                new Arguments("String", "bucketName"),
-                new Arguments("String", "objectName"));
-        final String result = constructorArgs(arguments);
+        final String expectedResult = "final String bucketName, final String objectName, @Nonnull final SeekableByteChannel channel, final long size";
+        final ImmutableList<ConstructorParam> params = ImmutableList.of(
+                new NonnullConstructorParam("Channel", "SeekableByteChannel"),
+                new SimpleConstructorParam("Size", "long"),
+                new SimpleConstructorParam("bucketName", "String"),
+                new SimpleConstructorParam("objectName", "String"));
+        final String result = constructorArgs(params);
         assertThat(result, is(expectedResult));
     }
 

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/models/ConstructorParam_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/models/ConstructorParam_Test.java
@@ -1,0 +1,55 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.java.models;
+
+import org.junit.Test;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class ConstructorParam_Test {
+
+    private static final String PARAM_NAME = "ParamName";
+    private static final String PARAM_TYPE = "ParamType";
+    private static final String ANNOTATION = "ParamAnnotation";
+
+    private static final String EXPECTED_NO_ANNOTATION = "final ParamType paramName";
+
+    @Test
+    public void simpleConstructorParamTest() {
+        final ConstructorParam constructorParam = new SimpleConstructorParam(PARAM_NAME, PARAM_TYPE);
+        assertThat(constructorParam.toJavaCode(), is(EXPECTED_NO_ANNOTATION));
+    }
+
+    @Test
+    public void nonnullConstructorParamTest() {
+        final String expected = "@Nonnull final ParamType paramName";
+        final ConstructorParam constructorParam = new NonnullConstructorParam(PARAM_NAME, PARAM_TYPE);
+        assertThat(constructorParam.toJavaCode(), is(expected));
+    }
+
+    @Test
+    public void constructorParamWithoutAnnotationTest() {
+        final ConstructorParam constructorParam = new ConstructorParam(PARAM_NAME, PARAM_TYPE, "");
+        assertThat(constructorParam.toJavaCode(), is(EXPECTED_NO_ANNOTATION));
+    }
+
+    @Test
+    public void constructorParamWithAnnotationTest() {
+        final String expected = "@ParamAnnotation final ParamType paramName";
+        final ConstructorParam constructorParam = new ConstructorParam(PARAM_NAME, PARAM_TYPE, ANNOTATION);
+        assertThat(constructorParam.toJavaCode(), is(expected));
+    }
+}

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/models/Precondition_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/models/Precondition_Test.java
@@ -13,13 +13,18 @@
  * ****************************************************************************
  */
 
-apply plugin: 'kotlin'
+package com.spectralogic.ds3autogen.java.models;
 
-dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    compile project(':ds3-autogen-api')
-    compile project(':ds3-autogen-utils')
-    testCompile project(':ds3-autogen-parser')
-    compile     'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.5.3'
-    compile     'com.fasterxml.jackson.datatype:jackson-datatype-guava:2.5.0'
+import org.junit.Test;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class Precondition_Test {
+
+    @Test
+    public void toJavaCodeTest() {
+        final String expected = "Preconditions.checkNotNull(paramName, \"ParamName may not be null.\");";
+        final Precondition precondition = new NotNullPrecondition("ParamName");
+        assertThat(precondition.toJavaCode(), is(expected));
+    }
 }

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/utils/CommonRequestGeneratorUtils_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/utils/CommonRequestGeneratorUtils_Test.java
@@ -18,13 +18,13 @@ package com.spectralogic.ds3autogen.java.utils;
 import com.google.common.collect.ImmutableList;
 import com.spectralogic.ds3autogen.api.models.Arguments;
 import com.spectralogic.ds3autogen.docspec.Ds3DocSpecEmptyImpl;
-import com.spectralogic.ds3autogen.java.models.QueryParam;
-import com.spectralogic.ds3autogen.java.models.RequestConstructor;
+import com.spectralogic.ds3autogen.java.models.*;
 import org.junit.Test;
 
 import static com.spectralogic.ds3autogen.java.utils.CommonRequestGeneratorUtils.*;
+import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.*;
 
 public class CommonRequestGeneratorUtils_Test {
 
@@ -93,5 +93,73 @@ public class CommonRequestGeneratorUtils_Test {
         assertThat(result.get(0).getType(), is("TypeOne"));
         assertThat(result.get(1).getName(), is("NameTwo"));
         assertThat(result.get(1).getType(), is("TypeTwo"));
+    }
+
+    @Test
+    public void toConstructorParamsEmptyListTest() {
+        final ImmutableList<ConstructorParam> result = toConstructorParams(ImmutableList.of());
+        assertThat(result.size(), is(0));
+    }
+
+    private static final ImmutableList<Arguments> CHANNEL_STREAM_ARGS = ImmutableList.of(
+            new Arguments("InputStream", "InStreamArg"),
+            new Arguments("Integer", "IntArg"),
+            new Arguments("OutputStream", "OutStreamArg"),
+            new Arguments("SeekableByteChannel", "SeekableChannelArg"),
+            new Arguments("WritableByteChannel", "WriteChannelArg")
+    );
+
+    private static final ImmutableList<ConstructorParam> CHANNEL_STREAM_PARAMS = ImmutableList.of(
+            new NonnullConstructorParam("InStreamArg", "InputStream"),
+            new SimpleConstructorParam("IntArg", "Integer"),
+            new NonnullConstructorParam("OutStreamArg", "OutputStream"),
+            new NonnullConstructorParam("SeekableChannelArg", "SeekableByteChannel"),
+            new NonnullConstructorParam("WriteChannelArg", "WritableByteChannel")
+    );
+
+    @Test
+    public void toConstructorParamsFullListTest() {
+        final ImmutableList<ConstructorParam> result = toConstructorParams(CHANNEL_STREAM_ARGS);
+
+        assertThat(result.size(), is(CHANNEL_STREAM_ARGS.size()));
+
+        for (int i = 0; i < result.size(); i++) {
+            assertThat(result.get(i).toJavaCode(), is(CHANNEL_STREAM_PARAMS.get(i).toJavaCode()));
+        }
+    }
+
+    @Test
+    public void toConstructorParamTest() {
+        for (int i = 0; i < CHANNEL_STREAM_ARGS.size(); i++) {
+            final ConstructorParam result = toConstructorParam(CHANNEL_STREAM_ARGS.get(i));
+            assertThat(result.toJavaCode(), is(CHANNEL_STREAM_PARAMS.get(i).toJavaCode()));
+        }
+    }
+
+    @Test
+    public void containsTypeTest() {
+        assertTrue(containsType(CHANNEL_STREAM_PARAMS, "InputStream"));
+        assertTrue(containsType(CHANNEL_STREAM_PARAMS, "Integer"));
+        assertTrue(containsType(CHANNEL_STREAM_PARAMS, "OutputStream"));
+        assertTrue(containsType(CHANNEL_STREAM_PARAMS, "SeekableByteChannel"));
+        assertTrue(containsType(CHANNEL_STREAM_PARAMS, "WritableByteChannel"));
+
+        assertFalse(containsType(CHANNEL_STREAM_PARAMS, "integer"));
+        assertFalse(containsType(CHANNEL_STREAM_PARAMS, "String"));
+    }
+
+    @Test
+    public void toPreconditionsTest() {
+        final ImmutableList<Precondition> expected = ImmutableList.of(
+                new NotNullPrecondition("InStreamArg"),
+                new NotNullPrecondition("OutStreamArg"),
+                new NotNullPrecondition("SeekableChannelArg"),
+                new NotNullPrecondition("WriteChannelArg")
+        );
+
+        final ImmutableList<Precondition> result = toPreconditions(CHANNEL_STREAM_PARAMS);
+        assertThat(result.size(), is(expected.size()));
+
+        result.forEach(condition -> assertThat(expected, hasItem(condition)));
     }
 }


### PR DESCRIPTION
**Changes**
- Updated constructor parameters to be new type `ConstructorParam` as opposed to just `Arguments`
- Added list of preconditions to java constructors
- Updated java request handler templates to reflect changes in constructor
- Updated all relevant tests

Generated code was merged in PR: https://github.com/SpectraLogic/ds3_java_sdk/pull/510