### PR TITLE
GOSDK-8: Special cased client commands with string payloads in Go module

### DIFF
--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/client/BaseClientGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/client/BaseClientGenerator.kt
@@ -78,6 +78,7 @@ open class BaseClientGenerator : ClientModelGenerator<Client> {
             hasGetObjectsWithLengthOffsetRequestPayload(ds3Request) -> Ds3GetObjectPayloadCommandGenerator()
             hasSimpleObjectsRequestPayload(ds3Request) -> ObjectNamePayloadCommandGenerator()
             hasIdsRequestPayload(ds3Request) -> IdsPayloadCommandGenerator()
+            hasStringRequestPayload(ds3Request) -> StringPayloadCommandGenerator()
             else -> BaseCommandGenerator()
         }
     }

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/client/command/StringPayloadCommandGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/client/command/StringPayloadCommandGenerator.kt
@@ -1,0 +1,38 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.go.generators.client.command
+
+import com.spectralogic.ds3autogen.go.models.client.ReadCloserBuildLine
+import com.spectralogic.ds3autogen.go.models.client.RequestBuildLine
+import java.util.*
+
+/**
+ * The Go generator for client commands that have a string request payload
+ * that is not specified within the contract.
+ *
+ * Used to generate the commands:
+ *   GetBlobPersistenceRequest
+ *   ReplicatePutJobRequest
+ */
+class StringPayloadCommandGenerator : BaseCommandGenerator() {
+
+    /**
+     * Retrieves the request builder line for adding the request payload in string format.
+     */
+    override fun toReaderBuildLine(): Optional<RequestBuildLine> {
+        return Optional.of(ReadCloserBuildLine("buildStreamFromString(request.Content)"))
+    }
+}

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTests.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTests.java
@@ -332,6 +332,7 @@ public class GoFunctionalTests {
         assertTrue(client.contains("WithQueryParam(\"replicate\", \"\")."));
         assertTrue(client.contains("WithOptionalQueryParam(\"priority\", networking.InterfaceToStrPtr(request.Priority))."));
         assertTrue(client.contains("WithQueryParam(\"operation\", \"start_bulk_put\")."));
+        assertTrue(client.contains("WithReadCloser(buildStreamFromString(request.Content))."));
     }
 
     @Test

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/client/BaseClientGenerator_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/client/BaseClientGenerator_Test.java
@@ -224,5 +224,11 @@ public class BaseClientGenerator_Test {
 
         assertThat(generator.getCommandGenerator(markSuspectBlobTapesAsDegradedRequest()))
                 .isInstanceOf(IdsPayloadCommandGenerator.class);
+
+        assertThat(generator.getCommandGenerator(getGetBlobPersistence()))
+                .isInstanceOf(StringPayloadCommandGenerator.class);
+
+        assertThat(generator.getCommandGenerator(getReplicatePutJob()))
+                .isInstanceOf(StringPayloadCommandGenerator.class);
     }
 }

--- a/ds3-autogen-go/src/test/kotlin/com/spectralogic/ds3autogen/go/generators/client/command/StringPayloadCommandGeneratorTest.kt
+++ b/ds3-autogen-go/src/test/kotlin/com/spectralogic/ds3autogen/go/generators/client/command/StringPayloadCommandGeneratorTest.kt
@@ -1,0 +1,33 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.go.generators.client.command
+
+import com.spectralogic.ds3autogen.go.models.client.ReadCloserBuildLine
+import com.spectralogic.ds3autogen.go.models.client.RequestBuildLine
+import org.assertj.core.api.Assertions
+import org.junit.Test
+
+class StringPayloadCommandGeneratorTest {
+
+    private val generator = StringPayloadCommandGenerator()
+
+    @Test
+    fun toReaderBuildLineTest() {
+        Assertions.assertThat<RequestBuildLine>(generator.toReaderBuildLine())
+                .isNotEmpty
+                .contains(ReadCloserBuildLine("buildStreamFromString(request.Content)"))
+    }
+}


### PR DESCRIPTION
**Changes**
Added read closer to request builder for commands with string request payloads.

**Example Code**
```
package ds3

import (
    "ds3/models"
    "ds3/networking"
)

func (client *Client) ReplicatePutJobSpectraS3(request *models.ReplicatePutJobSpectraS3Request) (*models.ReplicatePutJobSpectraS3Response, error) {
    // Build the http request
    httpRequest, err := networking.NewHttpRequestBuilder().
        WithHttpVerb(HTTP_VERB_PUT).
        WithPath("/_rest_/bucket/" + request.BucketName).
        WithQueryParam("replicate", "").
        WithOptionalQueryParam("priority", networking.InterfaceToStrPtr(request.Priority)).
        WithQueryParam("operation", "start_bulk_put").
        WithReadCloser(buildStreamFromString(request.Content)).
        Build(client.connectionInfo)

    if err != nil {
        return nil, err
    }

    networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.sendNetwork), client.clientPolicy.maxRetries)

    // Invoke the HTTP request.
    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
    if requestErr != nil {
        return nil, requestErr
    }

    // Create a response object based on the result.
    return models.NewReplicatePutJobSpectraS3Response(response)
}
```