### PR TITLE
Updating go client to use new request builder design

### DIFF
--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/client/BaseClientGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/client/BaseClientGenerator.kt
@@ -18,8 +18,7 @@ package com.spectralogic.ds3autogen.go.generators.client
 import com.google.common.collect.ImmutableList
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3Request
 import com.spectralogic.ds3autogen.api.models.enums.HttpVerb
-import com.spectralogic.ds3autogen.go.models.client.Client
-import com.spectralogic.ds3autogen.go.models.client.Command
+import com.spectralogic.ds3autogen.go.models.client.*
 import com.spectralogic.ds3autogen.utils.ClientGeneratorUtil
 import com.spectralogic.ds3autogen.utils.ConverterUtil
 import com.spectralogic.ds3autogen.utils.Ds3RequestClassificationUtil.isGetObjectAmazonS3Request
@@ -54,8 +53,22 @@ open class BaseClientGenerator : ClientModelGenerator<Client> {
      * Converts a Ds3Request into a Command
      */
     fun toCommand(ds3Request: Ds3Request): Command {
-        val name = ClientGeneratorUtil.toCommandName(ds3Request.name)
-        return Command(name)
+        return Command(
+                ClientGeneratorUtil.toCommandName(ds3Request.name),
+                toRequestBuildLines(ds3Request))
+    }
+
+    /**
+     * Creates the list of request handler build lines required to construct the
+     * http request using a builder within the client. This excludes the request
+     * builder initialization (first line) and the build command (last line).
+     */
+    fun toRequestBuildLines(ds3Request: Ds3Request): ImmutableList<RequestBuildLine> {
+        val builder = ImmutableList.builder<RequestBuildLine>()
+        builder.add(HttpVerbBuildLine(ds3Request.httpVerb!!))
+        builder.add(PathBuildLine(toRequestPath(ds3Request)))
+        //todo add required params, optional params, reader, read closer, checksum, headers
+        return builder.build()
     }
 
     /**

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/client/BaseClientGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/client/BaseClientGenerator.kt
@@ -66,7 +66,7 @@ open class BaseClientGenerator : ClientModelGenerator<Client> {
     fun toRequestBuildLines(ds3Request: Ds3Request): ImmutableList<RequestBuildLine> {
         val builder = ImmutableList.builder<RequestBuildLine>()
         builder.add(HttpVerbBuildLine(ds3Request.httpVerb!!))
-        builder.add(PathBuildLine(toRequestPath(ds3Request)))
+        builder.add(PathBuildLine(ds3Request.toRequestPath()))
         //todo add required params, optional params, reader, read closer, checksum, headers
         return builder.build()
     }

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/client/ClientGeneratorUtil.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/client/ClientGeneratorUtil.kt
@@ -1,0 +1,92 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.go.generators.client
+
+import com.spectralogic.ds3autogen.api.models.apispec.Ds3Request
+import com.spectralogic.ds3autogen.api.models.enums.Classification
+import com.spectralogic.ds3autogen.api.models.enums.Requirement
+import com.spectralogic.ds3autogen.go.utils.getGoArgFromResource
+import com.spectralogic.ds3autogen.go.utils.isGoResourceAnArg
+import com.spectralogic.ds3autogen.utils.Ds3RequestClassificationUtil
+import com.spectralogic.ds3autogen.utils.Ds3RequestUtils
+import com.spectralogic.ds3autogen.utils.RequestConverterUtil
+import com.spectralogic.ds3autogen.utils.models.NotificationType
+
+private val PATH_REQUEST_REFERENCE = "request"
+
+/**
+ * Creates the Go request path code for a Ds3 request
+ */
+fun toRequestPath(ds3Request: Ds3Request): String {
+    if (ds3Request.classification == Classification.amazons3) {
+        return getAmazonS3RequestPath(ds3Request)
+    }
+    if (ds3Request.classification == Classification.spectrads3) {
+        return getSpectraDs3RequestPath(ds3Request)
+    }
+
+    throw IllegalArgumentException("Unsupported classification: " + ds3Request.classification.toString())
+}
+
+/**
+ * Creates the Go request path code for an AmazonS3 request
+ */
+fun getAmazonS3RequestPath(ds3Request: Ds3Request): String {
+    val builder = StringBuilder()
+
+    if (ds3Request.classification != Classification.amazons3) {
+        return builder.toString()
+    }
+    builder.append("\"/\"")
+    if (ds3Request.bucketRequirement == Requirement.REQUIRED) {
+        builder.append(" + ").append(PATH_REQUEST_REFERENCE).append(".BucketName")
+    }
+    if (ds3Request.objectRequirement == Requirement.REQUIRED) {
+        builder.append(" + \"/\" + ").append(PATH_REQUEST_REFERENCE).append(".ObjectName")
+    }
+    return builder.toString()
+}
+
+/**
+ * Creates the Go request path code for a SpectraS3 request
+ */
+fun getSpectraDs3RequestPath(ds3Request: Ds3Request): String {
+    val builder = StringBuilder()
+
+    if (ds3Request.classification != Classification.spectrads3) {
+        return builder.toString()
+    }
+    if (ds3Request.resource == null) {
+        return builder.append("\"/_rest_/\"").toString()
+    }
+
+    builder.append("\"/_rest_/").append(ds3Request.resource!!.toString().toLowerCase())
+    if (Ds3RequestClassificationUtil.isNotificationRequest(ds3Request)
+            && ds3Request.includeInPath
+            && (RequestConverterUtil.getNotificationType(ds3Request) == NotificationType.DELETE
+                || RequestConverterUtil.getNotificationType(ds3Request) == NotificationType.GET)) {
+        builder.append("/\"").append(" + ").append(PATH_REQUEST_REFERENCE).append(".NotificationId")
+    } else if (Ds3RequestUtils.hasBucketNameInPath(ds3Request)) {
+        builder.append("/\"").append(" + ").append(PATH_REQUEST_REFERENCE).append(".BucketName")
+    } else if (ds3Request.isGoResourceAnArg()) {
+        val resourceArg = ds3Request.getGoArgFromResource()
+        builder.append("/\"").append(" + ").append(PATH_REQUEST_REFERENCE)
+                .append(".").append(resourceArg.name.capitalize())
+    } else {
+        builder.append("\"")
+    }
+    return builder.toString()
+}

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/client/ClientGeneratorUtil.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/client/ClientGeneratorUtil.kt
@@ -30,29 +30,29 @@ private const val PATH_REQUEST_REFERENCE = "request"
 /**
  * Creates the Go request path code for a Ds3 request
  */
-fun toRequestPath(ds3Request: Ds3Request): String {
-    if (ds3Request.classification == Classification.amazons3) {
-        return getAmazonS3RequestPath(ds3Request)
+fun Ds3Request.toRequestPath(): String {
+    if (classification == Classification.amazons3) {
+        return getAmazonS3RequestPath()
     }
-    if (ds3Request.classification == Classification.spectrads3) {
-        return getSpectraDs3RequestPath(ds3Request)
+    if (classification == Classification.spectrads3) {
+        return getSpectraDs3RequestPath()
     }
 
-    throw IllegalArgumentException("Unsupported classification: " + ds3Request.classification.toString())
+    throw IllegalArgumentException("Unsupported classification: " + classification.toString())
 }
 
 /**
  * Creates the Go request path code for an AmazonS3 request
  */
-fun getAmazonS3RequestPath(ds3Request: Ds3Request): String {
-    if (ds3Request.classification != Classification.amazons3) {
+fun Ds3Request.getAmazonS3RequestPath(): String {
+    if (classification != Classification.amazons3) {
         return ""
     }
     val builder = StringBuilder("\"/\"")
-    if (ds3Request.bucketRequirement == Requirement.REQUIRED) {
+    if (bucketRequirement == Requirement.REQUIRED) {
         builder.append(" + ").append(PATH_REQUEST_REFERENCE).append(".BucketName")
     }
-    if (ds3Request.objectRequirement == Requirement.REQUIRED) {
+    if (objectRequirement == Requirement.REQUIRED) {
         builder.append(" + \"/\" + ").append(PATH_REQUEST_REFERENCE).append(".ObjectName")
     }
     return builder.toString()
@@ -61,26 +61,26 @@ fun getAmazonS3RequestPath(ds3Request: Ds3Request): String {
 /**
  * Creates the Go request path code for a SpectraS3 request
  */
-fun getSpectraDs3RequestPath(ds3Request: Ds3Request): String {
-    if (ds3Request.classification != Classification.spectrads3) {
+fun Ds3Request.getSpectraDs3RequestPath(): String {
+    if (classification != Classification.spectrads3) {
         return ""
     }
-    if (ds3Request.resource == null) {
+    if (resource == null) {
         return "\"/_rest_/\""
     }
 
     val builder = StringBuilder("\"/_rest_/")
-            .append(ds3Request.resource!!.toString().toLowerCase())
+            .append(resource!!.toString().toLowerCase())
 
-    if (Ds3RequestClassificationUtil.isNotificationRequest(ds3Request)
-            && ds3Request.includeInPath
-            && (RequestConverterUtil.getNotificationType(ds3Request) == NotificationType.DELETE
-                || RequestConverterUtil.getNotificationType(ds3Request) == NotificationType.GET)) {
+    if (Ds3RequestClassificationUtil.isNotificationRequest(this)
+            && includeInPath
+            && (RequestConverterUtil.getNotificationType(this) == NotificationType.DELETE
+                || RequestConverterUtil.getNotificationType(this) == NotificationType.GET)) {
         builder.append("/\"").append(" + ").append(PATH_REQUEST_REFERENCE).append(".NotificationId")
-    } else if (Ds3RequestUtils.hasBucketNameInPath(ds3Request)) {
+    } else if (Ds3RequestUtils.hasBucketNameInPath(this)) {
         builder.append("/\"").append(" + ").append(PATH_REQUEST_REFERENCE).append(".BucketName")
-    } else if (ds3Request.isGoResourceAnArg()) {
-        val resourceArg = ds3Request.getGoArgFromResource()
+    } else if (this.isGoResourceAnArg()) {
+        val resourceArg = this.getGoArgFromResource()
         builder.append("/\"").append(" + ").append(PATH_REQUEST_REFERENCE)
                 .append(".").append(resourceArg.name.capitalize())
     } else {

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/client/ClientGeneratorUtil.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/client/ClientGeneratorUtil.kt
@@ -25,7 +25,7 @@ import com.spectralogic.ds3autogen.utils.Ds3RequestUtils
 import com.spectralogic.ds3autogen.utils.RequestConverterUtil
 import com.spectralogic.ds3autogen.utils.models.NotificationType
 
-private val PATH_REQUEST_REFERENCE = "request"
+private const val PATH_REQUEST_REFERENCE = "request"
 
 /**
  * Creates the Go request path code for a Ds3 request
@@ -45,12 +45,10 @@ fun toRequestPath(ds3Request: Ds3Request): String {
  * Creates the Go request path code for an AmazonS3 request
  */
 fun getAmazonS3RequestPath(ds3Request: Ds3Request): String {
-    val builder = StringBuilder()
-
     if (ds3Request.classification != Classification.amazons3) {
-        return builder.toString()
+        return ""
     }
-    builder.append("\"/\"")
+    val builder = StringBuilder("\"/\"")
     if (ds3Request.bucketRequirement == Requirement.REQUIRED) {
         builder.append(" + ").append(PATH_REQUEST_REFERENCE).append(".BucketName")
     }
@@ -64,16 +62,16 @@ fun getAmazonS3RequestPath(ds3Request: Ds3Request): String {
  * Creates the Go request path code for a SpectraS3 request
  */
 fun getSpectraDs3RequestPath(ds3Request: Ds3Request): String {
-    val builder = StringBuilder()
-
     if (ds3Request.classification != Classification.spectrads3) {
-        return builder.toString()
+        return ""
     }
     if (ds3Request.resource == null) {
-        return builder.append("\"/_rest_/\"").toString()
+        return "\"/_rest_/\""
     }
 
-    builder.append("\"/_rest_/").append(ds3Request.resource!!.toString().toLowerCase())
+    val builder = StringBuilder("\"/_rest_/")
+            .append(ds3Request.resource!!.toString().toLowerCase())
+
     if (Ds3RequestClassificationUtil.isNotificationRequest(ds3Request)
             && ds3Request.includeInPath
             && (RequestConverterUtil.getNotificationType(ds3Request) == NotificationType.DELETE

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/request/BaseRequestGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/request/BaseRequestGenerator.kt
@@ -22,7 +22,10 @@ import com.spectralogic.ds3autogen.api.models.apispec.Ds3Param
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3Request
 import com.spectralogic.ds3autogen.api.models.enums.Operation
 import com.spectralogic.ds3autogen.api.models.enums.Requirement
+import com.spectralogic.ds3autogen.go.generators.client.toRequestPath
 import com.spectralogic.ds3autogen.go.models.request.*
+import com.spectralogic.ds3autogen.go.utils.getGoArgFromResource
+import com.spectralogic.ds3autogen.go.utils.isGoResourceAnArg
 import com.spectralogic.ds3autogen.go.utils.toGoType
 import com.spectralogic.ds3autogen.utils.ConverterUtil.isEmpty
 import com.spectralogic.ds3autogen.utils.Helper

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/request/BaseRequestGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/request/BaseRequestGenerator.kt
@@ -49,7 +49,7 @@ open class BaseRequestGenerator : RequestModelGenerator<Request>, RequestModelGe
                 name,
                 constructor,
                 getHttpVerb(ds3Request.httpVerb),
-                toRequestPath(ds3Request),
+                ds3Request.toRequestPath(),
                 structParams,
                 withConstructors,
                 nullableWithConstructors,

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/models/client/RequestBuildLine.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/models/client/RequestBuildLine.kt
@@ -15,8 +15,23 @@
 
 package com.spectralogic.ds3autogen.go.models.client
 
-import com.google.common.collect.ImmutableList
+import com.spectralogic.ds3autogen.api.models.enums.HttpVerb
 
-data class Command(
-        val name: String,
-        val requestBuildLine: ImmutableList<RequestBuildLine>)
+interface RequestBuildLine {
+    val line: String
+}
+
+// Creates the Go request builder line for adding an http verb to an http request
+data class HttpVerbBuildLine(private val httpVerb: HttpVerb) : RequestBuildLine {
+    override val line: String get() {
+        val verb = httpVerb.toString()
+        return "WithHttpVerb(HTTP_VERB_$verb)."
+    }
+}
+
+// Creates the Go request builder line for adding a path to an http request
+data class PathBuildLine(private val path: String) : RequestBuildLine {
+    override val line: String get() {
+        return "WithPath($path)."
+    }
+}

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/utils/Ds3RequestUtil.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/utils/Ds3RequestUtil.kt
@@ -1,0 +1,48 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.go.utils
+
+import com.spectralogic.ds3autogen.api.models.Arguments
+import com.spectralogic.ds3autogen.api.models.apispec.Ds3Request
+import com.spectralogic.ds3autogen.utils.Helper
+import com.spectralogic.ds3autogen.utils.RequestConverterUtil
+
+/**
+ * Determines if a Ds3Request's Resource describes a required argument or not.
+ */
+fun Ds3Request.isGoResourceAnArg(): Boolean {
+    return resource != null && includeInPath
+}
+
+/**
+ * Creates an argument from a resource. Notification resource args are simplified to notificationId.
+ * If the resource does not describe a valid argument, such as a singleton, an error is thrown.
+ */
+fun Ds3Request.getGoArgFromResource(): Arguments {
+    if (RequestConverterUtil.isResourceSingleton(resource)) {
+        throw IllegalArgumentException("Cannot create an argument from a singleton resource: " + resource.toString())
+    }
+    if (RequestConverterUtil.isResourceNotification(resource)) {
+        return Arguments("String", "NotificationId")
+    }
+    if (RequestConverterUtil.isResourceNamed(resource)) {
+        return Arguments("String", Helper.underscoreToCamel(resource.toString()) + "Name")
+    }
+    if (RequestConverterUtil.isResourceId(resource)) {
+        return Arguments("String", Helper.underscoreToCamel(resource.toString()) + "Id")
+    }
+    return Arguments("String", Helper.underscoreToCamel(resource.toString()))
+}

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTests.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTests.java
@@ -37,7 +37,7 @@ import static org.mockito.Mockito.mock;
 public class GoFunctionalTests {
 
     private final static Logger LOG = LoggerFactory.getLogger(GoFunctionalTests.class);
-    private final static GeneratedCodeLogger CODE_LOGGER = new GeneratedCodeLogger(FileTypeToLog.REQUEST, LOG);
+    private final static GeneratedCodeLogger CODE_LOGGER = new GeneratedCodeLogger(FileTypeToLog.CLIENT, LOG);
 
     @Test
     public void simpleRequestNoPayload() throws IOException, TemplateModelException {
@@ -78,9 +78,9 @@ public class GoFunctionalTests {
         CODE_LOGGER.logFile(client, FileTypeToLog.CLIENT);
         assertTrue(hasContent(client));
         assertTrue(client.contains("func (client *Client) SimpleNoPayload(request *models.SimpleNoPayloadRequest) (*models.SimpleNoPayloadResponse, error) {"));
-        assertTrue(client.contains("networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.netLayer), client.clientPolicy.maxRetries)"));
+        assertTrue(client.contains("networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.sendNetwork), client.clientPolicy.maxRetries)"));
         assertTrue(client.contains("httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(&networkRetryDecorator, client.clientPolicy.maxRedirect)"));
-        assertTrue(client.contains("response, requestErr := httpRedirectDecorator.Invoke(request)"));
+        assertTrue(client.contains("response, requestErr := httpRedirectDecorator.Invoke(httpRequest)"));
     }
 
     @Test
@@ -129,8 +129,8 @@ public class GoFunctionalTests {
         CODE_LOGGER.logFile(client, FileTypeToLog.CLIENT);
         assertTrue(hasContent(client));
         assertTrue(client.contains("func (client *Client) SimpleWithPayload(request *models.SimpleWithPayloadRequest) (*models.SimpleWithPayloadResponse, error) {"));
-        assertTrue(client.contains("networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.netLayer), client.clientPolicy.maxRetries)"));
-        assertTrue(client.contains("response, requestErr := networkRetryDecorator.Invoke(request)"));
+        assertTrue(client.contains("networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.sendNetwork), client.clientPolicy.maxRetries)"));
+        assertTrue(client.contains("response, requestErr := networkRetryDecorator.Invoke(httpRequest)"));
     }
 
     @Test
@@ -148,7 +148,6 @@ public class GoFunctionalTests {
 
         assertFalse(requestCode.contains("\"strconv\""));
         assertTrue(requestCode.contains("func NewDeleteBucketAclSpectraS3Request(bucketAcl string) *DeleteBucketAclSpectraS3Request {"));
-        assertTrue(requestCode.contains("return \"/_rest_/bucket_acl/\" + deleteBucketAclSpectraS3Request.bucketAcl"));
         assertFalse(returnsStream(requestName, requestCode));
 
         // Verify Response file was generated
@@ -176,9 +175,13 @@ public class GoFunctionalTests {
         final String client = codeGenerator.getClientCode(HttpVerb.DELETE);
         CODE_LOGGER.logFile(client, FileTypeToLog.CLIENT);
         assertTrue(hasContent(client));
+
         assertTrue(client.contains("func (client *Client) DeleteBucketAclSpectraS3(request *models.DeleteBucketAclSpectraS3Request) (*models.DeleteBucketAclSpectraS3Response, error) {"));
-        assertTrue(client.contains("networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.netLayer), client.clientPolicy.maxRetries)"));
-        assertTrue(client.contains("response, requestErr := networkRetryDecorator.Invoke(request)"));
+        assertTrue(client.contains("networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.sendNetwork), client.clientPolicy.maxRetries)"));
+        assertTrue(client.contains("response, requestErr := networkRetryDecorator.Invoke(httpRequest)"));
+
+        assertTrue(client.contains("WithHttpVerb(HTTP_VERB_DELETE)"));
+        assertTrue(client.contains("WithPath(\"/_rest_/bucket_acl/\" + request.BucketAcl)."));
     }
 
     @Test
@@ -208,9 +211,6 @@ public class GoFunctionalTests {
         assertTrue(requestCode.contains("queryParams.Set(\"operation\", \"verify_physical_placement\")"));
         assertTrue(requestCode.contains("bucketName: bucketName,"));
         assertTrue(requestCode.contains("content: buildDs3ObjectStreamFromNames(objectNames),"));
-
-        assertTrue(requestCode.contains("return \"/_rest_/bucket/\" + verifyPhysicalPlacementForObjectsSpectraS3Request.bucketName"));
-        assertTrue(requestCode.contains("return networking.GET"));
 
         assertTrue(returnsStream(requestName, requestCode));
 
@@ -246,9 +246,12 @@ public class GoFunctionalTests {
         CODE_LOGGER.logFile(client, FileTypeToLog.CLIENT);
         assertTrue(hasContent(client));
         assertTrue(client.contains("func (client *Client) VerifyPhysicalPlacementForObjectsSpectraS3(request *models.VerifyPhysicalPlacementForObjectsSpectraS3Request) (*models.VerifyPhysicalPlacementForObjectsSpectraS3Response, error) {"));
-        assertTrue(client.contains("networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.netLayer), client.clientPolicy.maxRetries)"));
+        assertTrue(client.contains("networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.sendNetwork), client.clientPolicy.maxRetries)"));
         assertTrue(client.contains("httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(&networkRetryDecorator, client.clientPolicy.maxRedirect)"));
-        assertTrue(client.contains("response, requestErr := httpRedirectDecorator.Invoke(request)"));
+        assertTrue(client.contains("response, requestErr := httpRedirectDecorator.Invoke(httpRequest)"));
+
+        assertTrue(client.contains("WithHttpVerb(HTTP_VERB_GET)."));
+        assertTrue(client.contains("WithPath(\"/_rest_/bucket/\" + request.BucketName)."));
     }
 
     @Test
@@ -303,8 +306,8 @@ public class GoFunctionalTests {
         CODE_LOGGER.logFile(client, FileTypeToLog.CLIENT);
         assertTrue(hasContent(client));
         assertTrue(client.contains("func (client *Client) ReplicatePutJobSpectraS3(request *models.ReplicatePutJobSpectraS3Request) (*models.ReplicatePutJobSpectraS3Response, error) {"));
-        assertTrue(client.contains("networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.netLayer), client.clientPolicy.maxRetries)"));
-        assertTrue(client.contains("response, requestErr := networkRetryDecorator.Invoke(request)"));
+        assertTrue(client.contains("networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.sendNetwork), client.clientPolicy.maxRetries)"));
+        assertTrue(client.contains("response, requestErr := networkRetryDecorator.Invoke(httpRequest)"));
     }
 
     @Test
@@ -356,8 +359,8 @@ public class GoFunctionalTests {
         CODE_LOGGER.logFile(client, FileTypeToLog.CLIENT);
         assertTrue(hasContent(client));
         assertTrue(client.contains("func (client *Client) CompleteMultiPartUpload(request *models.CompleteMultiPartUploadRequest) (*models.CompleteMultiPartUploadResponse, error) {"));
-        assertTrue(client.contains("networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.netLayer), client.clientPolicy.maxRetries)"));
-        assertTrue(client.contains("response, requestErr := networkRetryDecorator.Invoke(request)"));
+        assertTrue(client.contains("networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.sendNetwork), client.clientPolicy.maxRetries)"));
+        assertTrue(client.contains("response, requestErr := networkRetryDecorator.Invoke(httpRequest)"));
     }
 
     @Test
@@ -414,8 +417,8 @@ public class GoFunctionalTests {
         CODE_LOGGER.logFile(client, FileTypeToLog.CLIENT);
         assertTrue(hasContent(client));
         assertTrue(client.contains("func (client *Client) DeleteObjects(request *models.DeleteObjectsRequest) (*models.DeleteObjectsResponse, error) {"));
-        assertTrue(client.contains("networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.netLayer), client.clientPolicy.maxRetries)"));
-        assertTrue(client.contains("response, requestErr := networkRetryDecorator.Invoke(request)"));
+        assertTrue(client.contains("networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.sendNetwork), client.clientPolicy.maxRetries)"));
+        assertTrue(client.contains("response, requestErr := networkRetryDecorator.Invoke(httpRequest)"));
     }
 
     @Test
@@ -434,7 +437,6 @@ public class GoFunctionalTests {
         assertFalse(requestCode.contains("\"strconv\""));
         assertTrue(requestCode.contains("jobId string"));
         assertTrue(requestCode.contains("jobId: jobId,"));
-        assertTrue(requestCode.contains("\"/_rest_/job/\" + getJobToReplicateSpectraS3Request.jobId"));
 
         // Verify Response file was generated
         final String responseCode = codeGenerator.getResponseCode();
@@ -463,9 +465,12 @@ public class GoFunctionalTests {
         CODE_LOGGER.logFile(client, FileTypeToLog.CLIENT);
         assertTrue(hasContent(client));
         assertTrue(client.contains("func (client *Client) GetJobToReplicateSpectraS3(request *models.GetJobToReplicateSpectraS3Request) (*models.GetJobToReplicateSpectraS3Response, error) {"));
-        assertTrue(client.contains("networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.netLayer), client.clientPolicy.maxRetries)"));
+        assertTrue(client.contains("networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.sendNetwork), client.clientPolicy.maxRetries)"));
         assertTrue(client.contains("httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(&networkRetryDecorator, client.clientPolicy.maxRedirect)"));
-        assertTrue(client.contains("response, requestErr := httpRedirectDecorator.Invoke(request)"));
+        assertTrue(client.contains("response, requestErr := httpRedirectDecorator.Invoke(httpRequest)"));
+
+        assertTrue(client.contains("WithHttpVerb(HTTP_VERB_GET)."));
+        assertTrue(client.contains("WithPath(\"/_rest_/job/\" + request.JobId)"));
     }
 
     @Test
@@ -534,8 +539,8 @@ public class GoFunctionalTests {
         CODE_LOGGER.logFile(client, FileTypeToLog.CLIENT);
         assertTrue(hasContent(client));
         assertTrue(client.contains("func (client *Client) GetObject(request *models.GetObjectRequest) (*models.GetObjectResponse, error) {"));
-        assertTrue(client.contains("networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.netLayer), client.clientPolicy.maxRetries)"));
-        assertTrue(client.contains("response, requestErr := networkRetryDecorator.Invoke(request)"));
+        assertTrue(client.contains("networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.sendNetwork), client.clientPolicy.maxRetries)"));
+        assertTrue(client.contains("response, requestErr := networkRetryDecorator.Invoke(httpRequest)"));
     }
 
     @Test
@@ -611,9 +616,9 @@ public class GoFunctionalTests {
         assertTrue(hasContent(client));
 
         assertTrue(client.contains("func (client *Client) GetAzureDataReplicationRulesSpectraS3(request *models.GetAzureDataReplicationRulesSpectraS3Request) (*models.GetAzureDataReplicationRulesSpectraS3Response, error) {"));
-        assertTrue(client.contains("networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.netLayer), client.clientPolicy.maxRetries)"));
+        assertTrue(client.contains("networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.sendNetwork), client.clientPolicy.maxRetries)"));
         assertTrue(client.contains("httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(&networkRetryDecorator, client.clientPolicy.maxRedirect)"));
-        assertTrue(client.contains("response, requestErr := httpRedirectDecorator.Invoke(request)"));
+        assertTrue(client.contains("response, requestErr := httpRedirectDecorator.Invoke(httpRequest)"));
     }
 
     @Test
@@ -684,8 +689,8 @@ public class GoFunctionalTests {
         assertTrue(hasContent(client));
 
         assertTrue(client.contains("func (client *Client) PutAzureDataReplicationRuleSpectraS3(request *models.PutAzureDataReplicationRuleSpectraS3Request) (*models.PutAzureDataReplicationRuleSpectraS3Response, error) {"));
-        assertTrue(client.contains("networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.netLayer), client.clientPolicy.maxRetries)"));
-        assertTrue(client.contains("response, requestErr := networkRetryDecorator.Invoke(request)"));
+        assertTrue(client.contains("networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.sendNetwork), client.clientPolicy.maxRetries)"));
+        assertTrue(client.contains("response, requestErr := networkRetryDecorator.Invoke(httpRequest)"));
     }
 
     @Test
@@ -716,9 +721,6 @@ public class GoFunctionalTests {
         assertTrue(requestCode.contains("func NewDeleteJobCreatedNotificationRegistrationSpectraS3Request(notificationId string) *DeleteJobCreatedNotificationRegistrationSpectraS3Request {"));
         assertTrue(requestCode.contains("notificationId: notificationId,"));
 
-        // test path
-        assertTrue(requestCode.contains("return \"/_rest_/job_created_notification_registration/\" + deleteJobCreatedNotificationRegistrationSpectraS3Request.notificationId"));
-
         // Verify Response file was generated
         final String responseCode = codeGenerator.getResponseCode();
         CODE_LOGGER.logFile(responseCode, FileTypeToLog.RESPONSE);
@@ -746,8 +748,11 @@ public class GoFunctionalTests {
         assertTrue(hasContent(client));
 
         assertTrue(client.contains("func (client *Client) DeleteJobCreatedNotificationRegistrationSpectraS3(request *models.DeleteJobCreatedNotificationRegistrationSpectraS3Request) (*models.DeleteJobCreatedNotificationRegistrationSpectraS3Response, error) {"));
-        assertTrue(client.contains("networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.netLayer), client.clientPolicy.maxRetries)"));
-        assertTrue(client.contains("response, requestErr := networkRetryDecorator.Invoke(request)"));
+        assertTrue(client.contains("networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.sendNetwork), client.clientPolicy.maxRetries)"));
+        assertTrue(client.contains("response, requestErr := networkRetryDecorator.Invoke(httpRequest)"));
+
+        assertTrue(client.contains("WithHttpVerb(HTTP_VERB_DELETE)."));
+        assertTrue(client.contains("WithPath(\"/_rest_/job_created_notification_registration/\" + request.NotificationId)."));
     }
 
     @Test
@@ -785,9 +790,6 @@ public class GoFunctionalTests {
         assertTrue(requestCode.contains("uploadId: uploadId,"));
         assertTrue(requestCode.contains("content: content,"));
 
-        // test path
-        assertTrue(requestCode.contains("return \"/\" + putMultiPartUploadPartRequest.bucketName + \"/\" + putMultiPartUploadPartRequest.objectName"));
-
         // test content stream
         assertTrue(requestCode.contains("func (putMultiPartUploadPartRequest *PutMultiPartUploadPartRequest) GetContentStream() networking.ReaderWithSizeDecorator {"));
         assertTrue(requestCode.contains("return putMultiPartUploadPartRequest.content"));
@@ -819,8 +821,10 @@ public class GoFunctionalTests {
         assertTrue(hasContent(client));
 
         assertTrue(client.contains("func (client *Client) PutMultiPartUploadPart(request *models.PutMultiPartUploadPartRequest) (*models.PutMultiPartUploadPartResponse, error) {"));
-        assertTrue(client.contains("networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.netLayer), client.clientPolicy.maxRetries)"));
-        assertTrue(client.contains("response, requestErr := networkRetryDecorator.Invoke(request)"));
+        assertTrue(client.contains("networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.sendNetwork), client.clientPolicy.maxRetries)"));
+        assertTrue(client.contains("response, requestErr := networkRetryDecorator.Invoke(httpRequest)"));
+
+        assertTrue(client.contains("WithPath(\"/\" + request.BucketName + \"/\" + request.ObjectName)."));
     }
 
     @Test
@@ -860,9 +864,6 @@ public class GoFunctionalTests {
         assertTrue(requestCode.contains("content: content,"));
         assertTrue(requestCode.contains("checksum: networking.NewNoneChecksum()"));
         assertTrue(requestCode.contains("headers: &http.Header{},"));
-
-        // test path
-        assertTrue(requestCode.contains("return \"/\" + putObjectRequest.bucketName + \"/\" + putObjectRequest.objectName"));
 
         // test content stream
         assertTrue(requestCode.contains("func (putObjectRequest *PutObjectRequest) GetContentStream() networking.ReaderWithSizeDecorator {"));
@@ -906,8 +907,11 @@ public class GoFunctionalTests {
         assertTrue(hasContent(client));
 
         assertTrue(client.contains("func (client *Client) PutObject(request *models.PutObjectRequest) (*models.PutObjectResponse, error) {"));
-        assertTrue(client.contains("networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.netLayer), client.clientPolicy.maxRetries)"));
-        assertTrue(client.contains("response, requestErr := networkRetryDecorator.Invoke(request)"));
+        assertTrue(client.contains("networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.sendNetwork), client.clientPolicy.maxRetries)"));
+        assertTrue(client.contains("response, requestErr := networkRetryDecorator.Invoke(httpRequest)"));
+
+        assertTrue(client.contains("WithHttpVerb(HTTP_VERB_PUT)."));
+        assertTrue(client.contains("WithPath(\"/\" + request.BucketName + \"/\" + request.ObjectName)"));
     }
 
     @Test
@@ -936,9 +940,6 @@ public class GoFunctionalTests {
         assertTrue(requestCode.contains("func (clearSuspectBlobAzureTargetsSpectraS3Request *ClearSuspectBlobAzureTargetsSpectraS3Request) WithForce() *ClearSuspectBlobAzureTargetsSpectraS3Request {"));
         assertTrue(requestCode.contains("clearSuspectBlobAzureTargetsSpectraS3Request.queryParams.Set(\"force\", \"\")"));
 
-        assertTrue(requestCode.contains("return networking.DELETE"));
-        assertTrue(requestCode.contains("return \"/_rest_/suspect_blob_azure_target\""));
-
         assertTrue(requestCode.contains("func (clearSuspectBlobAzureTargetsSpectraS3Request *ClearSuspectBlobAzureTargetsSpectraS3Request) GetContentStream() networking.ReaderWithSizeDecorator {"));
         assertTrue(requestCode.contains("return clearSuspectBlobAzureTargetsSpectraS3Request.content"));
 
@@ -953,9 +954,12 @@ public class GoFunctionalTests {
         assertTrue(isEmpty(typeCode));
 
         // Verify that the client code was generated
-        final String client = codeGenerator.getClientCode(HttpVerb.GET);
+        final String client = codeGenerator.getClientCode(HttpVerb.DELETE);
         CODE_LOGGER.logFile(client, FileTypeToLog.CLIENT);
         assertTrue(hasContent(client));
+
+        assertTrue(client.contains("WithHttpVerb(HTTP_VERB_DELETE)."));
+        assertTrue(client.contains("WithPath(\"/_rest_/suspect_blob_azure_target\")"));
     }
 
     @Test
@@ -994,8 +998,6 @@ public class GoFunctionalTests {
         assertTrue(requestCode.contains("func (putBulkJobSpectraS3Request *PutBulkJobSpectraS3Request) GetContentStream() networking.ReaderWithSizeDecorator {"));
         assertTrue(requestCode.contains("return putBulkJobSpectraS3Request.content"));
 
-        assertTrue(requestCode.contains("return \"/_rest_/bucket/\" + putBulkJobSpectraS3Request.bucketName"));
-
         // Verify Response file was generated
         final String responseCode = codeGenerator.getResponseCode();
         CODE_LOGGER.logFile(responseCode, FileTypeToLog.RESPONSE);
@@ -1020,9 +1022,12 @@ public class GoFunctionalTests {
         assertTrue(hasContent(typeCode));
 
         // Verify that the client code was generated
-        final String client = codeGenerator.getClientCode(HttpVerb.DELETE);
+        final String client = codeGenerator.getClientCode(HttpVerb.PUT);
         CODE_LOGGER.logFile(client, FileTypeToLog.CLIENT);
         assertTrue(hasContent(client));
+
+        assertTrue(client.contains("WithHttpVerb(HTTP_VERB_PUT)."));
+        assertTrue(client.contains("WithPath(\"/_rest_/bucket/\" + request.BucketName)."));
     }
 
     @Test
@@ -1062,9 +1067,6 @@ public class GoFunctionalTests {
         assertTrue(requestCode.contains("func (getBulkJobSpectraS3Request *GetBulkJobSpectraS3Request) GetContentStream() networking.ReaderWithSizeDecorator {"));
         assertTrue(requestCode.contains("return getBulkJobSpectraS3Request.content"));
 
-        assertTrue(requestCode.contains("return networking.PUT"));
-        assertTrue(requestCode.contains("return \"/_rest_/bucket/\" + getBulkJobSpectraS3Request.bucketName"));
-
         // Verify Response file was generated
         final String responseCode = codeGenerator.getResponseCode();
         CODE_LOGGER.logFile(responseCode, FileTypeToLog.RESPONSE);
@@ -1089,9 +1091,12 @@ public class GoFunctionalTests {
         assertTrue(hasContent(typeCode));
 
         // Verify that the client code was generated
-        final String client = codeGenerator.getClientCode(HttpVerb.DELETE);
+        final String client = codeGenerator.getClientCode(HttpVerb.PUT);
         CODE_LOGGER.logFile(client, FileTypeToLog.CLIENT);
         assertTrue(hasContent(client));
+
+        assertTrue(client.contains("WithHttpVerb(HTTP_VERB_PUT)."));
+        assertTrue(client.contains("WithPath(\"/_rest_/bucket/\" + request.BucketName)."));
     }
 
     @Test
@@ -1128,9 +1133,6 @@ public class GoFunctionalTests {
         assertTrue(requestCode.contains("func (verifyBulkJobSpectraS3Request *VerifyBulkJobSpectraS3Request) GetContentStream() networking.ReaderWithSizeDecorator {"));
         assertTrue(requestCode.contains("return verifyBulkJobSpectraS3Request.content"));
 
-        assertTrue(requestCode.contains("return networking.PUT"));
-        assertTrue(requestCode.contains("return \"/_rest_/bucket/\" + verifyBulkJobSpectraS3Request.bucketName"));
-
         // Verify Response file was generated
         final String responseCode = codeGenerator.getResponseCode();
         CODE_LOGGER.logFile(responseCode, FileTypeToLog.RESPONSE);
@@ -1155,8 +1157,11 @@ public class GoFunctionalTests {
         assertTrue(hasContent(typeCode));
 
         // Verify that the client code was generated
-        final String client = codeGenerator.getClientCode(HttpVerb.DELETE);
+        final String client = codeGenerator.getClientCode(HttpVerb.PUT);
         CODE_LOGGER.logFile(client, FileTypeToLog.CLIENT);
         assertTrue(hasContent(client));
+
+        assertTrue(client.contains("WithHttpVerb(HTTP_VERB_PUT)."));
+        assertTrue(client.contains("WithPath(\"/_rest_/bucket/\" + request.BucketName)."));
     }
 }

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/client/ClientGeneratorUtil_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/client/ClientGeneratorUtil_Test.java
@@ -86,14 +86,14 @@ public class ClientGeneratorUtil_Test {
                 .isEqualTo("\"/\" + request.BucketName + \"/\" + request.ObjectName");
 
         //Spectra requests
-        assertThat(getAmazonS3RequestPath(getRequestDeleteNotification())).isEqualTo("");
-        assertThat(getAmazonS3RequestPath(getRequestCreateNotification())).isEqualTo("");
-        assertThat(getAmazonS3RequestPath(getRequestGetNotification())).isEqualTo("");
-        assertThat(getAmazonS3RequestPath(getRequestVerifyPhysicalPlacement())).isEqualTo("");
-        assertThat(getAmazonS3RequestPath(getRequestBulkGet())).isEqualTo("");
-        assertThat(getAmazonS3RequestPath(getRequestBulkPut())).isEqualTo("");
-        assertThat(getAmazonS3RequestPath(getRequestSpectraS3GetObject())).isEqualTo("");
-        assertThat(getAmazonS3RequestPath(getRequestGetJob())).isEqualTo("");
+        assertThat(getAmazonS3RequestPath(getRequestDeleteNotification())).isEmpty();
+        assertThat(getAmazonS3RequestPath(getRequestCreateNotification())).isEmpty();
+        assertThat(getAmazonS3RequestPath(getRequestGetNotification())).isEmpty();
+        assertThat(getAmazonS3RequestPath(getRequestVerifyPhysicalPlacement())).isEmpty();
+        assertThat(getAmazonS3RequestPath(getRequestBulkGet())).isEmpty();
+        assertThat(getAmazonS3RequestPath(getRequestBulkPut())).isEmpty();
+        assertThat(getAmazonS3RequestPath(getRequestSpectraS3GetObject())).isEmpty();
+        assertThat(getAmazonS3RequestPath(getRequestGetJob())).isEmpty();
     }
 
     @Test
@@ -117,8 +117,8 @@ public class ClientGeneratorUtil_Test {
                 .isEqualTo("\"/_rest_/job/\" + request.JobId");
 
         //Amazon requests
-        assertThat(getSpectraDs3RequestPath(getRequestMultiFileDelete())).isEqualTo("");
-        assertThat(getSpectraDs3RequestPath(getRequestCreateObject())).isEqualTo("");
-        assertThat(getSpectraDs3RequestPath(getRequestAmazonS3GetObject())).isEqualTo("");
+        assertThat(getSpectraDs3RequestPath(getRequestMultiFileDelete())).isEmpty();
+        assertThat(getSpectraDs3RequestPath(getRequestCreateObject())).isEmpty();
+        assertThat(getSpectraDs3RequestPath(getRequestAmazonS3GetObject())).isEmpty();
     }
 }

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/client/ClientGeneratorUtil_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/client/ClientGeneratorUtil_Test.java
@@ -1,0 +1,124 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.go.generators.client;
+
+import com.google.common.collect.ImmutableList;
+import com.spectralogic.ds3autogen.api.models.apispec.Ds3Request;
+import com.spectralogic.ds3autogen.api.models.enums.*;
+import org.junit.Test;
+
+import static com.spectralogic.ds3autogen.go.generators.client.ClientGeneratorUtilKt.*;
+import static com.spectralogic.ds3autogen.testutil.Ds3ModelFixtures.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ClientGeneratorUtil_Test {
+
+    @Test
+    public void toRequestPath_Test() {
+        //Spectra requests
+        assertThat(toRequestPath(getRequestDeleteNotification()))
+                .isEqualTo("\"/_rest_/job_created_notification_registration/\" + request.NotificationId");
+        assertThat(toRequestPath(getRequestCreateNotification()))
+                .isEqualTo("\"/_rest_/job_created_notification_registration\"");
+        assertThat(toRequestPath(getRequestGetNotification()))
+                .isEqualTo("\"/_rest_/job_completed_notification_registration/\" + request.NotificationId");
+        assertThat(toRequestPath(getRequestVerifyPhysicalPlacement())).
+                isEqualTo("\"/_rest_/bucket/\" + request.BucketName");
+        assertThat(toRequestPath(getRequestBulkGet()))
+                .isEqualTo("\"/_rest_/bucket/\" + request.BucketName");
+        assertThat(toRequestPath(getRequestBulkPut()))
+                .isEqualTo("\"/_rest_/bucket/\" + request.BucketName");
+        assertThat(toRequestPath(getRequestSpectraS3GetObject()))
+                .isEqualTo("\"/_rest_/object/\" + request.ObjectName");
+        assertThat(toRequestPath(getRequestGetJob()))
+                .isEqualTo("\"/_rest_/job/\" + request.JobId");
+
+        //Amazon requests
+        assertThat(toRequestPath(getRequestMultiFileDelete()))
+                .isEqualTo("\"/\" + request.BucketName");
+        assertThat(toRequestPath(getRequestCreateObject()))
+                .isEqualTo("\"/\" + request.BucketName + \"/\" + request.ObjectName");
+        assertThat(toRequestPath(getRequestAmazonS3GetObject()))
+                .isEqualTo("\"/\" + request.BucketName + \"/\" + request.ObjectName");
+    }
+
+    @Test (expected = IllegalArgumentException.class)
+    public void toRequestPath_Exception_Test() {
+        final Ds3Request request = new Ds3Request(
+                "Test",
+                HttpVerb.GET,
+                Classification.spectrainternal,
+                Requirement.NOT_ALLOWED,
+                Requirement.NOT_ALLOWED,
+                Action.BULK_DELETE,
+                Resource.ACTIVE_JOB,
+                ResourceType.NON_SINGLETON,
+                Operation.ALLOCATE,
+                false,
+                ImmutableList.of(),
+                ImmutableList.of(),
+                ImmutableList.of());
+
+        toRequestPath(request);
+    }
+
+    @Test
+    public void getAmazonS3RequestPath_Test() {
+        //Amazon requests
+        assertThat(getAmazonS3RequestPath(getRequestMultiFileDelete()))
+                .isEqualTo("\"/\" + request.BucketName");
+        assertThat(getAmazonS3RequestPath(getRequestCreateObject()))
+                .isEqualTo("\"/\" + request.BucketName + \"/\" + request.ObjectName");
+        assertThat(getAmazonS3RequestPath(getRequestAmazonS3GetObject()))
+                .isEqualTo("\"/\" + request.BucketName + \"/\" + request.ObjectName");
+
+        //Spectra requests
+        assertThat(getAmazonS3RequestPath(getRequestDeleteNotification())).isEqualTo("");
+        assertThat(getAmazonS3RequestPath(getRequestCreateNotification())).isEqualTo("");
+        assertThat(getAmazonS3RequestPath(getRequestGetNotification())).isEqualTo("");
+        assertThat(getAmazonS3RequestPath(getRequestVerifyPhysicalPlacement())).isEqualTo("");
+        assertThat(getAmazonS3RequestPath(getRequestBulkGet())).isEqualTo("");
+        assertThat(getAmazonS3RequestPath(getRequestBulkPut())).isEqualTo("");
+        assertThat(getAmazonS3RequestPath(getRequestSpectraS3GetObject())).isEqualTo("");
+        assertThat(getAmazonS3RequestPath(getRequestGetJob())).isEqualTo("");
+    }
+
+    @Test
+    public void getSpectraDs3RequestPath_Test() {
+        //Spectra requests
+        assertThat(getSpectraDs3RequestPath(getRequestDeleteNotification()))
+                .isEqualTo("\"/_rest_/job_created_notification_registration/\" + request.NotificationId");
+        assertThat(getSpectraDs3RequestPath(getRequestCreateNotification()))
+                .isEqualTo("\"/_rest_/job_created_notification_registration\"");
+        assertThat(getSpectraDs3RequestPath(getRequestGetNotification()))
+                .isEqualTo("\"/_rest_/job_completed_notification_registration/\" + request.NotificationId");
+        assertThat(getSpectraDs3RequestPath(getRequestVerifyPhysicalPlacement()))
+                .isEqualTo("\"/_rest_/bucket/\" + request.BucketName");
+        assertThat(getSpectraDs3RequestPath(getRequestBulkGet()))
+                .isEqualTo("\"/_rest_/bucket/\" + request.BucketName");
+        assertThat(getSpectraDs3RequestPath(getRequestBulkPut()))
+                .isEqualTo("\"/_rest_/bucket/\" + request.BucketName");
+        assertThat(getSpectraDs3RequestPath(getRequestSpectraS3GetObject()))
+                .isEqualTo("\"/_rest_/object/\" + request.ObjectName");
+        assertThat(getSpectraDs3RequestPath(getRequestGetJob()))
+                .isEqualTo("\"/_rest_/job/\" + request.JobId");
+
+        //Amazon requests
+        assertThat(getSpectraDs3RequestPath(getRequestMultiFileDelete())).isEqualTo("");
+        assertThat(getSpectraDs3RequestPath(getRequestCreateObject())).isEqualTo("");
+        assertThat(getSpectraDs3RequestPath(getRequestAmazonS3GetObject())).isEqualTo("");
+    }
+}

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/request/RequestGeneratorUtil_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/request/RequestGeneratorUtil_Test.java
@@ -18,38 +18,17 @@ package com.spectralogic.ds3autogen.go.generators.request;
 import com.google.common.collect.ImmutableList;
 import com.spectralogic.ds3autogen.api.models.Arguments;
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3Param;
-import com.spectralogic.ds3autogen.api.models.apispec.Ds3Request;
-import com.spectralogic.ds3autogen.api.models.enums.*;
+import com.spectralogic.ds3autogen.api.models.enums.HttpVerb;
 import com.spectralogic.ds3autogen.go.models.request.SimpleVariable;
 import com.spectralogic.ds3autogen.go.models.request.Variable;
 import com.spectralogic.ds3autogen.go.models.request.WithConstructor;
 import org.junit.Test;
 
 import static com.spectralogic.ds3autogen.go.generators.request.RequestGeneratorUtilKt.*;
-import static com.spectralogic.ds3autogen.testutil.Ds3ModelFixtures.*;
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class RequestGeneratorUtil_Test {
-
-    private static Ds3Request createTestRequest(final Resource resource, final boolean includeInPath) {
-        return new Ds3Request(
-                "com.test.TestRequest",
-                null,
-                Classification.amazons3,
-                null,
-                null,
-                null,
-                resource,
-                null,
-                null,
-                includeInPath,
-                null,
-                null,
-                null);
-    }
 
     @Test
     public void removeVoidParams_NullList_Test() {
@@ -313,102 +292,6 @@ public class RequestGeneratorUtil_Test {
     }
 
     @Test
-    public void toRequestPath_Test() {
-        //Spectra requests
-        assertThat(toRequestPath(getRequestDeleteNotification()),
-                is("\"/_rest_/job_created_notification_registration/\" + deleteJobCreatedNotificationRegistrationRequestHandler.notificationId"));
-        assertThat(toRequestPath(getRequestCreateNotification()),
-                is("\"/_rest_/job_created_notification_registration\""));
-        assertThat(toRequestPath(getRequestGetNotification()),
-                is("\"/_rest_/job_completed_notification_registration/\" + getJobCompletedNotificationRegistrationRequestHandler.notificationId"));
-        assertThat(toRequestPath(getRequestVerifyPhysicalPlacement()),
-                is("\"/_rest_/bucket/\" + verifyPhysicalPlacementForObjectsRequestHandler.bucketName"));
-        assertThat(toRequestPath(getRequestBulkGet()),
-                is("\"/_rest_/bucket/\" + createGetJobRequestHandler.bucketName"));
-        assertThat(toRequestPath(getRequestBulkPut()),
-                is("\"/_rest_/bucket/\" + createPutJobRequestHandler.bucketName"));
-        assertThat(toRequestPath(getRequestSpectraS3GetObject()),
-                is("\"/_rest_/object/\" + getObjectRequestHandler.objectName"));
-        assertThat(toRequestPath(getRequestGetJob()),
-                is("\"/_rest_/job/\" + getJobRequestHandler.jobId"));
-
-        //Amazon requests
-        assertThat(toRequestPath(getRequestMultiFileDelete()),
-                is("\"/\" + deleteObjectsRequestHandler.bucketName"));
-        assertThat(toRequestPath(getRequestCreateObject()),
-                is("\"/\" + createObjectRequestHandler.bucketName + \"/\" + createObjectRequestHandler.objectName"));
-        assertThat(toRequestPath(getRequestAmazonS3GetObject()),
-                is("\"/\" + getObjectRequestHandler.bucketName + \"/\" + getObjectRequestHandler.objectName"));
-    }
-
-    @Test (expected = IllegalArgumentException.class)
-    public void toRequestPath_Exception_Test() {
-        final Ds3Request request = new Ds3Request(
-                "Test",
-                HttpVerb.GET,
-                Classification.spectrainternal,
-                Requirement.NOT_ALLOWED,
-                Requirement.NOT_ALLOWED,
-                Action.BULK_DELETE,
-                Resource.ACTIVE_JOB,
-                ResourceType.NON_SINGLETON,
-                Operation.ALLOCATE,
-                false,
-                ImmutableList.of(),
-                ImmutableList.of(),
-                ImmutableList.of());
-
-        toRequestPath(request);
-    }
-
-    @Test
-    public void getAmazonS3RequestPath_Test() {
-        //Amazon requests
-        assertThat(getAmazonS3RequestPath(getRequestMultiFileDelete()),
-                is("\"/\" + deleteObjectsRequestHandler.bucketName"));
-        assertThat(getAmazonS3RequestPath(getRequestCreateObject()),
-                is("\"/\" + createObjectRequestHandler.bucketName + \"/\" + createObjectRequestHandler.objectName"));
-        assertThat(getAmazonS3RequestPath(getRequestAmazonS3GetObject()),
-                is("\"/\" + getObjectRequestHandler.bucketName + \"/\" + getObjectRequestHandler.objectName"));
-
-        //Spectra requests
-        assertThat(getAmazonS3RequestPath(getRequestDeleteNotification()), is(""));
-        assertThat(getAmazonS3RequestPath(getRequestCreateNotification()), is(""));
-        assertThat(getAmazonS3RequestPath(getRequestGetNotification()), is(""));
-        assertThat(getAmazonS3RequestPath(getRequestVerifyPhysicalPlacement()), is(""));
-        assertThat(getAmazonS3RequestPath(getRequestBulkGet()), is(""));
-        assertThat(getAmazonS3RequestPath(getRequestBulkPut()), is(""));
-        assertThat(getAmazonS3RequestPath(getRequestSpectraS3GetObject()), is(""));
-        assertThat(getAmazonS3RequestPath(getRequestGetJob()), is(""));
-    }
-
-    @Test
-    public void getSpectraDs3RequestPath_Test() {
-        //Spectra requests
-        assertThat(getSpectraDs3RequestPath(getRequestDeleteNotification()),
-                is("\"/_rest_/job_created_notification_registration/\" + deleteJobCreatedNotificationRegistrationRequestHandler.notificationId"));
-        assertThat(getSpectraDs3RequestPath(getRequestCreateNotification()),
-                is("\"/_rest_/job_created_notification_registration\""));
-        assertThat(getSpectraDs3RequestPath(getRequestGetNotification()),
-                is("\"/_rest_/job_completed_notification_registration/\" + getJobCompletedNotificationRegistrationRequestHandler.notificationId"));
-        assertThat(getSpectraDs3RequestPath(getRequestVerifyPhysicalPlacement()),
-                is("\"/_rest_/bucket/\" + verifyPhysicalPlacementForObjectsRequestHandler.bucketName"));
-        assertThat(getSpectraDs3RequestPath(getRequestBulkGet()),
-                is("\"/_rest_/bucket/\" + createGetJobRequestHandler.bucketName"));
-        assertThat(getSpectraDs3RequestPath(getRequestBulkPut()),
-                is("\"/_rest_/bucket/\" + createPutJobRequestHandler.bucketName"));
-        assertThat(getSpectraDs3RequestPath(getRequestSpectraS3GetObject()),
-                is("\"/_rest_/object/\" + getObjectRequestHandler.objectName"));
-        assertThat(getSpectraDs3RequestPath(getRequestGetJob()),
-                is("\"/_rest_/job/\" + getJobRequestHandler.jobId"));
-
-        //Amazon requests
-        assertThat(getSpectraDs3RequestPath(getRequestMultiFileDelete()), is(""));
-        assertThat(getSpectraDs3RequestPath(getRequestCreateObject()), is(""));
-        assertThat(getSpectraDs3RequestPath(getRequestAmazonS3GetObject()), is(""));
-    }
-
-    @Test
     public void toWithConstructors_NullList_Test() {
         final ImmutableList<WithConstructor> result = toWithConstructors(null, false);
         assertThat(result.size(), is(0));
@@ -480,44 +363,6 @@ public class RequestGeneratorUtil_Test {
 
         assertThat(params.size(), is(expected.size()));
         params.forEach(param -> assertThat(expected, hasItem(toWithConstructor(param))));
-    }
-
-    @Test (expected = IllegalArgumentException.class)
-    public void getGoArgFromResource_ExceptionTest() {
-        getGoArgFromResource(createTestRequest(Resource.CAPACITY_SUMMARY, true));
-    }
-
-    @Test
-    public void getGoArgFromResource_Test() {
-        final ImmutableList<Arguments> expectedArgs = ImmutableList.of(
-                new Arguments("String", "notificationId"),
-                new Arguments("String", "bucketId"),
-                new Arguments("UUID", "jobId"),
-                new Arguments("String", "activeJob")
-        );
-
-        final ImmutableList<Ds3Request> requests = ImmutableList.of(
-                createTestRequest(Resource.DS3_TARGET_FAILURE_NOTIFICATION_REGISTRATION, true),
-                createTestRequest(Resource.BUCKET, true),
-                createTestRequest(Resource.JOB, true),
-                createTestRequest(Resource.ACTIVE_JOB, true)
-        );
-
-        assertThat(requests.size(), is(expectedArgs.size()));
-        for (int i = 0; i > requests.size(); i++) {
-            final Arguments result = getGoArgFromResource(requests.get(i));
-            assertThat(result.getName(), is(expectedArgs.get(i).getName()));
-            assertThat(result.getType(), is(expectedArgs.get(i).getType()));
-        }
-    }
-
-    @Test
-    public void isGoResourceAnArg_Test() {
-        assertFalse(isGoResourceAnArg(createTestRequest(null, true)));
-        assertFalse(isGoResourceAnArg(createTestRequest(null, false)));
-        assertFalse(isGoResourceAnArg(createTestRequest(Resource.ACTIVE_JOB, false)));
-
-        assertTrue(isGoResourceAnArg(createTestRequest(Resource.ACTIVE_JOB, true)));
     }
 
     @Test

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/models/client/RequestBuildLine_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/models/client/RequestBuildLine_Test.java
@@ -1,0 +1,44 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.go.models.client;
+
+import com.spectralogic.ds3autogen.api.models.enums.HttpVerb;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RequestBuildLine_Test {
+
+    @Test
+    public void httpVerbBuildLine_Test() {
+        assertThat(new HttpVerbBuildLine(HttpVerb.GET).getLine())
+                .isEqualTo("WithHttpVerb(HTTP_VERB_GET).");
+        assertThat(new HttpVerbBuildLine(HttpVerb.PUT).getLine())
+                .isEqualTo("WithHttpVerb(HTTP_VERB_PUT).");
+        assertThat(new HttpVerbBuildLine(HttpVerb.POST).getLine())
+                .isEqualTo("WithHttpVerb(HTTP_VERB_POST).");
+        assertThat(new HttpVerbBuildLine(HttpVerb.DELETE).getLine())
+                .isEqualTo("WithHttpVerb(HTTP_VERB_DELETE).");
+        assertThat(new HttpVerbBuildLine(HttpVerb.HEAD).getLine())
+                .isEqualTo("WithHttpVerb(HTTP_VERB_HEAD).");
+    }
+
+    @Test
+    public void pathBuildLine_Test() {
+        assertThat(new PathBuildLine("\"/_rest_/my-path\"").getLine())
+                .isEqualTo("WithPath(\"/_rest_/my-path\").");
+    }
+}

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/utils/Ds3RequestUtil_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/utils/Ds3RequestUtil_Test.java
@@ -1,0 +1,87 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.go.utils;
+
+import com.google.common.collect.ImmutableList;
+import com.spectralogic.ds3autogen.api.models.Arguments;
+import com.spectralogic.ds3autogen.api.models.apispec.Ds3Request;
+import com.spectralogic.ds3autogen.api.models.enums.Classification;
+import com.spectralogic.ds3autogen.api.models.enums.Resource;
+import org.junit.Test;
+
+import static com.spectralogic.ds3autogen.go.utils.Ds3RequestUtilKt.getGoArgFromResource;
+import static com.spectralogic.ds3autogen.go.utils.Ds3RequestUtilKt.isGoResourceAnArg;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class Ds3RequestUtil_Test {
+
+    private static Ds3Request createTestRequest(final Resource resource, final boolean includeInPath) {
+        return new Ds3Request(
+                "com.test.TestRequest",
+                null,
+                Classification.amazons3,
+                null,
+                null,
+                null,
+                resource,
+                null,
+                null,
+                includeInPath,
+                null,
+                null,
+                null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void getGoArgFromResource_ExceptionTest() {
+        getGoArgFromResource(createTestRequest(Resource.CAPACITY_SUMMARY, true));
+    }
+
+    @Test
+    public void getGoArgFromResource_Test() {
+        final ImmutableList<Arguments> expectedArgs = ImmutableList.of(
+                new Arguments("String", "NotificationId"),
+                new Arguments("String", "BucketName"),
+                new Arguments("String", "JobId"),
+                new Arguments("String", "ActiveJobId")
+        );
+
+        final ImmutableList<Ds3Request> requests = ImmutableList.of(
+                createTestRequest(Resource.DS3_TARGET_FAILURE_NOTIFICATION_REGISTRATION, true),
+                createTestRequest(Resource.BUCKET, true),
+                createTestRequest(Resource.JOB, true),
+                createTestRequest(Resource.ACTIVE_JOB, true)
+        );
+
+        assertThat(requests).hasSize(expectedArgs.size());
+        for (int i = 0; i < requests.size(); i++) {
+            final Arguments result = getGoArgFromResource(requests.get(i));
+            assertThat(result.getName()).isEqualTo(expectedArgs.get(i).getName());
+            assertThat(result.getType()).isEqualTo(expectedArgs.get(i).getType());
+        }
+    }
+
+    @Test
+    public void isGoResourceAnArg_Test() {
+        assertFalse(isGoResourceAnArg(createTestRequest(null, true)));
+        assertFalse(isGoResourceAnArg(createTestRequest(null, false)));
+        assertFalse(isGoResourceAnArg(createTestRequest(Resource.ACTIVE_JOB, false)));
+
+        assertTrue(isGoResourceAnArg(createTestRequest(Resource.ACTIVE_JOB, true)));
+    }
+}


### PR DESCRIPTION
**Changes**
- Updated client template
- Moved request path logic from requests to client module and updated accordingly
- Client now generates request builder for each command, and adds Http Verb and Path
- Updated existing tests

**Work To Do**
- Add the rest of the build options for each request
  - optional parameters, required parameters, stream, metadata, checksum

**Example Code**
```
func (client *Client) PutObject(request *models.PutObjectRequest) (*models.PutObjectResponse, error) {
    // Build the http request
    httpRequest, err := networking.NewHttpRequestBuilder().
        WithHttpVerb(HTTP_VERB_PUT).
        WithPath("/" + request.BucketName + "/" + request.ObjectName).
        Build(client.connectionInfo)

    if err != nil {
        return nil, err
    }

    networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.sendNetwork), client.clientPolicy.maxRetries)

    // Invoke the HTTP request.
    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
    if requestErr != nil {
        return nil, requestErr
    }

    // Create a response object based on the result.
    return models.NewPutObjectResponse(response)
}
```