### PR TITLE
GOSDK-8: Special cased PutMultiPartUploadPart client command in Go module

### DIFF
--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/client/BaseClientGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/client/BaseClientGenerator.kt
@@ -18,15 +18,11 @@ package com.spectralogic.ds3autogen.go.generators.client
 import com.google.common.collect.ImmutableList
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3Request
 import com.spectralogic.ds3autogen.api.models.enums.HttpVerb
-import com.spectralogic.ds3autogen.go.generators.client.command.BaseCommandGenerator
-import com.spectralogic.ds3autogen.go.generators.client.command.CommandModelGenerator
-import com.spectralogic.ds3autogen.go.generators.client.command.GetObjectCommandGenerator
-import com.spectralogic.ds3autogen.go.generators.client.command.PutObjectCommandGenerator
+import com.spectralogic.ds3autogen.go.generators.client.command.*
 import com.spectralogic.ds3autogen.go.models.client.Client
 import com.spectralogic.ds3autogen.go.models.client.Command
 import com.spectralogic.ds3autogen.utils.ConverterUtil
-import com.spectralogic.ds3autogen.utils.Ds3RequestClassificationUtil.isAmazonCreateObjectRequest
-import com.spectralogic.ds3autogen.utils.Ds3RequestClassificationUtil.isGetObjectAmazonS3Request
+import com.spectralogic.ds3autogen.utils.Ds3RequestClassificationUtil.*
 import com.spectralogic.ds3autogen.utils.collections.GuavaCollectors
 
 open class BaseClientGenerator : ClientModelGenerator<Client> {
@@ -77,6 +73,7 @@ open class BaseClientGenerator : ClientModelGenerator<Client> {
         return when {
             isAmazonCreateObjectRequest(ds3Request) -> PutObjectCommandGenerator()
             isGetObjectAmazonS3Request(ds3Request) -> GetObjectCommandGenerator()
+            isCreateMultiPartUploadPartRequest(ds3Request) -> ReaderPayloadCommandGenerator()
             else -> BaseCommandGenerator()
         }
     }

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/client/command/ReaderPayloadCommandGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/client/command/ReaderPayloadCommandGenerator.kt
@@ -1,0 +1,31 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.go.generators.client.command
+
+import com.spectralogic.ds3autogen.go.models.client.ReaderBuildLine
+import com.spectralogic.ds3autogen.go.models.client.RequestBuildLine
+import java.util.*
+
+class ReaderPayloadCommandGenerator : BaseCommandGenerator() {
+
+    /**
+     * Retrieves the request builder line for adding the request payload,
+     * which is the object content to be put to BP.
+     */
+    override fun toReaderBuildLine(): Optional<RequestBuildLine> {
+        return Optional.of(ReaderBuildLine("request.Content"))
+    }
+}

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTests.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTests.java
@@ -888,6 +888,7 @@ public class GoFunctionalTests {
         assertTrue(client.contains("WithPath(\"/\" + request.BucketName + \"/\" + request.ObjectName)."));
         assertTrue(client.contains("WithQueryParam(\"part_number\", strconv.Itoa(request.PartNumber))."));
         assertTrue(client.contains("WithQueryParam(\"upload_id\", request.UploadId)."));
+        assertTrue(client.contains("WithReader(request.Content)."));
     }
 
     @Test

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/client/BaseClientGenerator_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/client/BaseClientGenerator_Test.java
@@ -22,6 +22,7 @@ import com.spectralogic.ds3autogen.api.models.enums.Operation;
 import com.spectralogic.ds3autogen.go.generators.client.command.BaseCommandGenerator;
 import com.spectralogic.ds3autogen.go.generators.client.command.GetObjectCommandGenerator;
 import com.spectralogic.ds3autogen.go.generators.client.command.PutObjectCommandGenerator;
+import com.spectralogic.ds3autogen.go.generators.client.command.ReaderPayloadCommandGenerator;
 import com.spectralogic.ds3autogen.go.models.client.*;
 import org.junit.Test;
 
@@ -174,5 +175,8 @@ public class BaseClientGenerator_Test {
 
         assertThat(generator.getCommandGenerator(getRequestAmazonS3GetObject()))
                 .isInstanceOf(GetObjectCommandGenerator.class);
+
+        assertThat(generator.getCommandGenerator(getCreateMultiPartUploadPart()))
+                .isInstanceOf(ReaderPayloadCommandGenerator.class);
     }
 }

--- a/ds3-autogen-go/src/test/kotlin/com/spectralogic/ds3autogen/go/generators/client/command/ReaderPayloadCommandGeneratorTest.kt
+++ b/ds3-autogen-go/src/test/kotlin/com/spectralogic/ds3autogen/go/generators/client/command/ReaderPayloadCommandGeneratorTest.kt
@@ -1,0 +1,33 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.go.generators.client.command;
+
+import com.spectralogic.ds3autogen.go.models.client.ReaderBuildLine
+import com.spectralogic.ds3autogen.go.models.client.RequestBuildLine
+import org.assertj.core.api.Assertions
+import org.junit.Test
+
+class ReaderPayloadCommandGeneratorTest {
+
+    private val generator = ReaderPayloadCommandGenerator()
+
+    @Test
+    fun toReaderBuildLineTest() {
+        Assertions.assertThat<RequestBuildLine>(generator.toReaderBuildLine())
+                .isNotEmpty
+                .contains(ReaderBuildLine("request.Content"))
+    }
+}


### PR DESCRIPTION
**Changes**
Added request payload to PutMultiPartUploadPart request builder.

**Example Code**
```
package ds3

import (
    "ds3/models"
    "ds3/networking"
)

func (client *Client) PutMultiPartUploadPart(request *models.PutMultiPartUploadPartRequest) (*models.PutMultiPartUploadPartResponse, error) {
    // Build the http request
    httpRequest, err := networking.NewHttpRequestBuilder().
        WithHttpVerb(HTTP_VERB_PUT).
        WithPath("/" + request.BucketName + "/" + request.ObjectName).
        WithQueryParam("part_number", strconv.Itoa(request.PartNumber)).
        WithQueryParam("upload_id", request.UploadId).
        WithReader(request.Content).
        Build(client.connectionInfo)

    if err != nil {
        return nil, err
    }

    networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.sendNetwork), client.clientPolicy.maxRetries)

    // Invoke the HTTP request.
    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
    if requestErr != nil {
        return nil, requestErr
    }

    // Create a response object based on the result.
    return models.NewPutMultiPartUploadPartResponse(response)
}
```