### PR TITLE
GOSDK-8: Special cased Get Object client command generation in Go module

### DIFF
--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/client/BaseClientGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/client/BaseClientGenerator.kt
@@ -20,7 +20,9 @@ import com.spectralogic.ds3autogen.api.models.apispec.Ds3Request
 import com.spectralogic.ds3autogen.api.models.enums.HttpVerb
 import com.spectralogic.ds3autogen.go.generators.client.command.BaseCommandGenerator
 import com.spectralogic.ds3autogen.go.generators.client.command.CommandModelGenerator
+import com.spectralogic.ds3autogen.go.generators.client.command.GetObjectCommandGenerator
 import com.spectralogic.ds3autogen.go.generators.client.command.PutObjectCommandGenerator
+import com.spectralogic.ds3autogen.go.generators.request.GetObjectRequestGenerator
 import com.spectralogic.ds3autogen.go.models.client.Client
 import com.spectralogic.ds3autogen.go.models.client.Command
 import com.spectralogic.ds3autogen.utils.ConverterUtil
@@ -73,8 +75,10 @@ open class BaseClientGenerator : ClientModelGenerator<Client> {
      * Retrieves the command generator for the specified Ds3Request.
      */
     fun getCommandGenerator(ds3Request: Ds3Request): CommandModelGenerator<*> {
-        return if (isAmazonCreateObjectRequest(ds3Request)) {
-            PutObjectCommandGenerator()
-        } else BaseCommandGenerator()
+        return when {
+            isAmazonCreateObjectRequest(ds3Request) -> PutObjectCommandGenerator()
+            isGetObjectAmazonS3Request(ds3Request) -> GetObjectCommandGenerator()
+            else -> BaseCommandGenerator()
+        }
     }
 }

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/client/BaseClientGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/client/BaseClientGenerator.kt
@@ -22,7 +22,6 @@ import com.spectralogic.ds3autogen.go.generators.client.command.BaseCommandGener
 import com.spectralogic.ds3autogen.go.generators.client.command.CommandModelGenerator
 import com.spectralogic.ds3autogen.go.generators.client.command.GetObjectCommandGenerator
 import com.spectralogic.ds3autogen.go.generators.client.command.PutObjectCommandGenerator
-import com.spectralogic.ds3autogen.go.generators.request.GetObjectRequestGenerator
 import com.spectralogic.ds3autogen.go.models.client.Client
 import com.spectralogic.ds3autogen.go.models.client.Command
 import com.spectralogic.ds3autogen.utils.ConverterUtil

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/client/command/GetObjectCommandGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/client/command/GetObjectCommandGenerator.kt
@@ -1,0 +1,41 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.go.generators.client.command
+
+import com.spectralogic.ds3autogen.go.models.client.CustomBuildLine
+import com.spectralogic.ds3autogen.go.models.client.RequestBuildLine
+import java.util.*
+
+/**
+ * Generates the Go client command for Amazon GetObject
+ */
+class GetObjectCommandGenerator : BaseCommandGenerator() {
+
+    /**
+     * Retrieves the request builder line that adds the optional checksum.
+     */
+    override fun toChecksumBuildLine(): Optional<RequestBuildLine> {
+        return Optional.of(CustomBuildLine.CHECKSUM_BUILD_LINE)
+    }
+
+    /**
+     * Retrieves the request builder line that adds metadata which may
+     * include the range header.
+     */
+    override fun toHeadersBuildLine(): Optional<RequestBuildLine> {
+        return Optional.of(CustomBuildLine.METADATA_BUILD_LINE)
+    }
+}

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTests.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTests.java
@@ -579,6 +579,8 @@ public class GoFunctionalTests {
         assertTrue(client.contains("WithPath(\"/\" + request.BucketName + \"/\" + request.ObjectName)."));
         assertTrue(client.contains("WithOptionalQueryParam(\"job\", request.Job)."));
         assertTrue(client.contains("WithOptionalQueryParam(\"offset\", networking.Int64PtrToStrPtr(request.Offset))."));
+        assertTrue(client.contains("WithChecksum(request.Checksum)."));
+        assertTrue(client.contains("WithHeaders(request.Metadata)."));
     }
 
     @Test

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/client/BaseClientGenerator_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/client/BaseClientGenerator_Test.java
@@ -20,6 +20,7 @@ import com.spectralogic.ds3autogen.api.models.apispec.Ds3Request;
 import com.spectralogic.ds3autogen.api.models.enums.HttpVerb;
 import com.spectralogic.ds3autogen.api.models.enums.Operation;
 import com.spectralogic.ds3autogen.go.generators.client.command.BaseCommandGenerator;
+import com.spectralogic.ds3autogen.go.generators.client.command.GetObjectCommandGenerator;
 import com.spectralogic.ds3autogen.go.generators.client.command.PutObjectCommandGenerator;
 import com.spectralogic.ds3autogen.go.models.client.*;
 import org.junit.Test;
@@ -170,5 +171,8 @@ public class BaseClientGenerator_Test {
 
         assertThat(generator.getCommandGenerator(getRequestCreateObject()))
                 .isInstanceOf(PutObjectCommandGenerator.class);
+
+        assertThat(generator.getCommandGenerator(getRequestAmazonS3GetObject()))
+                .isInstanceOf(GetObjectCommandGenerator.class);
     }
 }

--- a/ds3-autogen-go/src/test/kotlin/com/spectralogic/ds3autogen/go/generators/client/command/GetObjectCommandGeneratorTest.kt
+++ b/ds3-autogen-go/src/test/kotlin/com/spectralogic/ds3autogen/go/generators/client/command/GetObjectCommandGeneratorTest.kt
@@ -1,0 +1,40 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.go.generators.client.command
+
+import com.spectralogic.ds3autogen.go.models.client.CustomBuildLine
+import com.spectralogic.ds3autogen.go.models.client.RequestBuildLine
+import org.assertj.core.api.Assertions
+import org.junit.Test
+
+class GetObjectCommandGeneratorTest {
+
+    private val generator = GetObjectCommandGenerator()
+
+    @Test
+    fun toHeadersBuildLineTest() {
+        Assertions.assertThat<RequestBuildLine>(generator.toHeadersBuildLine())
+                .isNotEmpty
+                .containsSame(CustomBuildLine.METADATA_BUILD_LINE)
+    }
+
+    @Test
+    fun toChecksumBuildLineTest() {
+        Assertions.assertThat<RequestBuildLine>(generator.toChecksumBuildLine())
+                .isNotEmpty
+                .containsSame(CustomBuildLine.CHECKSUM_BUILD_LINE)
+    }
+}


### PR DESCRIPTION
**Changes**
Updated GetObject request builder to add checksum and headers/metadata. The metadata may contain the optional range header.

**Example Code**
```
package ds3

import (
    "ds3/models"
    "ds3/networking"
)

func (client *Client) GetObject(request *models.GetObjectRequest) (*models.GetObjectResponse, error) {
    // Build the http request
    httpRequest, err := networking.NewHttpRequestBuilder().
        WithHttpVerb(HTTP_VERB_GET).
        WithPath("/" + request.BucketName + "/" + request.ObjectName).
        WithOptionalQueryParam("job", request.Job).
        WithOptionalQueryParam("offset", networking.Int64PtrToStrPtr(request.Offset)).
        WithChecksum(request.Checksum).
        WithHeaders(request.Metadata).
        Build(client.connectionInfo)

    if err != nil {
        return nil, err
    }

    networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.sendNetwork), client.clientPolicy.maxRetries)

    // Invoke the HTTP request.
    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
    if requestErr != nil {
        return nil, requestErr
    }

    // Create a response object based on the result.
    return models.NewGetObjectResponse(response)
}
```