### PR TITLE
GOSDK-8: Special cased client commands with part list payloads in Go module

### DIFF
--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/client/BaseClientGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/client/BaseClientGenerator.kt
@@ -79,6 +79,7 @@ open class BaseClientGenerator : ClientModelGenerator<Client> {
             hasSimpleObjectsRequestPayload(ds3Request) -> ObjectNamePayloadCommandGenerator()
             hasIdsRequestPayload(ds3Request) -> IdsPayloadCommandGenerator()
             hasStringRequestPayload(ds3Request) -> StringPayloadCommandGenerator()
+            isCompleteMultiPartUploadRequest(ds3Request) -> PartsPayloadCommandGenerator()
             else -> BaseCommandGenerator()
         }
     }

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/client/command/PartsPayloadCommandGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/client/command/PartsPayloadCommandGenerator.kt
@@ -1,0 +1,39 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.go.generators.client.command
+
+import com.spectralogic.ds3autogen.go.models.client.ReadCloserBuildLine
+import com.spectralogic.ds3autogen.go.models.client.RequestBuildLine
+import java.util.*
+
+/**
+ * The Go generator for client commands that take in a list of Parts and
+ * converts them into the request payload:
+ * <CompleteMultipartUpload><Part><PartNumber>partNumber</PartNumber><ETag>eTag</ETag></Part>...</CompleteMultipartUpload>
+ *
+ * Used to generate command:
+ *   CompleteMultiPartUploadRequest
+ */
+class PartsPayloadCommandGenerator : BaseCommandGenerator() {
+
+    /**
+     * Retrieves the request builder line for adding the request payload,
+     * which is an xml marshaled list of object parts.
+     */
+    override fun toReaderBuildLine(): Optional<RequestBuildLine> {
+        return Optional.of(ReadCloserBuildLine("buildPartsListStream(request.Parts)"))
+    }
+}

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTests.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTests.java
@@ -390,6 +390,7 @@ public class GoFunctionalTests {
         assertTrue(client.contains("WithHttpVerb(HTTP_VERB_POST)."));
         assertTrue(client.contains("WithPath(\"/\" + request.BucketName + \"/\" + request.ObjectName)."));
         assertTrue(client.contains("WithQueryParam(\"upload_id\", request.UploadId)."));
+        assertTrue(client.contains("WithReadCloser(buildPartsListStream(request.Parts))."));
     }
 
     @Test

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/client/BaseClientGenerator_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/client/BaseClientGenerator_Test.java
@@ -230,5 +230,8 @@ public class BaseClientGenerator_Test {
 
         assertThat(generator.getCommandGenerator(getReplicatePutJob()))
                 .isInstanceOf(StringPayloadCommandGenerator.class);
+
+        assertThat(generator.getCommandGenerator(getCompleteMultipartUploadRequest()))
+                .isInstanceOf(PartsPayloadCommandGenerator.class);
     }
 }

--- a/ds3-autogen-go/src/test/kotlin/com/spectralogic/ds3autogen/go/generators/client/command/PartsPayloadCommandGeneratorTest.kt
+++ b/ds3-autogen-go/src/test/kotlin/com/spectralogic/ds3autogen/go/generators/client/command/PartsPayloadCommandGeneratorTest.kt
@@ -1,0 +1,33 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.go.generators.client.command
+
+import com.spectralogic.ds3autogen.go.models.client.ReadCloserBuildLine
+import com.spectralogic.ds3autogen.go.models.client.RequestBuildLine
+import org.assertj.core.api.Assertions
+import org.junit.Test
+
+class PartsPayloadCommandGeneratorTest {
+
+    private val generator = PartsPayloadCommandGenerator()
+
+    @Test
+    fun toReaderBuildLineTest() {
+        Assertions.assertThat<RequestBuildLine>(generator.toReaderBuildLine())
+                .isNotEmpty
+                .contains(ReadCloserBuildLine("buildPartsListStream(request.Parts)"))
+    }
+}


### PR DESCRIPTION
**Changes**
Added closable stream to commands with request payloads of part lists.

**Example Code**
```
func (client *Client) CompleteMultiPartUpload(request *models.CompleteMultiPartUploadRequest) (*models.CompleteMultiPartUploadResponse, error) {
    // Build the http request
    httpRequest, err := networking.NewHttpRequestBuilder().
        WithHttpVerb(HTTP_VERB_POST).
        WithPath("/" + request.BucketName + "/" + request.ObjectName).
        WithQueryParam("upload_id", request.UploadId).
        WithReadCloser(buildPartsListStream(request.Parts)).
        Build(client.connectionInfo)

    if err != nil {
        return nil, err
    }

    networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.sendNetwork), client.clientPolicy.maxRetries)

    // Invoke the HTTP request.
    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
    if requestErr != nil {
        return nil, requestErr
    }

    // Create a response object based on the result.
    return models.NewCompleteMultiPartUploadResponse(response)
}
```