### PR TITLE
GOSDK-8: Special cased client commands with object name list payloads in Go module

### DIFF
--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/client/BaseClientGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/client/BaseClientGenerator.kt
@@ -76,6 +76,7 @@ open class BaseClientGenerator : ClientModelGenerator<Client> {
             isCreateMultiPartUploadPartRequest(ds3Request) -> ReaderPayloadCommandGenerator()
             hasPutObjectsWithSizeRequestPayload(ds3Request) -> Ds3PutObjectPayloadCommandGenerator()
             hasGetObjectsWithLengthOffsetRequestPayload(ds3Request) -> Ds3GetObjectPayloadCommandGenerator()
+            hasSimpleObjectsRequestPayload(ds3Request) -> ObjectNamePayloadCommandGenerator()
             else -> BaseCommandGenerator()
         }
     }

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/client/command/ObjectNamePayloadCommandGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/client/command/ObjectNamePayloadCommandGenerator.kt
@@ -1,0 +1,43 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.go.generators.client.command
+
+import com.spectralogic.ds3autogen.go.models.client.ReadCloserBuildLine
+import com.spectralogic.ds3autogen.go.models.client.RequestBuildLine
+import java.util.*
+
+/**
+ * Go generator for client commands that take in a list of object names
+ * and convert them into the request payload:
+ *   <Objects><Object Name="o1" /><Object Name="o2" />...</Objects>
+ *
+ * Used to generate the commands:
+ *   GetPhysicalPlacementForObjectsSpectraS3Request
+ *   GetPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request
+ *   VerifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request
+ *   VerifyPhysicalPlacementForObjectsSpectraS3Request
+ *   EjectStorageDomainBlobsSpectraS3Request
+ */
+class ObjectNamePayloadCommandGenerator : BaseCommandGenerator() {
+
+    /**
+     * Retrieves the request builder line for adding the request payload,
+     * which is an xml marshaled list of object names.
+     */
+    override fun toReaderBuildLine(): Optional<RequestBuildLine> {
+        return Optional.of(ReadCloserBuildLine("buildDs3ObjectStreamFromNames(request.ObjectNames)"))
+    }
+}

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTests.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTests.java
@@ -269,6 +269,7 @@ public class GoFunctionalTests {
         assertTrue(client.contains("WithPath(\"/_rest_/bucket/\" + request.BucketName)."));
         assertTrue(client.contains("WithOptionalQueryParam(\"storage_domain_id\", request.StorageDomainId)."));
         assertTrue(client.contains("WithQueryParam(\"operation\", \"verify_physical_placement\")."));
+        assertTrue(client.contains("WithReadCloser(buildDs3ObjectStreamFromNames(request.ObjectNames))."));
     }
 
     @Test

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/client/BaseClientGenerator_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/client/BaseClientGenerator_Test.java
@@ -182,5 +182,20 @@ public class BaseClientGenerator_Test {
 
         assertThat(generator.getCommandGenerator(getRequestBulkGet()))
                 .isInstanceOf(Ds3GetObjectPayloadCommandGenerator.class);
+
+        assertThat(generator.getCommandGenerator(getPhysicalPlacementForObjects()))
+                .isInstanceOf(ObjectNamePayloadCommandGenerator.class);
+
+        assertThat(generator.getCommandGenerator(getPhysicalPlacementForObjectsWithFullDetails()))
+                .isInstanceOf(ObjectNamePayloadCommandGenerator.class);
+
+        assertThat(generator.getCommandGenerator(verifyPhysicalPlacementForObjectsRequest()))
+                .isInstanceOf(ObjectNamePayloadCommandGenerator.class);
+
+        assertThat(generator.getCommandGenerator(verifyPhysicalPlacementForObjectsWithFullDetailsRequest()))
+                .isInstanceOf(ObjectNamePayloadCommandGenerator.class);
+
+        assertThat(generator.getCommandGenerator(getEjectStorageDomainBlobsRequest()))
+                .isInstanceOf(ObjectNamePayloadCommandGenerator.class);
     }
 }

--- a/ds3-autogen-go/src/test/kotlin/com/spectralogic/ds3autogen/go/generators/client/command/ObjectNamePayloadCommandGeneratorTest.kt
+++ b/ds3-autogen-go/src/test/kotlin/com/spectralogic/ds3autogen/go/generators/client/command/ObjectNamePayloadCommandGeneratorTest.kt
@@ -1,0 +1,34 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.go.generators.client.command
+
+import com.spectralogic.ds3autogen.go.models.client.ReadCloserBuildLine
+import com.spectralogic.ds3autogen.go.models.client.RequestBuildLine
+import org.assertj.core.api.Assertions
+import org.junit.Test
+
+
+class ObjectNamePayloadCommandGeneratorTest {
+
+    private val generator = ObjectNamePayloadCommandGenerator()
+
+    @Test
+    fun toReaderBuildLineTest() {
+        Assertions.assertThat<RequestBuildLine>(generator.toReaderBuildLine())
+                .isNotEmpty
+                .contains(ReadCloserBuildLine("buildDs3ObjectStreamFromNames(request.ObjectNames)"))
+    }
+}


### PR DESCRIPTION
**Changes**
Added closable reader to client request builder for commands with request payloads of:
`<Objects><Object Name="o1" /><Object Name="o2" />...</Objects>`

Commands affected:
- GetPhysicalPlacementForObjectsSpectraS3Request
- GetPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request
- VerifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request
- VerifyPhysicalPlacementForObjectsSpectraS3Request
- EjectStorageDomainBlobsSpectraS3Request

**Sample Generated Code**
```
package ds3

import (
    "ds3/models"
    "ds3/networking"
)


func (client *Client) VerifyPhysicalPlacementForObjectsSpectraS3(request *models.VerifyPhysicalPlacementForObjectsSpectraS3Request) (*models.VerifyPhysicalPlacementForObjectsSpectraS3Response, error) {
    // Build the http request
    httpRequest, err := networking.NewHttpRequestBuilder().
        WithHttpVerb(HTTP_VERB_GET).
        WithPath("/_rest_/bucket/" + request.BucketName).
        WithOptionalQueryParam("storage_domain_id", request.StorageDomainId).
        WithQueryParam("operation", "verify_physical_placement").
        WithReadCloser(buildDs3ObjectStreamFromNames(request.ObjectNames)).
        Build(client.connectionInfo)

    if err != nil {
        return nil, err
    }

    networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.sendNetwork), client.clientPolicy.maxRetries)
    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(&networkRetryDecorator, client.clientPolicy.maxRedirect)

    // Invoke the HTTP request.
    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
    if requestErr != nil {
        return nil, requestErr
    }

    // Create a response object based on the result.
    return models.NewVerifyPhysicalPlacementForObjectsSpectraS3Response(response)
}
```