### PR TITLE
GOSDK-8: Special cased bulk get client command generation in Go module

### DIFF
--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/client/BaseClientGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/client/BaseClientGenerator.kt
@@ -75,6 +75,7 @@ open class BaseClientGenerator : ClientModelGenerator<Client> {
             isGetObjectAmazonS3Request(ds3Request) -> GetObjectCommandGenerator()
             isCreateMultiPartUploadPartRequest(ds3Request) -> ReaderPayloadCommandGenerator()
             hasPutObjectsWithSizeRequestPayload(ds3Request) -> Ds3PutObjectPayloadCommandGenerator()
+            hasGetObjectsWithLengthOffsetRequestPayload(ds3Request) -> Ds3GetObjectPayloadCommandGenerator()
             else -> BaseCommandGenerator()
         }
     }

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/client/command/Ds3GetObjectPayloadCommandGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/client/command/Ds3GetObjectPayloadCommandGenerator.kt
@@ -1,0 +1,35 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.go.generators.client.command
+
+import com.spectralogic.ds3autogen.go.models.client.ReadCloserBuildLine
+import com.spectralogic.ds3autogen.go.models.client.RequestBuildLine
+import java.util.*
+
+/**
+ * Generates commands with request payloads built from a list of Ds3PutObjects.
+ * Used to generate PutBulkJobSpectraS3 command.
+ */
+class Ds3GetObjectPayloadCommandGenerator : BaseCommandGenerator() {
+
+    /**
+     * Retrieves the request builder line for adding the request payload
+     * built from a list of Ds3GetObjects.
+     */
+    override fun toReaderBuildLine(): Optional<RequestBuildLine> {
+        return Optional.of(ReadCloserBuildLine("buildDs3GetObjectListStream(request.Objects)"))
+    }
+}

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTests.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTests.java
@@ -1184,6 +1184,7 @@ public class GoFunctionalTests {
         assertTrue(client.contains("WithOptionalQueryParam(\"name\", request.Name)."));
         assertTrue(client.contains("WithOptionalQueryParam(\"priority\", networking.InterfaceToStrPtr(request.Priority))."));
         assertTrue(client.contains("WithQueryParam(\"operation\", \"start_bulk_get\")."));
+        assertTrue(client.contains("WithReadCloser(buildDs3GetObjectListStream(request.Objects))."));
     }
 
     @Test

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/client/BaseClientGenerator_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/client/BaseClientGenerator_Test.java
@@ -178,5 +178,8 @@ public class BaseClientGenerator_Test {
 
         assertThat(generator.getCommandGenerator(getRequestBulkPut()))
                 .isInstanceOf(Ds3PutObjectPayloadCommandGenerator.class);
+
+        assertThat(generator.getCommandGenerator(getRequestBulkGet()))
+                .isInstanceOf(Ds3GetObjectPayloadCommandGenerator.class);
     }
 }

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/client/BaseClientGenerator_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/client/BaseClientGenerator_Test.java
@@ -157,7 +157,8 @@ public class BaseClientGenerator_Test {
                                 new PathBuildLine("\"/_rest_/bucket/\" + request.BucketName"),
                                 new OptionalQueryParamBuildLine("chunk_client_processing_order_guarantee", "networking.InterfaceToStrPtr(request.ChunkClientProcessingOrderGuarantee)"),
                                 new OptionalQueryParamBuildLine("priority", "networking.InterfaceToStrPtr(request.Priority)"),
-                                new OperationBuildLine(Operation.START_BULK_GET)
+                                new OperationBuildLine(Operation.START_BULK_GET),
+                                new ReadCloserBuildLine("buildDs3GetObjectListStream(request.Objects)")
                         ))
                 );
     }

--- a/ds3-autogen-go/src/test/kotlin/com/spectralogic/ds3autogen/go/generators/client/command/Ds3GetObjectPayloadCommandGeneratorTest.kt
+++ b/ds3-autogen-go/src/test/kotlin/com/spectralogic/ds3autogen/go/generators/client/command/Ds3GetObjectPayloadCommandGeneratorTest.kt
@@ -1,0 +1,33 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.go.generators.client.command
+
+import com.spectralogic.ds3autogen.go.models.client.ReadCloserBuildLine
+import com.spectralogic.ds3autogen.go.models.client.RequestBuildLine
+import org.assertj.core.api.Assertions
+import org.junit.Test
+
+class Ds3GetObjectPayloadCommandGeneratorTest {
+
+    private val generator = Ds3GetObjectPayloadCommandGenerator()
+
+    @Test
+    fun toReaderBuildLineTest() {
+        Assertions.assertThat<RequestBuildLine>(generator.toReaderBuildLine())
+                .isNotEmpty
+                .contains(ReadCloserBuildLine("buildDs3GetObjectListStream(request.Objects)"))
+    }
+}


### PR DESCRIPTION
**Changes**
Added payload read closer to request builder for bulk get.

**Example Code**
```
package ds3

import (
    "ds3/models"
    "ds3/networking"
)

func (client *Client) GetBulkJobSpectraS3(request *models.GetBulkJobSpectraS3Request) (*models.GetBulkJobSpectraS3Response, error) {
    // Build the http request
    httpRequest, err := networking.NewHttpRequestBuilder().
        WithHttpVerb(HTTP_VERB_PUT).
        WithPath("/_rest_/bucket/" + request.BucketName).
        WithOptionalQueryParam("aggregating", networking.BoolPtrToStrPtr(request.Aggregating)).
        WithOptionalQueryParam("chunk_client_processing_order_guarantee", networking.InterfaceToStrPtr(request.ChunkClientProcessingOrderGuarantee)).
        WithOptionalQueryParam("implicit_job_id_resolution", networking.BoolPtrToStrPtr(request.ImplicitJobIdResolution)).
        WithOptionalQueryParam("name", request.Name).
        WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
        WithQueryParam("operation", "start_bulk_get").
        WithReadCloser(buildDs3GetObjectListStream(request.Objects)).
        Build(client.connectionInfo)

    if err != nil {
        return nil, err
    }

    networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.sendNetwork), client.clientPolicy.maxRetries)

    // Invoke the HTTP request.
    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
    if requestErr != nil {
        return nil, requestErr
    }

    // Create a response object based on the result.
    return models.NewGetBulkJobSpectraS3Response(response)
}
```