### PR TITLE
GOSDK-8: Special cased Bulk Put client command generation in Go module

### DIFF
--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/client/BaseClientGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/client/BaseClientGenerator.kt
@@ -74,6 +74,7 @@ open class BaseClientGenerator : ClientModelGenerator<Client> {
             isAmazonCreateObjectRequest(ds3Request) -> PutObjectCommandGenerator()
             isGetObjectAmazonS3Request(ds3Request) -> GetObjectCommandGenerator()
             isCreateMultiPartUploadPartRequest(ds3Request) -> ReaderPayloadCommandGenerator()
+            hasPutObjectsWithSizeRequestPayload(ds3Request) -> Ds3PutObjectPayloadCommandGenerator()
             else -> BaseCommandGenerator()
         }
     }

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/client/command/Ds3PutObjectPayloadCommandGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/client/command/Ds3PutObjectPayloadCommandGenerator.kt
@@ -1,0 +1,35 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.go.generators.client.command
+
+import com.spectralogic.ds3autogen.go.models.client.ReadCloserBuildLine
+import com.spectralogic.ds3autogen.go.models.client.RequestBuildLine
+import java.util.*
+
+/**
+ * Generates commands with request payloads built from a list of Ds3PutObjects.
+ * Used to generate PutBulkJobSpectraS3 command.
+ */
+class Ds3PutObjectPayloadCommandGenerator : BaseCommandGenerator() {
+
+    /**
+     * Retrieves the request builder line for adding the request payload
+     * built from a list of Ds3PutObjects.
+     */
+    override fun toReaderBuildLine(): Optional<RequestBuildLine> {
+        return Optional.of(ReadCloserBuildLine("buildDs3PutObjectListStream(request.Objects)"))
+    }
+}

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/models/client/RequestBuildLine.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/models/client/RequestBuildLine.kt
@@ -78,3 +78,8 @@ data class CustomBuildLine(private val customLine: String) : RequestBuildLine {
 data class ReaderBuildLine(private val reader: String) : RequestBuildLine {
     override val line = "WithReader($reader)."
 }
+
+// Creates the Go request builder line for adding a readCloser that contains the request payload.
+data class ReadCloserBuildLine(private val readCloser: String) : RequestBuildLine {
+    override val line = "WithReadCloser($readCloser)."
+}

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTests.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTests.java
@@ -1108,6 +1108,7 @@ public class GoFunctionalTests {
         assertTrue(client.contains("WithOptionalQueryParam(\"priority\", networking.InterfaceToStrPtr(request.Priority))."));
         assertTrue(client.contains("WithOptionalQueryParam(\"verify_after_write\", networking.BoolPtrToStrPtr(request.VerifyAfterWrite))."));
         assertTrue(client.contains("WithQueryParam(\"operation\", \"start_bulk_put\")."));
+        assertTrue(client.contains("WithReadCloser(buildDs3PutObjectListStream(request.Objects))."));
     }
 
     @Test

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/client/BaseClientGenerator_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/client/BaseClientGenerator_Test.java
@@ -19,10 +19,7 @@ import com.google.common.collect.ImmutableList;
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3Request;
 import com.spectralogic.ds3autogen.api.models.enums.HttpVerb;
 import com.spectralogic.ds3autogen.api.models.enums.Operation;
-import com.spectralogic.ds3autogen.go.generators.client.command.BaseCommandGenerator;
-import com.spectralogic.ds3autogen.go.generators.client.command.GetObjectCommandGenerator;
-import com.spectralogic.ds3autogen.go.generators.client.command.PutObjectCommandGenerator;
-import com.spectralogic.ds3autogen.go.generators.client.command.ReaderPayloadCommandGenerator;
+import com.spectralogic.ds3autogen.go.generators.client.command.*;
 import com.spectralogic.ds3autogen.go.models.client.*;
 import org.junit.Test;
 
@@ -178,5 +175,8 @@ public class BaseClientGenerator_Test {
 
         assertThat(generator.getCommandGenerator(getCreateMultiPartUploadPart()))
                 .isInstanceOf(ReaderPayloadCommandGenerator.class);
+
+        assertThat(generator.getCommandGenerator(getRequestBulkPut()))
+                .isInstanceOf(Ds3PutObjectPayloadCommandGenerator.class);
     }
 }

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/models/client/RequestBuildLine_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/models/client/RequestBuildLine_Test.java
@@ -76,4 +76,10 @@ public class RequestBuildLine_Test {
         assertThat(new ReaderBuildLine("RequestPayloadReader").getLine())
                 .isEqualTo("WithReader(RequestPayloadReader).");
     }
+
+    @Test
+    public void readCloserBuldLineTest() {
+        assertThat(new ReadCloserBuildLine("PayloadReadCloser").getLine())
+                .isEqualTo("WithReadCloser(PayloadReadCloser).");
+    }
 }

--- a/ds3-autogen-go/src/test/kotlin/com/spectralogic/ds3autogen/go/generators/client/command/Ds3PutObjectPayloadCommandGeneratorTest.kt
+++ b/ds3-autogen-go/src/test/kotlin/com/spectralogic/ds3autogen/go/generators/client/command/Ds3PutObjectPayloadCommandGeneratorTest.kt
@@ -1,0 +1,33 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.go.generators.client.command
+
+import com.spectralogic.ds3autogen.go.models.client.ReadCloserBuildLine
+import com.spectralogic.ds3autogen.go.models.client.RequestBuildLine
+import org.assertj.core.api.Assertions
+import org.junit.Test
+
+class Ds3PutObjectPayloadCommandGeneratorTest {
+
+    private val generator = Ds3PutObjectPayloadCommandGenerator()
+
+    @Test
+    fun toReaderBuildLineTest() {
+        Assertions.assertThat<RequestBuildLine>(generator.toReaderBuildLine())
+                .isNotEmpty
+                .contains(ReadCloserBuildLine("buildDs3PutObjectListStream(request.Objects)"))
+    }
+}


### PR DESCRIPTION
**Changes**
Added read closer to request builder for bulk put command.  The list of Ds3PutObjects is transformed into a stream within the client.

**Example Code**
```
package ds3

import (
    "ds3/models"
    "ds3/networking"
)

func (client *Client) PutBulkJobSpectraS3(request *models.PutBulkJobSpectraS3Request) (*models.PutBulkJobSpectraS3Response, error) {
    // Build the http request
    httpRequest, err := networking.NewHttpRequestBuilder().
        WithHttpVerb(HTTP_VERB_PUT).
        WithPath("/_rest_/bucket/" + request.BucketName).
        WithOptionalQueryParam("aggregating", networking.BoolPtrToStrPtr(request.Aggregating)).
        WithOptionalVoidQueryParam("force", request.Force).
        WithOptionalVoidQueryParam("ignore_naming_conflicts", request.IgnoreNamingConflicts).
        WithOptionalQueryParam("implicit_job_id_resolution", networking.BoolPtrToStrPtr(request.ImplicitJobIdResolution)).
        WithOptionalQueryParam("max_upload_size", networking.Int64PtrToStrPtr(request.MaxUploadSize)).
        WithOptionalQueryParam("minimize_spanning_across_media", networking.BoolPtrToStrPtr(request.MinimizeSpanningAcrossMedia)).
        WithOptionalQueryParam("name", request.Name).
        WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
        WithOptionalQueryParam("verify_after_write", networking.BoolPtrToStrPtr(request.VerifyAfterWrite)).
        WithQueryParam("operation", "start_bulk_put").
        WithReadCloser(buildDs3PutObjectListStream(request.Objects)).
        Build(client.connectionInfo)

    if err != nil {
        return nil, err
    }

    networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.sendNetwork), client.clientPolicy.maxRetries)

    // Invoke the HTTP request.
    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
    if requestErr != nil {
        return nil, requestErr
    }

    // Create a response object based on the result.
    return models.NewPutBulkJobSpectraS3Response(response)
}
```