### PR TITLE
GOSDK-8 continued: Created base command generator used within client

### DIFF
--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/client/BaseClientGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/client/BaseClientGenerator.kt
@@ -18,8 +18,10 @@ package com.spectralogic.ds3autogen.go.generators.client
 import com.google.common.collect.ImmutableList
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3Request
 import com.spectralogic.ds3autogen.api.models.enums.HttpVerb
-import com.spectralogic.ds3autogen.go.models.client.*
-import com.spectralogic.ds3autogen.utils.ClientGeneratorUtil
+import com.spectralogic.ds3autogen.go.generators.client.command.BaseCommandGenerator
+import com.spectralogic.ds3autogen.go.generators.client.command.CommandModelGenerator
+import com.spectralogic.ds3autogen.go.models.client.Client
+import com.spectralogic.ds3autogen.go.models.client.Command
 import com.spectralogic.ds3autogen.utils.ConverterUtil
 import com.spectralogic.ds3autogen.utils.Ds3RequestClassificationUtil.isGetObjectAmazonS3Request
 import com.spectralogic.ds3autogen.utils.collections.GuavaCollectors
@@ -50,35 +52,26 @@ open class BaseClientGenerator : ClientModelGenerator<Client> {
     }
 
     /**
-     * Converts a Ds3Request into a Command
-     */
-    fun toCommand(ds3Request: Ds3Request): Command {
-        return Command(
-                ClientGeneratorUtil.toCommandName(ds3Request.name),
-                toRequestBuildLines(ds3Request))
-    }
-
-    /**
-     * Creates the list of request handler build lines required to construct the
-     * http request using a builder within the client. This excludes the request
-     * builder initialization (first line) and the build command (last line).
-     */
-    fun toRequestBuildLines(ds3Request: Ds3Request): ImmutableList<RequestBuildLine> {
-        val builder = ImmutableList.builder<RequestBuildLine>()
-        builder.add(HttpVerbBuildLine(ds3Request.httpVerb))
-        builder.add(PathBuildLine(ds3Request.toRequestPath()))
-        //todo add required params, optional params, reader, read closer, checksum, headers
-        return builder.build()
-    }
-
-    /**
      * Determines if a command should handle http temporary redirects within generated
      * Go client code
      */
     fun hasHttpRedirect(ds3Request: Ds3Request): Boolean {
-        if (ds3Request.httpVerb != HttpVerb.GET || isGetObjectAmazonS3Request(ds3Request)) {
-            return false
-        }
-        return true
+        return ds3Request.httpVerb == HttpVerb.GET && !isGetObjectAmazonS3Request(ds3Request)
+    }
+
+    /**
+     * Converts a Ds3Request into a Command
+     */
+    fun toCommand(ds3Request: Ds3Request): Command {
+        val generator = getCommandGenerator(ds3Request)
+        return generator.generate(ds3Request)
+    }
+
+    /**
+     * Retrieves the command generator for the specified Ds3Request.
+     */
+    fun getCommandGenerator(ds3Request: Ds3Request): CommandModelGenerator<*> {
+        //todo add special casing
+        return BaseCommandGenerator()
     }
 }

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/client/command/BaseCommandGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/client/command/BaseCommandGenerator.kt
@@ -1,0 +1,149 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.go.generators.client.command
+
+import com.google.common.collect.ImmutableList
+import com.spectralogic.ds3autogen.api.models.apispec.Ds3Param
+import com.spectralogic.ds3autogen.api.models.apispec.Ds3Request
+import com.spectralogic.ds3autogen.api.models.enums.Operation
+import com.spectralogic.ds3autogen.go.generators.client.*
+import com.spectralogic.ds3autogen.go.models.client.*
+import com.spectralogic.ds3autogen.go.utils.toGoParamName
+import com.spectralogic.ds3autogen.go.utils.toGoType
+import com.spectralogic.ds3autogen.utils.ClientGeneratorUtil
+import com.spectralogic.ds3autogen.utils.ConverterUtil.isEmpty
+import com.spectralogic.ds3autogen.utils.Helper
+import com.spectralogic.ds3autogen.utils.collections.GuavaCollectors
+import java.util.*
+
+open class BaseCommandGenerator : CommandModelGenerator<Command>, CommandGeneratorUtil {
+
+    override fun generate(ds3Request: Ds3Request): Command {
+        return Command(
+                ClientGeneratorUtil.toCommandName(ds3Request.name),
+                toRequestBuildLines(ds3Request))
+    }
+
+    /**
+     * Creates the list of request handler build lines required to construct the
+     * http request using a builder within the client. This excludes the request
+     * builder initialization (first line) and the build command (last line).
+     */
+    fun toRequestBuildLines(ds3Request: Ds3Request): ImmutableList<RequestBuildLine> {
+        val builder = ImmutableList.builder<RequestBuildLine>()
+        builder.add(HttpVerbBuildLine(ds3Request.httpVerb))
+        builder.add(PathBuildLine(ds3Request.toRequestPath()))
+        builder.addAll(toRequiredQueryParamBuildLines(ds3Request.requiredQueryParams))
+        builder.addAll(toOptionalQueryParamBuildLines(ds3Request.optionalQueryParams))
+
+        // Add optional build lines
+        toOperationBuildLine(ds3Request.operation).ifPresent { line -> builder.add(line) }
+        toReaderBuildLine().ifPresent{ line -> builder.add(line) }
+        toChecksumBuildLine().ifPresent{ line -> builder.add(line) }
+        toHeadersBuildLine().ifPresent { line -> builder.add(line) }
+        return builder.build()
+    }
+
+    /**
+     * Retrieves the request builder lines for adding required query parameters.
+     */
+    override fun toRequiredQueryParamBuildLines(requiredParams: ImmutableList<Ds3Param>?): ImmutableList<RequestBuildLine> {
+        if (isEmpty(requiredParams)) {
+            return ImmutableList.of()
+        }
+
+        return requiredParams!!.stream()
+                .filter { param -> param.name != "Operation" }
+                .map { param -> toRequiredQueryParamBuildLine(param) }
+                .collect(GuavaCollectors.immutableList())
+    }
+
+    /**
+     * Generates the request builder line for adding this required query parameter.
+     */
+    fun toRequiredQueryParamBuildLine(ds3Param: Ds3Param): RequestBuildLine {
+        val goType = toGoType(ds3Param.type, nullable = false)
+        val goName = toGoParamName(ds3Param.name, ds3Param.type)
+        val key = Helper.camelToUnderscore(ds3Param.name)
+        val value = goQueryParamToString(goName, goType)
+        return QueryParamBuildLine(key, value)
+    }
+
+    /**
+     * Retrieves the request builder lines for adding optional query parameters.
+     */
+    override fun toOptionalQueryParamBuildLines(optionalParams: ImmutableList<Ds3Param>?): ImmutableList<RequestBuildLine> {
+        if (isEmpty(optionalParams)) {
+            return ImmutableList.of()
+        }
+
+        return optionalParams!!.stream()
+                .map { param -> toOptionalQueryParamBuildLine(param) }
+                .collect(GuavaCollectors.immutableList())
+    }
+
+
+    /**
+     * Converts a Ds3Param into an optional query parameter RequestBuildLine.
+     */
+    fun toOptionalQueryParamBuildLine(ds3Param: Ds3Param): RequestBuildLine {
+        val goType = toGoType(ds3Param.type, nullable = true)
+        val goName = toGoParamName(ds3Param.name, ds3Param.type)
+        val key = Helper.camelToUnderscore(ds3Param.name)
+
+        if (ds3Param.type.toLowerCase() == "void") {
+            return VoidOptionalQueryParamBuildLine(key, goName)
+        }
+
+        val value = goPtrQueryParamToStringPtr(goName, goType)
+        return OptionalQueryParamBuildLine(key, value)
+    }
+
+    /**
+     * Retrieves the request builder line for adding the operation query param if the command
+     * specifies an operation. Else, it returns an empty optional.
+     */
+    fun toOperationBuildLine(operation: Operation?): Optional<RequestBuildLine> {
+        if (operation == null) {
+            return Optional.empty()
+        }
+        return Optional.of(OperationBuildLine(operation))
+    }
+
+    /**
+     * Retrieves the request builder line for adding a reader/read closer if the command has
+     * a request payload. The base command does not have a request payload.
+     */
+    override fun toReaderBuildLine(): Optional<RequestBuildLine> {
+        return Optional.empty()
+    }
+
+    /**
+     * Retrieves the request builder line for adding checksum if the command supports checksumming.
+     * The base command does not have checksumming.
+     */
+    override fun toChecksumBuildLine(): Optional<RequestBuildLine> {
+        return Optional.empty()
+    }
+
+    /**
+     * Retrieves the request builder line for adding headers if the command has headers.
+     * The base command does not have any headers.
+     */
+    override fun toHeadersBuildLine(): Optional<RequestBuildLine> {
+        return Optional.empty()
+    }
+}

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/client/command/CommandGeneratorUtil.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/client/command/CommandGeneratorUtil.kt
@@ -1,0 +1,52 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.go.generators.client.command
+
+import com.google.common.collect.ImmutableList
+import com.spectralogic.ds3autogen.api.models.apispec.Ds3Param
+import com.spectralogic.ds3autogen.go.models.client.RequestBuildLine
+import java.util.*
+
+interface CommandGeneratorUtil {
+
+    /**
+     * Retrieves the request builder lines for adding required query params.
+     */
+    fun toRequiredQueryParamBuildLines(requiredParams: ImmutableList<Ds3Param>?): ImmutableList<RequestBuildLine>
+
+    /**
+     * Retrieves the request builder lines for adding optional query params.
+     */
+    fun toOptionalQueryParamBuildLines(optionalParams: ImmutableList<Ds3Param>?): ImmutableList<RequestBuildLine>
+
+    /**
+     * Retrieves the request builder line for adding a reader/read closer if the command has
+     * a request payload. Else, an empty Optional is returned.
+     */
+    fun toReaderBuildLine(): Optional<RequestBuildLine>
+
+    /**
+     * Retrieves the request builder line for adding checksum if the command supports checksumming.
+     * Else, an empty Optional is returned.
+     */
+    fun toChecksumBuildLine(): Optional<RequestBuildLine>
+
+    /**
+     * Retrieves the request builder line for adding headers if the command has headers.
+     * Else, an empty Optional is returned.
+     */
+    fun toHeadersBuildLine(): Optional<RequestBuildLine>
+}

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/client/command/CommandModelGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/client/command/CommandModelGenerator.kt
@@ -1,0 +1,24 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.go.generators.client.command
+
+import com.spectralogic.ds3autogen.api.models.apispec.Ds3Request
+import com.spectralogic.ds3autogen.go.models.client.Command
+
+@FunctionalInterface
+interface CommandModelGenerator<out T : Command> {
+    fun generate(ds3Request: Ds3Request): T
+}

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/models/client/RequestBuildLine.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/models/client/RequestBuildLine.kt
@@ -16,6 +16,7 @@
 package com.spectralogic.ds3autogen.go.models.client
 
 import com.spectralogic.ds3autogen.api.models.enums.HttpVerb
+import com.spectralogic.ds3autogen.api.models.enums.Operation
 
 interface RequestBuildLine {
     val line: String
@@ -31,7 +32,35 @@ data class HttpVerbBuildLine(private val httpVerb: HttpVerb) : RequestBuildLine 
 
 // Creates the Go request builder line for adding a path to an http request
 data class PathBuildLine(private val path: String) : RequestBuildLine {
+    override val line: String
+        get() = "WithPath($path)."
+}
+
+// Creates the Go request builder line for adding the operation query param
+data class OperationBuildLine(private val operation: Operation) : RequestBuildLine {
     override val line: String get() {
-        return "WithPath($path)."
+        val op = operation.toString().toLowerCase()
+        return "WithQueryParam(\"operation\", \"$op\")."
     }
+}
+
+// Creates the Go request builder line for adding a required query param
+data class QueryParamBuildLine(private val key: String, private val value: String) : RequestBuildLine {
+    override val line: String
+        get() = "WithQueryParam(\"$key\", $value)."
+}
+
+// Creates the Go request builder line for adding an optional query param.
+// An optional parameter may be nil to indicate it has not been set.
+data class OptionalQueryParamBuildLine(private val key: String, private val value: String) : RequestBuildLine {
+    override val line: String
+        get() = "WithOptionalQueryParam(\"$key\", $value)."
+}
+
+// Creates the Go request builder line for adding an optional void query param.
+// Optional voids are represented by booleans within the Go request handler
+data class VoidOptionalQueryParamBuildLine(private val key: String, private val paramName: String) : RequestBuildLine {
+    override val line: String
+        get() = "WithOptionalVoidQueryParam(\"$key\", request.$paramName)."
+
 }

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTests.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTests.java
@@ -77,10 +77,17 @@ public class GoFunctionalTests {
         final String client = codeGenerator.getClientCode(HttpVerb.GET);
         CODE_LOGGER.logFile(client, FileTypeToLog.CLIENT);
         assertTrue(hasContent(client));
+
         assertTrue(client.contains("func (client *Client) SimpleNoPayload(request *models.SimpleNoPayloadRequest) (*models.SimpleNoPayloadResponse, error) {"));
         assertTrue(client.contains("networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.sendNetwork), client.clientPolicy.maxRetries)"));
         assertTrue(client.contains("httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(&networkRetryDecorator, client.clientPolicy.maxRedirect)"));
         assertTrue(client.contains("response, requestErr := httpRedirectDecorator.Invoke(httpRequest)"));
+
+        assertTrue(client.contains("WithHttpVerb(HTTP_VERB_GET)."));
+        assertTrue(client.contains("WithPath(\"/\" + request.BucketName)."));
+        assertTrue(client.contains("WithQueryParam(\"id\", request.Id)."));
+        assertTrue(client.contains("WithOptionalQueryParam(\"upload_id\", request.UploadId)."));
+        assertTrue(client.contains("WithOptionalQueryParam(\"offset\", networking.Int64PtrToStrPtr(request.Offset))."));
     }
 
     @Test
@@ -128,9 +135,17 @@ public class GoFunctionalTests {
         final String client = codeGenerator.getClientCode(HttpVerb.DELETE);
         CODE_LOGGER.logFile(client, FileTypeToLog.CLIENT);
         assertTrue(hasContent(client));
+
         assertTrue(client.contains("func (client *Client) SimpleWithPayload(request *models.SimpleWithPayloadRequest) (*models.SimpleWithPayloadResponse, error) {"));
         assertTrue(client.contains("networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.sendNetwork), client.clientPolicy.maxRetries)"));
         assertTrue(client.contains("response, requestErr := networkRetryDecorator.Invoke(httpRequest)"));
+
+        assertTrue(client.contains("WithHttpVerb(HTTP_VERB_DELETE)."));
+        assertTrue(client.contains("WithPath(\"/\" + request.BucketName + \"/\" + request.ObjectName)."));
+        assertTrue(client.contains("WithQueryParam(\"void_param\", \"\")."));
+        assertTrue(client.contains("WithQueryParam(\"place_holder\", request.PlaceHolder.String())."));
+        assertTrue(client.contains("WithOptionalQueryParam(\"optional_place_holder\", networking.IntPtrToStrPtr(request.OptionalPlaceHolder))."));
+        assertTrue(client.contains("WithQueryParam(\"operation\", \"start_bulk_get\")."));
     }
 
     @Test
@@ -252,6 +267,8 @@ public class GoFunctionalTests {
 
         assertTrue(client.contains("WithHttpVerb(HTTP_VERB_GET)."));
         assertTrue(client.contains("WithPath(\"/_rest_/bucket/\" + request.BucketName)."));
+        assertTrue(client.contains("WithOptionalQueryParam(\"storage_domain_id\", request.StorageDomainId)."));
+        assertTrue(client.contains("WithQueryParam(\"operation\", \"verify_physical_placement\")."));
     }
 
     @Test
@@ -308,6 +325,12 @@ public class GoFunctionalTests {
         assertTrue(client.contains("func (client *Client) ReplicatePutJobSpectraS3(request *models.ReplicatePutJobSpectraS3Request) (*models.ReplicatePutJobSpectraS3Response, error) {"));
         assertTrue(client.contains("networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.sendNetwork), client.clientPolicy.maxRetries)"));
         assertTrue(client.contains("response, requestErr := networkRetryDecorator.Invoke(httpRequest)"));
+
+        assertTrue(client.contains("WithHttpVerb(HTTP_VERB_PUT)."));
+        assertTrue(client.contains("WithPath(\"/_rest_/bucket/\" + request.BucketName)."));
+        assertTrue(client.contains("WithQueryParam(\"replicate\", \"\")."));
+        assertTrue(client.contains("WithOptionalQueryParam(\"priority\", networking.InterfaceToStrPtr(request.Priority))."));
+        assertTrue(client.contains("WithQueryParam(\"operation\", \"start_bulk_put\")."));
     }
 
     @Test
@@ -361,6 +384,10 @@ public class GoFunctionalTests {
         assertTrue(client.contains("func (client *Client) CompleteMultiPartUpload(request *models.CompleteMultiPartUploadRequest) (*models.CompleteMultiPartUploadResponse, error) {"));
         assertTrue(client.contains("networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.sendNetwork), client.clientPolicy.maxRetries)"));
         assertTrue(client.contains("response, requestErr := networkRetryDecorator.Invoke(httpRequest)"));
+
+        assertTrue(client.contains("WithHttpVerb(HTTP_VERB_POST)."));
+        assertTrue(client.contains("WithPath(\"/\" + request.BucketName + \"/\" + request.ObjectName)."));
+        assertTrue(client.contains("WithQueryParam(\"upload_id\", request.UploadId)."));
     }
 
     @Test
@@ -419,6 +446,11 @@ public class GoFunctionalTests {
         assertTrue(client.contains("func (client *Client) DeleteObjects(request *models.DeleteObjectsRequest) (*models.DeleteObjectsResponse, error) {"));
         assertTrue(client.contains("networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.sendNetwork), client.clientPolicy.maxRetries)"));
         assertTrue(client.contains("response, requestErr := networkRetryDecorator.Invoke(httpRequest)"));
+
+        assertTrue(client.contains("WithHttpVerb(HTTP_VERB_POST)."));
+        assertTrue(client.contains("WithPath(\"/\" + request.BucketName)."));
+        assertTrue(client.contains("WithQueryParam(\"delete\", \"\")."));
+        assertTrue(client.contains("WithOptionalVoidQueryParam(\"roll_back\", request.RollBack)."));
     }
 
     @Test
@@ -471,6 +503,7 @@ public class GoFunctionalTests {
 
         assertTrue(client.contains("WithHttpVerb(HTTP_VERB_GET)."));
         assertTrue(client.contains("WithPath(\"/_rest_/job/\" + request.JobId)"));
+        assertTrue(client.contains("WithQueryParam(\"replicate\", \"\")."));
     }
 
     @Test
@@ -541,6 +574,11 @@ public class GoFunctionalTests {
         assertTrue(client.contains("func (client *Client) GetObject(request *models.GetObjectRequest) (*models.GetObjectResponse, error) {"));
         assertTrue(client.contains("networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.sendNetwork), client.clientPolicy.maxRetries)"));
         assertTrue(client.contains("response, requestErr := networkRetryDecorator.Invoke(httpRequest)"));
+
+        assertTrue(client.contains("WithHttpVerb(HTTP_VERB_GET)."));
+        assertTrue(client.contains("WithPath(\"/\" + request.BucketName + \"/\" + request.ObjectName)."));
+        assertTrue(client.contains("WithOptionalQueryParam(\"job\", request.Job)."));
+        assertTrue(client.contains("WithOptionalQueryParam(\"offset\", networking.Int64PtrToStrPtr(request.Offset))."));
     }
 
     @Test
@@ -619,6 +657,18 @@ public class GoFunctionalTests {
         assertTrue(client.contains("networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.sendNetwork), client.clientPolicy.maxRetries)"));
         assertTrue(client.contains("httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(&networkRetryDecorator, client.clientPolicy.maxRedirect)"));
         assertTrue(client.contains("response, requestErr := httpRedirectDecorator.Invoke(httpRequest)"));
+
+        assertTrue(client.contains("WithHttpVerb(HTTP_VERB_GET)."));
+        assertTrue(client.contains("WithPath(\"/_rest_/azure_data_replication_rule\")."));
+        assertTrue(client.contains("WithOptionalQueryParam(\"data_policy_id\", request.DataPolicyId)."));
+        assertTrue(client.contains("WithOptionalVoidQueryParam(\"last_page\", request.LastPage)."));
+        assertTrue(client.contains("WithOptionalQueryParam(\"page_length\", networking.IntPtrToStrPtr(request.PageLength))."));
+        assertTrue(client.contains("WithOptionalQueryParam(\"page_offset\", networking.IntPtrToStrPtr(request.PageOffset))."));
+        assertTrue(client.contains("WithOptionalQueryParam(\"page_start_marker\", request.PageStartMarker)."));
+        assertTrue(client.contains("WithOptionalQueryParam(\"replicate_deletes\", networking.BoolPtrToStrPtr(request.ReplicateDeletes))."));
+        assertTrue(client.contains("WithOptionalQueryParam(\"state\", networking.InterfaceToStrPtr(request.State))."));
+        assertTrue(client.contains("WithOptionalQueryParam(\"target_id\", request.TargetId)."));
+        assertTrue(client.contains("WithOptionalQueryParam(\"type\", networking.InterfaceToStrPtr(request.DataReplicationRuleType))."));
     }
 
     @Test
@@ -691,6 +741,14 @@ public class GoFunctionalTests {
         assertTrue(client.contains("func (client *Client) PutAzureDataReplicationRuleSpectraS3(request *models.PutAzureDataReplicationRuleSpectraS3Request) (*models.PutAzureDataReplicationRuleSpectraS3Response, error) {"));
         assertTrue(client.contains("networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.sendNetwork), client.clientPolicy.maxRetries)"));
         assertTrue(client.contains("response, requestErr := networkRetryDecorator.Invoke(httpRequest)"));
+
+        assertTrue(client.contains("WithHttpVerb(HTTP_VERB_POST)."));
+        assertTrue(client.contains("WithPath(\"/_rest_/azure_data_replication_rule\")."));
+        assertTrue(client.contains("WithQueryParam(\"data_policy_id\", request.DataPolicyId)."));
+        assertTrue(client.contains("WithQueryParam(\"target_id\", request.TargetId)."));
+        assertTrue(client.contains("WithQueryParam(\"type\", request.DataReplicationRuleType.String())."));
+        assertTrue(client.contains("WithOptionalQueryParam(\"max_blob_part_size_in_bytes\", networking.Int64PtrToStrPtr(request.MaxBlobPartSizeInBytes))."));
+        assertTrue(client.contains("WithOptionalQueryParam(\"replicate_deletes\", networking.BoolPtrToStrPtr(request.ReplicateDeletes))."));
     }
 
     @Test
@@ -824,7 +882,10 @@ public class GoFunctionalTests {
         assertTrue(client.contains("networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.sendNetwork), client.clientPolicy.maxRetries)"));
         assertTrue(client.contains("response, requestErr := networkRetryDecorator.Invoke(httpRequest)"));
 
+        assertTrue(client.contains("WithHttpVerb(HTTP_VERB_PUT)."));
         assertTrue(client.contains("WithPath(\"/\" + request.BucketName + \"/\" + request.ObjectName)."));
+        assertTrue(client.contains("WithQueryParam(\"part_number\", strconv.Itoa(request.PartNumber))."));
+        assertTrue(client.contains("WithQueryParam(\"upload_id\", request.UploadId)."));
     }
 
     @Test
@@ -912,6 +973,8 @@ public class GoFunctionalTests {
 
         assertTrue(client.contains("WithHttpVerb(HTTP_VERB_PUT)."));
         assertTrue(client.contains("WithPath(\"/\" + request.BucketName + \"/\" + request.ObjectName)"));
+        assertTrue(client.contains("WithOptionalQueryParam(\"job\", request.Job)."));
+        assertTrue(client.contains("WithOptionalQueryParam(\"offset\", networking.Int64PtrToStrPtr(request.Offset))."));
     }
 
     @Test
@@ -960,6 +1023,7 @@ public class GoFunctionalTests {
 
         assertTrue(client.contains("WithHttpVerb(HTTP_VERB_DELETE)."));
         assertTrue(client.contains("WithPath(\"/_rest_/suspect_blob_azure_target\")"));
+        assertTrue(client.contains("WithOptionalVoidQueryParam(\"force\", request.Force)."));
     }
 
     @Test
@@ -1028,6 +1092,16 @@ public class GoFunctionalTests {
 
         assertTrue(client.contains("WithHttpVerb(HTTP_VERB_PUT)."));
         assertTrue(client.contains("WithPath(\"/_rest_/bucket/\" + request.BucketName)."));
+        assertTrue(client.contains("WithOptionalQueryParam(\"aggregating\", networking.BoolPtrToStrPtr(request.Aggregating))."));
+        assertTrue(client.contains("WithOptionalVoidQueryParam(\"force\", request.Force)."));
+        assertTrue(client.contains("WithOptionalVoidQueryParam(\"ignore_naming_conflicts\", request.IgnoreNamingConflicts)."));
+        assertTrue(client.contains("WithOptionalQueryParam(\"implicit_job_id_resolution\", networking.BoolPtrToStrPtr(request.ImplicitJobIdResolution))."));
+        assertTrue(client.contains("WithOptionalQueryParam(\"max_upload_size\", networking.Int64PtrToStrPtr(request.MaxUploadSize))."));
+        assertTrue(client.contains("WithOptionalQueryParam(\"minimize_spanning_across_media\", networking.BoolPtrToStrPtr(request.MinimizeSpanningAcrossMedia))."));
+        assertTrue(client.contains("WithOptionalQueryParam(\"name\", request.Name)."));
+        assertTrue(client.contains("WithOptionalQueryParam(\"priority\", networking.InterfaceToStrPtr(request.Priority))."));
+        assertTrue(client.contains("WithOptionalQueryParam(\"verify_after_write\", networking.BoolPtrToStrPtr(request.VerifyAfterWrite))."));
+        assertTrue(client.contains("WithQueryParam(\"operation\", \"start_bulk_put\")."));
     }
 
     @Test
@@ -1097,6 +1171,12 @@ public class GoFunctionalTests {
 
         assertTrue(client.contains("WithHttpVerb(HTTP_VERB_PUT)."));
         assertTrue(client.contains("WithPath(\"/_rest_/bucket/\" + request.BucketName)."));
+        assertTrue(client.contains("WithOptionalQueryParam(\"aggregating\", networking.BoolPtrToStrPtr(request.Aggregating))."));
+        assertTrue(client.contains("WithOptionalQueryParam(\"chunk_client_processing_order_guarantee\", networking.InterfaceToStrPtr(request.ChunkClientProcessingOrderGuarantee))."));
+        assertTrue(client.contains("WithOptionalQueryParam(\"implicit_job_id_resolution\", networking.BoolPtrToStrPtr(request.ImplicitJobIdResolution))."));
+        assertTrue(client.contains("WithOptionalQueryParam(\"name\", request.Name)."));
+        assertTrue(client.contains("WithOptionalQueryParam(\"priority\", networking.InterfaceToStrPtr(request.Priority))."));
+        assertTrue(client.contains("WithQueryParam(\"operation\", \"start_bulk_get\")."));
     }
 
     @Test
@@ -1163,5 +1243,9 @@ public class GoFunctionalTests {
 
         assertTrue(client.contains("WithHttpVerb(HTTP_VERB_PUT)."));
         assertTrue(client.contains("WithPath(\"/_rest_/bucket/\" + request.BucketName)."));
+        assertTrue(client.contains("WithOptionalQueryParam(\"aggregating\", networking.BoolPtrToStrPtr(request.Aggregating))."));
+        assertTrue(client.contains("WithOptionalQueryParam(\"name\", request.Name)."));
+        assertTrue(client.contains("WithOptionalQueryParam(\"priority\", networking.InterfaceToStrPtr(request.Priority))."));
+        assertTrue(client.contains("WithQueryParam(\"operation\", \"start_bulk_verify\")."));
     }
 }

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/client/ClientGeneratorUtil_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/client/ClientGeneratorUtil_Test.java
@@ -27,7 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class ClientGeneratorUtil_Test {
 
     @Test
-    public void toRequestPath_Test() {
+    public void toRequestPathTest() {
         //Spectra requests
         assertThat(toRequestPath(getRequestDeleteNotification()))
                 .isEqualTo("\"/_rest_/job_created_notification_registration/\" + request.NotificationId");
@@ -56,7 +56,7 @@ public class ClientGeneratorUtil_Test {
     }
 
     @Test (expected = IllegalArgumentException.class)
-    public void toRequestPath_Exception_Test() {
+    public void toRequestPath_ExceptionTest() {
         final Ds3Request request = new Ds3Request(
                 "Test",
                 HttpVerb.GET,
@@ -76,7 +76,7 @@ public class ClientGeneratorUtil_Test {
     }
 
     @Test
-    public void getAmazonS3RequestPath_Test() {
+    public void getAmazonS3RequestPathTest() {
         //Amazon requests
         assertThat(getAmazonS3RequestPath(getRequestMultiFileDelete()))
                 .isEqualTo("\"/\" + request.BucketName");
@@ -97,7 +97,7 @@ public class ClientGeneratorUtil_Test {
     }
 
     @Test
-    public void getSpectraDs3RequestPath_Test() {
+    public void getSpectraDs3RequestPathTest() {
         //Spectra requests
         assertThat(getSpectraDs3RequestPath(getRequestDeleteNotification()))
                 .isEqualTo("\"/_rest_/job_created_notification_registration/\" + request.NotificationId");
@@ -120,5 +120,49 @@ public class ClientGeneratorUtil_Test {
         assertThat(getSpectraDs3RequestPath(getRequestMultiFileDelete())).isEmpty();
         assertThat(getSpectraDs3RequestPath(getRequestCreateObject())).isEmpty();
         assertThat(getSpectraDs3RequestPath(getRequestAmazonS3GetObject())).isEmpty();
+    }
+
+    @Test (expected = IllegalArgumentException.class)
+    public void goPtrQueryParamToStringPtrExceptionTest() {
+        goPtrQueryParamToStringPtr("ParamName", "bool");
+    }
+
+    @Test
+    public void goPtrQueryParamToStringPtrTest() {
+        assertThat(goPtrQueryParamToStringPtr("ParamName", "*int"))
+                .isEqualTo("networking.IntPtrToStrPtr(request.ParamName)");
+        assertThat(goPtrQueryParamToStringPtr("ParamName", "*int64"))
+                .isEqualTo("networking.Int64PtrToStrPtr(request.ParamName)");
+        assertThat(goPtrQueryParamToStringPtr("ParamName", "*bool"))
+                .isEqualTo("networking.BoolPtrToStrPtr(request.ParamName)");
+        assertThat(goPtrQueryParamToStringPtr("ParamName", "*float64"))
+                .isEqualTo("networking.Float64PtrToStrPtr(request.ParamName)");
+        assertThat(goPtrQueryParamToStringPtr("ParamName", "*string"))
+                .isEqualTo("request.ParamName");
+        assertThat(goPtrQueryParamToStringPtr("ParamName", "com.test.SpectraType"))
+                .isEqualTo("networking.InterfaceToStrPtr(request.ParamName)");
+    }
+
+    @Test (expected = IllegalArgumentException.class)
+    public void goQueryParamToStringExceptionTest() {
+        goQueryParamToString("ParamName", "*int");
+    }
+
+    @Test
+    public void goQueryParamToStringTest() {
+        assertThat(goQueryParamToString("ParamName", ""))
+                .isEqualTo("\"\"");
+        assertThat(goQueryParamToString("ParamName", "bool"))
+                .isEqualTo("strconv.FormatBool(request.ParamName)");
+        assertThat(goQueryParamToString("ParamName", "int"))
+                .isEqualTo("strconv.Itoa(request.ParamName)");
+        assertThat(goQueryParamToString("ParamName", "int64"))
+                .isEqualTo("strconv.FormatInt(request.ParamName, 10)");
+        assertThat(goQueryParamToString("ParamName", "float64"))
+                .isEqualTo("strconv.FormatFloat(request.ParamName, 'f', -1, 64)");
+        assertThat(goQueryParamToString("ParamName", "string"))
+                .isEqualTo("request.ParamName");
+        assertThat(goQueryParamToString("ParamName", "com.test.SpectraType"))
+                .isEqualTo("request.ParamName.String()");
     }
 }

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/client/command/BaseCommandGenerator_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/client/command/BaseCommandGenerator_Test.java
@@ -1,0 +1,181 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.go.generators.client.command;
+
+import com.google.common.collect.ImmutableList;
+import com.spectralogic.ds3autogen.api.models.apispec.Ds3Param;
+import com.spectralogic.ds3autogen.api.models.enums.HttpVerb;
+import com.spectralogic.ds3autogen.api.models.enums.Operation;
+import com.spectralogic.ds3autogen.go.models.client.*;
+import org.junit.Test;
+
+import static com.spectralogic.ds3autogen.testutil.Ds3ModelFixtures.getBucketRequest;
+import static com.spectralogic.ds3autogen.testutil.Ds3ModelFixtures.getRequestCreateObject;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BaseCommandGenerator_Test {
+
+    private final BaseCommandGenerator generator = new BaseCommandGenerator();
+
+    @Test
+    public void toRequestBuildLinesPutObjectTest() {
+        final ImmutableList<RequestBuildLine> result = generator.toRequestBuildLines(getRequestCreateObject());
+
+        assertThat(result)
+                .containsExactlyInAnyOrder(
+                        new HttpVerbBuildLine(HttpVerb.PUT),
+                        new PathBuildLine("\"/\" + request.BucketName + \"/\" + request.ObjectName"),
+                        new OptionalQueryParamBuildLine("job", "request.Job"),
+                        new OptionalQueryParamBuildLine("offset", "networking.Int64PtrToStrPtr(request.Offset)")
+                );
+    }
+
+    @Test
+    public void toRequestBuildLinesGetBucketTest() {
+        final ImmutableList<RequestBuildLine> result = generator.toRequestBuildLines(getBucketRequest());
+
+        assertThat(result)
+                .containsExactlyInAnyOrder(
+                        new HttpVerbBuildLine(HttpVerb.GET),
+                        new PathBuildLine("\"/\" + request.BucketName"),
+                        new OptionalQueryParamBuildLine("delimiter", "request.Delimiter"),
+                        new OptionalQueryParamBuildLine("marker", "request.Marker"),
+                        new OptionalQueryParamBuildLine("max_keys", "networking.IntPtrToStrPtr(request.MaxKeys)"),
+                        new OptionalQueryParamBuildLine("prefix", "request.Prefix")
+                );
+    }
+
+    @Test
+    public void toHeadersBuildLineTest() {
+        assertThat(generator.toHeadersBuildLine().isPresent()).isFalse();
+    }
+
+    @Test
+    public void toChecksumBuildLineTest() {
+        assertThat(generator.toChecksumBuildLine().isPresent()).isFalse();
+    }
+
+    @Test
+    public void toReaderBuildLineTest() {
+        assertThat(generator.toReaderBuildLine().isPresent()).isFalse();
+    }
+
+    @Test
+    public void toOperationBuildLineTest() {
+        assertThat(generator.toOperationBuildLine(null).isPresent()).isFalse();
+
+        assertThat(generator.toOperationBuildLine(Operation.GET_PHYSICAL_PLACEMENT))
+                .isNotEmpty()
+                .contains(new OperationBuildLine(Operation.GET_PHYSICAL_PLACEMENT));
+
+        assertThat(generator.toOperationBuildLine(Operation.ALLOCATE))
+                .isNotEmpty()
+                .contains(new OperationBuildLine(Operation.ALLOCATE));
+
+        assertThat(generator.toOperationBuildLine(Operation.VERIFY_SAFE_TO_START_BULK_PUT))
+                .isNotEmpty()
+                .contains(new OperationBuildLine(Operation.VERIFY_SAFE_TO_START_BULK_PUT));
+    }
+
+    @Test
+    public void toOptionalQueryParamBuildLinePrimitiveTypeTest() {
+        final Ds3Param param = new Ds3Param("ParamName", "bool", false);
+        final RequestBuildLine result = generator.toOptionalQueryParamBuildLine(param);
+
+        assertThat(result.getLine())
+                .isEqualTo("WithOptionalQueryParam(\"param_name\", networking.BoolPtrToStrPtr(request.ParamName)).");
+    }
+
+    @Test
+    public void toOptionalQueryParamBuildLineJavaObjectTypeTest() {
+        final Ds3Param param = new Ds3Param("ParamName", "java.lang.Boolean", false);
+        final RequestBuildLine result = generator.toOptionalQueryParamBuildLine(param);
+
+        assertThat(result.getLine())
+                .isEqualTo("WithOptionalQueryParam(\"param_name\", networking.BoolPtrToStrPtr(request.ParamName)).");
+    }
+
+    @Test
+    public void toOptionalQueryParamBuildLineSpectraTypeTest() {
+        final Ds3Param param = new Ds3Param("ParamName", "com.test.SpectraType", false);
+        final RequestBuildLine result = generator.toOptionalQueryParamBuildLine(param);
+
+        assertThat(result.getLine())
+                .isEqualTo("WithOptionalQueryParam(\"param_name\", networking.InterfaceToStrPtr(request.ParamName)).");
+    }
+
+    @Test
+    public void toOptionalQueryParamBuildLineVoidTypeTest() {
+        final Ds3Param param = new Ds3Param("ParamName", "void", false);
+        final RequestBuildLine result = generator.toOptionalQueryParamBuildLine(param);
+
+        assertThat(result.getLine())
+                .isEqualTo("WithOptionalVoidQueryParam(\"param_name\", request.ParamName).");
+    }
+
+    @Test
+    public void toOptionalQueryParamBuildLinesTest() {
+        final ImmutableList<Ds3Param> params = ImmutableList.of(
+                new Ds3Param("ParamName", "bool", false),
+                new Ds3Param("ParamName", "com.test.SpectraType", false),
+                new Ds3Param("ParamName", "void", false)
+        );
+
+        final ImmutableList<RequestBuildLine> result = generator.toOptionalQueryParamBuildLines(params);
+
+        assertThat(result).extracting("line").containsExactlyInAnyOrder(
+                "WithOptionalQueryParam(\"param_name\", networking.BoolPtrToStrPtr(request.ParamName)).",
+                "WithOptionalQueryParam(\"param_name\", networking.InterfaceToStrPtr(request.ParamName)).",
+                "WithOptionalVoidQueryParam(\"param_name\", request.ParamName).");
+    }
+
+    @Test
+    public void toRequiredQueryParamBuildLineVoidTest() {
+        final Ds3Param param = new Ds3Param("ParamName", "void", false);
+        final RequestBuildLine result = generator.toRequiredQueryParamBuildLine(param);
+        assertThat(result.getLine()).isEqualTo("WithQueryParam(\"param_name\", \"\").");
+    }
+
+    @Test
+    public void toRequiredQueryParamBuildLinePrimitiveTest() {
+        final Ds3Param param = new Ds3Param("ParamName", "int", false);
+        final RequestBuildLine result = generator.toRequiredQueryParamBuildLine(param);
+        assertThat(result.getLine()).isEqualTo("WithQueryParam(\"param_name\", strconv.Itoa(request.ParamName)).");
+    }
+
+    @Test
+    public void toRequiredQueryParamBuildLineInterfaceTest() {
+        final Ds3Param param = new Ds3Param("ParamName", "com.test.SpectraType", false);
+        final RequestBuildLine result = generator.toRequiredQueryParamBuildLine(param);
+        assertThat(result.getLine()).isEqualTo("WithQueryParam(\"param_name\", request.ParamName.String()).");
+    }
+
+    @Test
+    public void toRequiredQueryParamBuildLinesTest() {
+        final ImmutableList<Ds3Param> params = ImmutableList.of(
+                new Ds3Param("ParamName", "bool", false),
+                new Ds3Param("ParamName", "com.test.SpectraType", false),
+                new Ds3Param("ParamName", "void", false)
+        );
+
+        final ImmutableList<RequestBuildLine> result = generator.toRequiredQueryParamBuildLines(params);
+
+        assertThat(result).extracting("line").containsExactlyInAnyOrder(
+                "WithQueryParam(\"param_name\", strconv.FormatBool(request.ParamName)).",
+                "WithQueryParam(\"param_name\", request.ParamName.String()).",
+                "WithQueryParam(\"param_name\", \"\").");
+    }
+}

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/models/client/RequestBuildLine_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/models/client/RequestBuildLine_Test.java
@@ -16,6 +16,7 @@
 package com.spectralogic.ds3autogen.go.models.client;
 
 import com.spectralogic.ds3autogen.api.models.enums.HttpVerb;
+import com.spectralogic.ds3autogen.api.models.enums.Operation;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -23,7 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class RequestBuildLine_Test {
 
     @Test
-    public void httpVerbBuildLine_Test() {
+    public void httpVerbBuildLineTest() {
         assertThat(new HttpVerbBuildLine(HttpVerb.GET).getLine())
                 .isEqualTo("WithHttpVerb(HTTP_VERB_GET).");
         assertThat(new HttpVerbBuildLine(HttpVerb.PUT).getLine())
@@ -37,8 +38,36 @@ public class RequestBuildLine_Test {
     }
 
     @Test
-    public void pathBuildLine_Test() {
+    public void pathBuildLineTest() {
         assertThat(new PathBuildLine("\"/_rest_/my-path\"").getLine())
                 .isEqualTo("WithPath(\"/_rest_/my-path\").");
+    }
+
+    @Test
+    public void operationBuildLineTest() {
+        assertThat(new OperationBuildLine(Operation.ALLOCATE).getLine())
+                .isEqualTo("WithQueryParam(\"operation\", \"allocate\").");
+        assertThat(new OperationBuildLine(Operation.GET_PHYSICAL_PLACEMENT).getLine())
+                .isEqualTo("WithQueryParam(\"operation\", \"get_physical_placement\").");
+        assertThat(new OperationBuildLine(Operation.VERIFY_SAFE_TO_START_BULK_PUT).getLine())
+                .isEqualTo("WithQueryParam(\"operation\", \"verify_safe_to_start_bulk_put\").");
+    }
+
+    @Test
+    public void queryParamBuildLineTest() {
+        assertThat(new QueryParamBuildLine("ParamKey", "ParamValue").getLine())
+                .isEqualTo("WithQueryParam(\"ParamKey\", ParamValue).");
+    }
+
+    @Test
+    public void optionalQueryParamBuildLineTest() {
+        assertThat(new OptionalQueryParamBuildLine("ParamKey", "ParamValue").getLine())
+                .isEqualTo("WithOptionalQueryParam(\"ParamKey\", ParamValue).");
+    }
+
+    @Test
+    public void voidOptionalQueryParamBuildLineTest() {
+        assertThat(new VoidOptionalQueryParamBuildLine("ParamKey", "ParamName").getLine())
+                .isEqualTo("WithOptionalVoidQueryParam(\"ParamKey\", request.ParamName).");
     }
 }


### PR DESCRIPTION
**Changes**
Created a command generator which is used by the client generator. The command generator is used to generate the Go request builder code. The base command generator creates the lines for the http verb, path, required query parameters, and optional query parameters.

**TODO**
- Special case the command generator to add request payload streams, checksum, and headers when applicable.

**Example Code**
```
package ds3

import (
    "ds3/models"
    "ds3/networking"
)

func (client *Client) PutObject(request *models.PutObjectRequest) (*models.PutObjectResponse, error) {
    // Build the http request
    httpRequest, err := networking.NewHttpRequestBuilder().
        WithHttpVerb(HTTP_VERB_PUT).
        WithPath("/" + request.BucketName + "/" + request.ObjectName).
        WithOptionalQueryParam("job", request.Job).
        WithOptionalQueryParam("offset", networking.Int64PtrToStrPtr(request.Offset)).
        Build(client.connectionInfo)

    if err != nil {
        return nil, err
    }

    networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.sendNetwork), client.clientPolicy.maxRetries)

    // Invoke the HTTP request.
    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
    if requestErr != nil {
        return nil, requestErr
    }

    // Create a response object based on the result.
    return models.NewPutObjectResponse(response)
}
```