### PR TITLE
GOSDK-8: Special cased client commands with delete objects payload in Go module

### DIFF
--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/client/BaseClientGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/client/BaseClientGenerator.kt
@@ -80,6 +80,7 @@ open class BaseClientGenerator : ClientModelGenerator<Client> {
             hasIdsRequestPayload(ds3Request) -> IdsPayloadCommandGenerator()
             hasStringRequestPayload(ds3Request) -> StringPayloadCommandGenerator()
             isCompleteMultiPartUploadRequest(ds3Request) -> PartsPayloadCommandGenerator()
+            isMultiFileDeleteRequest(ds3Request) -> DeleteObjectsCommandGenerator()
             else -> BaseCommandGenerator()
         }
     }

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/client/command/DeleteObjectsCommandGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/client/command/DeleteObjectsCommandGenerator.kt
@@ -1,0 +1,39 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.go.generators.client.command
+
+import com.spectralogic.ds3autogen.go.models.client.ReadCloserBuildLine
+import com.spectralogic.ds3autogen.go.models.client.RequestBuildLine
+import java.util.*
+
+/**
+ * Go generator for commands that take in a list of object names to be deleted
+ * and converts them into the request payload:
+ * <Delete><Object><Key>object/</Key></Object><Object><Key>object/1</Key></Object>...</Delete>
+ *
+ * Used to generate the command:
+ *   DeleteObjectsRequestHandler
+ */
+class DeleteObjectsCommandGenerator : BaseCommandGenerator() {
+
+    /**
+     * Retrieves the request builder line for adding the request payload,
+     * which is an xml marshaled list of objects to be deleted.
+     */
+    override fun toReaderBuildLine(): Optional<RequestBuildLine> {
+        return Optional.of(ReadCloserBuildLine("buildDeleteObjectsPayload(request.ObjectNames)"))
+    }
+}

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTests.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTests.java
@@ -454,6 +454,7 @@ public class GoFunctionalTests {
         assertTrue(client.contains("WithPath(\"/\" + request.BucketName)."));
         assertTrue(client.contains("WithQueryParam(\"delete\", \"\")."));
         assertTrue(client.contains("WithOptionalVoidQueryParam(\"roll_back\", request.RollBack)."));
+        assertTrue(client.contains("WithReadCloser(buildDeleteObjectsPayload(request.ObjectNames))."));
     }
 
     @Test

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/client/BaseClientGenerator_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/client/BaseClientGenerator_Test.java
@@ -233,5 +233,8 @@ public class BaseClientGenerator_Test {
 
         assertThat(generator.getCommandGenerator(getCompleteMultipartUploadRequest()))
                 .isInstanceOf(PartsPayloadCommandGenerator.class);
+
+        assertThat(generator.getCommandGenerator(getRequestMultiFileDelete()))
+                .isInstanceOf(DeleteObjectsCommandGenerator.class);
     }
 }

--- a/ds3-autogen-go/src/test/kotlin/com/spectralogic/ds3autogen/go/generators/client/command/DeleteObjectsCommandGeneratorTest.kt
+++ b/ds3-autogen-go/src/test/kotlin/com/spectralogic/ds3autogen/go/generators/client/command/DeleteObjectsCommandGeneratorTest.kt
@@ -1,0 +1,18 @@
+package com.spectralogic.ds3autogen.go.generators.client.command
+
+import com.spectralogic.ds3autogen.go.models.client.ReadCloserBuildLine
+import com.spectralogic.ds3autogen.go.models.client.RequestBuildLine
+import org.assertj.core.api.Assertions
+import org.junit.Test
+
+class DeleteObjectsCommandGeneratorTest {
+
+    private val generator = DeleteObjectsCommandGenerator()
+
+    @Test
+    fun toReaderBuildLineTest() {
+        Assertions.assertThat<RequestBuildLine>(generator.toReaderBuildLine())
+                .isNotEmpty
+                .contains(ReadCloserBuildLine("buildDeleteObjectsPayload(request.ObjectNames)"))
+    }
+}


### PR DESCRIPTION
**Changes**
Added closable stream DeleteObjects request builder.

**Sample Code**
```
func (client *Client) DeleteObjects(request *models.DeleteObjectsRequest) (*models.DeleteObjectsResponse, error) {
    // Build the http request
    httpRequest, err := networking.NewHttpRequestBuilder().
        WithHttpVerb(HTTP_VERB_POST).
        WithPath("/" + request.BucketName).
        WithQueryParam("delete", "").
        WithOptionalVoidQueryParam("roll_back", request.RollBack).
        WithReadCloser(buildDeleteObjectsPayload(request.ObjectNames)).
        Build(client.connectionInfo)

    if err != nil {
        return nil, err
    }

    networkRetryDecorator := networking.NewNetworkRetryDecorator(&(client.sendNetwork), client.clientPolicy.maxRetries)

    // Invoke the HTTP request.
    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
    if requestErr != nil {
        return nil, requestErr
    }

    // Create a response object based on the result.
    return models.NewDeleteObjectsResponse(response)
}
```