### PR TITLE
GOSDK-8: Special cased Put Object client command generation in Go module

### DIFF
--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/client/BaseClientGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/client/BaseClientGenerator.kt
@@ -20,9 +20,11 @@ import com.spectralogic.ds3autogen.api.models.apispec.Ds3Request
 import com.spectralogic.ds3autogen.api.models.enums.HttpVerb
 import com.spectralogic.ds3autogen.go.generators.client.command.BaseCommandGenerator
 import com.spectralogic.ds3autogen.go.generators.client.command.CommandModelGenerator
+import com.spectralogic.ds3autogen.go.generators.client.command.PutObjectCommandGenerator
 import com.spectralogic.ds3autogen.go.models.client.Client
 import com.spectralogic.ds3autogen.go.models.client.Command
 import com.spectralogic.ds3autogen.utils.ConverterUtil
+import com.spectralogic.ds3autogen.utils.Ds3RequestClassificationUtil.isAmazonCreateObjectRequest
 import com.spectralogic.ds3autogen.utils.Ds3RequestClassificationUtil.isGetObjectAmazonS3Request
 import com.spectralogic.ds3autogen.utils.collections.GuavaCollectors
 
@@ -71,7 +73,8 @@ open class BaseClientGenerator : ClientModelGenerator<Client> {
      * Retrieves the command generator for the specified Ds3Request.
      */
     fun getCommandGenerator(ds3Request: Ds3Request): CommandModelGenerator<*> {
-        //todo add special casing
-        return BaseCommandGenerator()
+        return if (isAmazonCreateObjectRequest(ds3Request)) {
+            PutObjectCommandGenerator()
+        } else BaseCommandGenerator()
     }
 }

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/client/command/PutObjectCommandGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/client/command/PutObjectCommandGenerator.kt
@@ -1,0 +1,47 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.go.generators.client.command
+
+import com.spectralogic.ds3autogen.go.models.client.*
+import java.util.*
+
+/**
+ * Generates the Go client command for Amazon PutObject command
+ */
+class PutObjectCommandGenerator : BaseCommandGenerator() {
+
+    /**
+     * Retrieves the request builder line that adds the optional checksum.
+     */
+    override fun toChecksumBuildLine(): Optional<RequestBuildLine> {
+        return Optional.of(CustomBuildLine.CHECKSUM_BUILD_LINE)
+    }
+
+    /**
+     * Retrieves the request builder line that adds the user specified metadata.
+     */
+    override fun toHeadersBuildLine(): Optional<RequestBuildLine> {
+        return Optional.of(CustomBuildLine.METADATA_BUILD_LINE)
+    }
+
+    /**
+     * Retrieves the request builder line for adding the request payload,
+     * which is the object content to be put to BP.
+     */
+    override fun toReaderBuildLine(): Optional<RequestBuildLine> {
+        return Optional.of(ReaderBuildLine("request.Content"))
+    }
+}

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/models/client/RequestBuildLine.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/models/client/RequestBuildLine.kt
@@ -32,8 +32,7 @@ data class HttpVerbBuildLine(private val httpVerb: HttpVerb) : RequestBuildLine 
 
 // Creates the Go request builder line for adding a path to an http request
 data class PathBuildLine(private val path: String) : RequestBuildLine {
-    override val line: String
-        get() = "WithPath($path)."
+    override val line = "WithPath($path)."
 }
 
 // Creates the Go request builder line for adding the operation query param
@@ -46,22 +45,19 @@ data class OperationBuildLine(private val operation: Operation) : RequestBuildLi
 
 // Creates the Go request builder line for adding a required query param
 data class QueryParamBuildLine(private val key: String, private val value: String) : RequestBuildLine {
-    override val line: String
-        get() = "WithQueryParam(\"$key\", $value)."
+    override val line = "WithQueryParam(\"$key\", $value)."
 }
 
 // Creates the Go request builder line for adding an optional query param.
 // An optional parameter may be nil to indicate it has not been set.
 data class OptionalQueryParamBuildLine(private val key: String, private val value: String) : RequestBuildLine {
-    override val line: String
-        get() = "WithOptionalQueryParam(\"$key\", $value)."
+    override val line = "WithOptionalQueryParam(\"$key\", $value)."
 }
 
 // Creates the Go request builder line for adding an optional void query param.
 // Optional voids are represented by booleans within the Go request handler
 data class VoidOptionalQueryParamBuildLine(private val key: String, private val paramName: String) : RequestBuildLine {
-    override val line: String
-        get() = "WithOptionalVoidQueryParam(\"$key\", request.$paramName)."
+    override val line = "WithOptionalVoidQueryParam(\"$key\", request.$paramName)."
 
 }
 
@@ -75,12 +71,10 @@ data class CustomBuildLine(private val customLine: String) : RequestBuildLine {
         val METADATA_BUILD_LINE = CustomBuildLine("WithHeaders(request.Metadata).")
     }
 
-    override val line: String
-        get() = customLine
+    override val line = customLine
 }
 
 // Creates the GO request builder line for adding a reader that contains the request payload.
 data class ReaderBuildLine(private val reader: String) : RequestBuildLine {
-    override val line: String
-        get() = "WithReader($reader)."
+    override val line = "WithReader($reader)."
 }

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/models/client/RequestBuildLine.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/models/client/RequestBuildLine.kt
@@ -64,3 +64,23 @@ data class VoidOptionalQueryParamBuildLine(private val key: String, private val 
         get() = "WithOptionalVoidQueryParam(\"$key\", request.$paramName)."
 
 }
+
+// Creates a custom request builder line.
+data class CustomBuildLine(private val customLine: String) : RequestBuildLine {
+
+    companion object {
+        @JvmStatic
+        val CHECKSUM_BUILD_LINE = CustomBuildLine("WithChecksum(request.Checksum).")
+        @JvmStatic
+        val METADATA_BUILD_LINE = CustomBuildLine("WithHeaders(request.Metadata).")
+    }
+
+    override val line: String
+        get() = customLine
+}
+
+// Creates the GO request builder line for adding a reader that contains the request payload.
+data class ReaderBuildLine(private val reader: String) : RequestBuildLine {
+    override val line: String
+        get() = "WithReader($reader)."
+}

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTests.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTests.java
@@ -975,6 +975,9 @@ public class GoFunctionalTests {
         assertTrue(client.contains("WithPath(\"/\" + request.BucketName + \"/\" + request.ObjectName)"));
         assertTrue(client.contains("WithOptionalQueryParam(\"job\", request.Job)."));
         assertTrue(client.contains("WithOptionalQueryParam(\"offset\", networking.Int64PtrToStrPtr(request.Offset))."));
+        assertTrue(client.contains("WithReader(request.Content)."));
+        assertTrue(client.contains("WithChecksum(request.Checksum)."));
+        assertTrue(client.contains("WithHeaders(request.Metadata)."));
     }
 
     @Test

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/client/BaseClientGenerator_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/client/BaseClientGenerator_Test.java
@@ -20,6 +20,7 @@ import com.spectralogic.ds3autogen.api.models.apispec.Ds3Request;
 import com.spectralogic.ds3autogen.api.models.enums.HttpVerb;
 import com.spectralogic.ds3autogen.api.models.enums.Operation;
 import com.spectralogic.ds3autogen.go.generators.client.command.BaseCommandGenerator;
+import com.spectralogic.ds3autogen.go.generators.client.command.PutObjectCommandGenerator;
 import com.spectralogic.ds3autogen.go.models.client.*;
 import org.junit.Test;
 
@@ -166,5 +167,8 @@ public class BaseClientGenerator_Test {
     public void getCommandGeneratorTest() {
         assertThat(generator.getCommandGenerator(getBucketsRequest()))
                 .isInstanceOf(BaseCommandGenerator.class);
+
+        assertThat(generator.getCommandGenerator(getRequestCreateObject()))
+                .isInstanceOf(PutObjectCommandGenerator.class);
     }
 }

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/models/client/RequestBuildLine_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/models/client/RequestBuildLine_Test.java
@@ -70,4 +70,10 @@ public class RequestBuildLine_Test {
         assertThat(new VoidOptionalQueryParamBuildLine("ParamKey", "ParamName").getLine())
                 .isEqualTo("WithOptionalVoidQueryParam(\"ParamKey\", request.ParamName).");
     }
+
+    @Test
+    public void readerBuildLineTest() {
+        assertThat(new ReaderBuildLine("RequestPayloadReader").getLine())
+                .isEqualTo("WithReader(RequestPayloadReader).");
+    }
 }

--- a/ds3-autogen-go/src/test/kotlin/com/spectralogic/ds3autogen/go/generators/client/command/PutObjectCommandGeneratorTest.kt
+++ b/ds3-autogen-go/src/test/kotlin/com/spectralogic/ds3autogen/go/generators/client/command/PutObjectCommandGeneratorTest.kt
@@ -1,0 +1,50 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.go.generators.client.command
+
+import com.spectralogic.ds3autogen.go.models.client.CustomBuildLine
+import com.spectralogic.ds3autogen.go.models.client.ReaderBuildLine
+import com.spectralogic.ds3autogen.go.models.client.RequestBuildLine
+import org.junit.Test
+
+
+import org.assertj.core.api.Assertions.assertThat
+
+class PutObjectCommandGeneratorTest {
+
+    private val generator = PutObjectCommandGenerator()
+
+    @Test
+    fun toHeadersBuildLineTest() {
+        assertThat<RequestBuildLine>(generator.toHeadersBuildLine())
+                .isNotEmpty
+                .containsSame(CustomBuildLine.METADATA_BUILD_LINE)
+    }
+
+    @Test
+    fun toChecksumBuildLineTest() {
+        assertThat<RequestBuildLine>(generator.toChecksumBuildLine())
+                .isNotEmpty
+                .containsSame(CustomBuildLine.CHECKSUM_BUILD_LINE)
+    }
+
+    @Test
+    fun toReaderBuildLineTest() {
+        assertThat<RequestBuildLine>(generator.toReaderBuildLine())
+                .isNotEmpty
+                .contains(ReaderBuildLine("request.Content"))
+    }
+}


### PR DESCRIPTION
**Changes**
Put Object request builder now adds content reader, checksum, and metadata.

**Example Code Generation**
```
package ds3

import (
    "ds3/models"
    "ds3/networking"
)

func (client *Client) PutObject(request *models.PutObjectRequest) (*models.PutObjectResponse, error) {
    // Build the http request
    httpRequest, err := networking.NewHttpRequestBuilder().
        WithHttpVerb(HTTP_VERB_PUT).
        WithPath("/" + request.BucketName + "/" + request.ObjectName).
        WithOptionalQueryParam("job", request.Job).
        WithOptionalQueryParam("offset", networking.Int64PtrToStrPtr(request.Offset)).
        WithReader(request.Content).
        WithChecksum(request.Checksum).
        WithHeaders(request.Metadata).
        Build(client.connectionInfo)

    if err != nil {
        return nil, err
    }

    networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.sendNetwork), client.clientPolicy.maxRetries)

    // Invoke the HTTP request.
    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
    if requestErr != nil {
        return nil, requestErr
    }

    // Create a response object based on the result.
    return models.NewPutObjectResponse(response)
}
```