### PR TITLE
GOSDK-8: Fixed incorrect generation of nullable constructor args in Go request handlers

### DIFF
--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/request/BaseRequestGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/request/BaseRequestGenerator.kt
@@ -143,7 +143,20 @@ open class BaseRequestGenerator : RequestModelGenerator<Request>, RequestModelGe
             builder.add(Arguments(toGoType(resourceArg.type), resourceArg.name))
         }
 
-        builder.addAll(toGoArgumentsList(removeVoidAndOperationDs3Params(ds3Request.requiredQueryParams)))
+        if (isEmpty(ds3Request.requiredQueryParams)) {
+            return builder.build()
+        }
+
+        ds3Request.requiredQueryParams!!.stream()
+                .filter{ param -> !param.type.equals("void", ignoreCase = true) //filter out void parameters
+                        && !param.name.equals("Operation", ignoreCase = true) } //filter out Operation parameter
+                .forEach { param ->
+                    // Convert to a non-nullable Go argument and add to builder
+                    val goType = toGoRequestType(param.type, false)
+                    val goName = toGoParamName(param.name, param.type)
+                    builder.add(Arguments(goType, goName))
+                }
+
         return builder.build()
     }
 
@@ -171,7 +184,17 @@ open class BaseRequestGenerator : RequestModelGenerator<Request>, RequestModelGe
             builder.add(SimpleVariable(uncapFirst(resourceArg.name)))
         }
 
-        builder.addAll(toSimpleVariables(removeVoidAndOperationDs3Params(ds3Request.requiredQueryParams)))
+        if (isEmpty(ds3Request.requiredQueryParams)) {
+            return builder.build()
+        }
+
+        ds3Request.requiredQueryParams!!.stream()
+                .filter{ param -> !param.type.equals("void", ignoreCase = true) //filter out void parameters
+                        && !param.name.equals("Operation", ignoreCase = true) } //filter out Operation parameter
+                .forEach { param ->
+                    // Create a simple variable from the parameter
+                    builder.add(SimpleVariable(uncapFirst(toGoParamName(param.name, param.type))))
+                }
 
         return builder.build()
     }

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/request/RequestGeneratorUtil.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/request/RequestGeneratorUtil.kt
@@ -17,60 +17,14 @@ package com.spectralogic.ds3autogen.go.generators.request
 
 import com.google.common.collect.ImmutableList
 import com.spectralogic.ds3autogen.api.models.Arguments
-import com.spectralogic.ds3autogen.api.models.apispec.Ds3Param
-import com.spectralogic.ds3autogen.go.models.request.SimpleVariable
-import com.spectralogic.ds3autogen.go.models.request.Variable
-import com.spectralogic.ds3autogen.go.utils.toGoParamName
-import com.spectralogic.ds3autogen.go.utils.toGoRequestType
-import com.spectralogic.ds3autogen.go.utils.toGoType
-import com.spectralogic.ds3autogen.utils.ConverterUtil
-import com.spectralogic.ds3autogen.utils.ConverterUtil.isEmpty
-import com.spectralogic.ds3autogen.utils.Helper
-import com.spectralogic.ds3autogen.utils.Helper.camelToUnderscore
 import com.spectralogic.ds3autogen.utils.Helper.uncapFirst
 import com.spectralogic.ds3autogen.utils.NormalizingContractNamesUtil
-import com.spectralogic.ds3autogen.utils.collections.GuavaCollectors
 import com.spectralogic.ds3autogen.utils.comparators.CustomArgumentComparator
 import java.util.stream.Collectors
 
 /**
  * Contains utilities used in by Go request generators
  */
-
-/**
- * Removes parameters with either type void or name operation
- */
-fun removeVoidAndOperationDs3Params(ds3Params: ImmutableList<Ds3Param>?): ImmutableList<Ds3Param> {
-    if (ConverterUtil.isEmpty(ds3Params)) {
-        return ImmutableList.of()
-    }
-    return ds3Params!!.stream()
-            .filter{ param -> !param.type.equals("void", ignoreCase = true)
-                           && !param.name.equals("Operation", ignoreCase = true) }
-            .collect(GuavaCollectors.immutableList<Ds3Param>())
-}
-
-/**
- * Converts a list of required Ds3Params into a list of Arguments. Returns an empty list
- * if requiredParams is null or empty.
- */
-fun toGoArgumentsList(requiredParams: ImmutableList<Ds3Param>?): ImmutableList<Arguments> {
-    if (ConverterUtil.isEmpty(requiredParams)) {
-        return ImmutableList.of()
-    }
-    return requiredParams!!.stream()
-            .map(::toGoArgument)
-            .collect(GuavaCollectors.immutableList())
-}
-
-/**
- * Converts a Ds3Param into an Argument containing the corresponding Go type and parameter name
- */
-fun toGoArgument(ds3Param: Ds3Param): Arguments {
-    val goType = toGoRequestType(ds3Param.type, ds3Param.nullable)
-    val goName = toGoParamName(ds3Param.name, ds3Param.type)
-    return Arguments(goType, goName)
-}
 
 /**
  * Transforms a list of Arguments into a comma-separated list of function input parameters.
@@ -94,17 +48,4 @@ fun usesStrconv(contractType: String): Boolean {
         "boolean", "integer", "int", "double", "long" -> return true
         else -> return false
     }
-}
-
-/**
- * Converts a list of Ds3Params into a list of SimpleVariables. This is used to create
- * assignments within the request constructor to the request struct.
- */
-fun toSimpleVariables(ds3Params: ImmutableList<Ds3Param>?): ImmutableList<SimpleVariable> {
-    if (isEmpty(ds3Params)) {
-        return ImmutableList.of()
-    }
-    return ds3Params!!.stream()
-            .map{ param -> SimpleVariable(uncapFirst(toGoParamName(param.name, param.type))) }
-            .collect(GuavaCollectors.immutableList())
 }

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTests.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTests.java
@@ -1270,4 +1270,36 @@ public class GoFunctionalTests {
         assertTrue(client.contains("WithQueryParam(\"operation\", \"start_bulk_verify\")."));
         assertTrue(client.contains("WithReadCloser(buildDs3GetObjectListStream(request.Objects))."));
     }
+
+    @Test
+    public void putBucketSpectraS3Test() throws IOException, TemplateModelException {
+        final String requestName = "PutBucketSpectraS3Request";
+        final FileUtils fileUtils = mock(FileUtils.class);
+        final GoTestCodeUtil codeGenerator = new GoTestCodeUtil(fileUtils, requestName, "Bucket");
+
+        codeGenerator.generateCode(fileUtils, "/input/putBucketSpectraS3.xml");
+
+        // Verify Request file was generated
+        final String requestCode = codeGenerator.getRequestCode();
+        CODE_LOGGER.logFile(requestCode, FileTypeToLog.REQUEST);
+        assertTrue(hasContent(requestCode));
+
+        assertTrue(requestCode.contains("type PutBucketSpectraS3Request struct {"));
+        assertTrue(requestCode.contains("DataPolicyId *string"));
+        assertTrue(requestCode.contains("Id *string"));
+        assertTrue(requestCode.contains("Name string"));
+        assertTrue(requestCode.contains("UserId *string"));
+
+        assertTrue(requestCode.contains("func NewPutBucketSpectraS3Request(name string) *PutBucketSpectraS3Request {"));
+        assertTrue(requestCode.contains("Name: name,"));
+
+        assertTrue(requestCode.contains("func (putBucketSpectraS3Request *PutBucketSpectraS3Request) WithDataPolicyId(dataPolicyId string) *PutBucketSpectraS3Request {"));
+        assertTrue(requestCode.contains("putBucketSpectraS3Request.DataPolicyId = &dataPolicyId"));
+
+        assertTrue(requestCode.contains("func (putBucketSpectraS3Request *PutBucketSpectraS3Request) WithId(id string) *PutBucketSpectraS3Request {"));
+        assertTrue(requestCode.contains("putBucketSpectraS3Request.Id = &id"));
+
+        assertTrue(requestCode.contains("func (putBucketSpectraS3Request *PutBucketSpectraS3Request) WithUserId(userId string) *PutBucketSpectraS3Request {"));
+        assertTrue(requestCode.contains("putBucketSpectraS3Request.UserId = &userId"));
+    }
 }

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/request/RequestGeneratorUtil_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/request/RequestGeneratorUtil_Test.java
@@ -17,105 +17,14 @@ package com.spectralogic.ds3autogen.go.generators.request;
 
 import com.google.common.collect.ImmutableList;
 import com.spectralogic.ds3autogen.api.models.Arguments;
-import com.spectralogic.ds3autogen.api.models.apispec.Ds3Param;
-import com.spectralogic.ds3autogen.go.models.request.SimpleVariable;
 import org.junit.Test;
 
-import static com.spectralogic.ds3autogen.go.generators.request.RequestGeneratorUtilKt.*;
-import static org.hamcrest.CoreMatchers.hasItem;
+import static com.spectralogic.ds3autogen.go.generators.request.RequestGeneratorUtilKt.toFunctionInput;
+import static com.spectralogic.ds3autogen.go.generators.request.RequestGeneratorUtilKt.usesStrconv;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.*;
 
 public class RequestGeneratorUtil_Test {
-
-    @Test
-    public void removeVoidAndOperationDs3Params_NullList_Test() {
-        final ImmutableList<Ds3Param> result = removeVoidAndOperationDs3Params(null);
-        assertThat(result.size(), is(0));
-    }
-
-    @Test
-    public void removeVoidAndOperationDs3Params_EmptyList_Test() {
-        final ImmutableList<Ds3Param> result = removeVoidAndOperationDs3Params(ImmutableList.of());
-        assertThat(result.size(), is(0));
-    }
-
-    @Test
-    public void removeVoidAndOperationDs3Params_FullList_Test() {
-        final ImmutableList<Ds3Param> expected = ImmutableList.of(
-                new Ds3Param("Param1", "Type1", false),
-                new Ds3Param("Param3", "int", false)
-        );
-
-        final ImmutableList<Ds3Param> params = ImmutableList.of(
-                new Ds3Param("Param1", "Type1", false),
-                new Ds3Param("Param2", "void", false),
-                new Ds3Param("Param3", "int", false),
-                new Ds3Param("Param4", "VOID", false),
-                new Ds3Param("Operation", "RestOperationType", false)
-        );
-
-        final ImmutableList<Ds3Param> result = removeVoidAndOperationDs3Params(params);
-        assertThat(result.size(), is(expected.size()));
-        expected.forEach(param -> assertThat(result, hasItem(param)));
-    }
-
-    @Test
-    public void toGoArgumentsList_NullList_Test() {
-        final ImmutableList<Arguments> result = toGoArgumentsList(null);
-        assertThat(result.size(), is(0));
-    }
-
-    @Test
-    public void toGoArgumentsList_EmptyList_Test() {
-        final ImmutableList<Arguments> result = toGoArgumentsList(ImmutableList.of());
-        assertThat(result.size(), is(0));
-    }
-
-    @Test
-    public void toGoArgumentsList_FullList_Test() {
-        final ImmutableList<String> expectedTypes = ImmutableList.of("", "*int", "float64", "string");
-
-        final ImmutableList<Ds3Param> params = ImmutableList.of(
-                new Ds3Param("Param1", "void", false),
-                new Ds3Param("Param2", "java.lang.Integer", true),
-                new Ds3Param("Param3", "double", false),
-                new Ds3Param("Param4", "java.util.UUID", false)
-        );
-
-        final ImmutableList<Arguments> result = toGoArgumentsList(params);
-        assertThat(result.size(), is(4));
-
-        for (int i = 0; i < result.size(); i++) {
-            assertThat(result.get(i).getType(), is(expectedTypes.get(i)));
-        }
-    }
-
-    @Test
-    public void toGoArgument_Test() {
-        final ImmutableList<Arguments> expectedArgs = ImmutableList.of(
-                new Arguments("", "Param1"),
-                new Arguments("*int", "Param2"),
-                new Arguments("float64", "Param3"),
-                new Arguments("string", "Param4"),
-                new Arguments("TestType", "TestType")
-        );
-
-        final ImmutableList<Ds3Param> params = ImmutableList.of(
-                new Ds3Param("Param1", "void", false),
-                new Ds3Param("Param2", "java.lang.Integer", true),
-                new Ds3Param("Param3", "double", false),
-                new Ds3Param("Param4", "java.util.UUID", false),
-                new Ds3Param("Type", "com.test.TestType", false)
-        );
-
-        for (int i = 0; i < params.size(); i++) {
-            final Arguments result = toGoArgument(params.get(i));
-            final Arguments expected = expectedArgs.get(i);
-            assertThat(result.getName(), is(expected.getName()));
-            assertThat(result.getType(), is(expected.getType()));
-        }
-    }
 
     @Test
     public void toFunctionInput_EmptyList_Test() {
@@ -136,39 +45,6 @@ public class RequestGeneratorUtil_Test {
 
         final String result = toFunctionInput(args);
         assertThat(result, is(expected));
-    }
-
-    @Test
-    public void toSimpleVariables_NullList_Test() {
-        final ImmutableList<SimpleVariable> result = toSimpleVariables(null);
-        assertThat(result.size(), is(0));
-    }
-
-    @Test
-    public void toSimpleVariables_EmptyList_Test() {
-        final ImmutableList<SimpleVariable> result = toSimpleVariables(ImmutableList.of());
-        assertThat(result.size(), is(0));
-    }
-
-    @Test
-    public void toSimpleVariables_FullList_Test() {
-        final ImmutableList<SimpleVariable> expected = ImmutableList.of(
-                new SimpleVariable("paramOne"),
-                new SimpleVariable("paramTwo"),
-                new SimpleVariable("paramThree"),
-                new SimpleVariable("typeName")
-        );
-
-        final ImmutableList<Ds3Param> params = ImmutableList.of(
-                new Ds3Param("ParamOne", "string", false),
-                new Ds3Param("ParamTwo", "string", true),
-                new Ds3Param("ParamThree", "string", false),
-                new Ds3Param("Type", "com.test.TypeName", false)
-        );
-
-        final ImmutableList<SimpleVariable> result = toSimpleVariables(params);
-        assertThat(result.size(), is(expected.size()));
-        expected.forEach(expectedVar -> assertThat(result, hasItem(expectedVar)));
     }
 
     @Test

--- a/ds3-autogen-go/src/test/resources/input/putBucketSpectraS3.xml
+++ b/ds3-autogen-go/src/test/resources/input/putBucketSpectraS3.xml
@@ -1,0 +1,131 @@
+<Data>
+    <Contract>
+        <RequestHandlers>
+            <RequestHandler Classification="spectrads3" Name="com.spectralogic.s3.server.handler.reqhandler.spectrads3.bucket.CreateBucketRequestHandler">
+                <Request Action="CREATE" HttpVerb="POST" IncludeIdInPath="false" Resource="BUCKET" ResourceType="NON_SINGLETON">
+                    <OptionalQueryParams>
+                        <Param Name="DataPolicyId" Type="java.util.UUID"/>
+                        <Param Name="Id" Type="java.util.UUID"/>
+                        <Param Name="UserId" Type="java.util.UUID"/>
+                    </OptionalQueryParams>
+                    <RequiredQueryParams>
+                        <Param Name="Name" Type="java.lang.String"/>
+                    </RequiredQueryParams>
+                </Request>
+                <ResponseCodes>
+                    <ResponseCode>
+                        <Code>201</Code>
+                        <ResponseTypes>
+                            <ResponseType Type="com.spectralogic.s3.common.dao.domain.ds3.Bucket"/>
+                        </ResponseTypes>
+                    </ResponseCode>
+                    <ResponseCode>
+                        <Code>400</Code>
+                        <ResponseTypes>
+                            <ResponseType Type="com.spectralogic.s3.server.domain.HttpErrorResultApiBean"/>
+                        </ResponseTypes>
+                    </ResponseCode>
+                    <ResponseCode>
+                        <Code>403</Code>
+                        <ResponseTypes>
+                            <ResponseType Type="com.spectralogic.s3.server.domain.HttpErrorResultApiBean"/>
+                        </ResponseTypes>
+                    </ResponseCode>
+                    <ResponseCode>
+                        <Code>409</Code>
+                        <ResponseTypes>
+                            <ResponseType Type="com.spectralogic.s3.server.domain.HttpErrorResultApiBean"/>
+                        </ResponseTypes>
+                    </ResponseCode>
+                </ResponseCodes>
+                <Version>1.4751D97F3546F963C451CE9F9AE16C76</Version>
+            </RequestHandler>
+        </RequestHandlers>
+        <Types>
+            <Type Name="com.spectralogic.s3.common.dao.domain.ds3.Bucket">
+                <Elements>
+                    <Element Name="CreationDate" Type="java.util.Date">
+                        <Annotations>
+                            <Annotation Name="com.spectralogic.util.bean.lang.DefaultToCurrentDate">
+                                <AnnotationElements/>
+                            </Annotation>
+                        </Annotations>
+                    </Element>
+                    <Element Name="DataPolicyId" Type="java.util.UUID">
+                        <Annotations>
+                            <Annotation Name="com.spectralogic.util.db.lang.References">
+                                <AnnotationElements>
+                                    <AnnotationElement Name="Value" Value="com.spectralogic.s3.common.dao.domain.ds3.DataPolicy" ValueType="java.lang.Class"/>
+                                </AnnotationElements>
+                            </Annotation>
+                        </Annotations>
+                    </Element>
+                    <Element Name="Empty" Type="java.lang.Boolean">
+                        <Annotations>
+                            <Annotation Name="com.spectralogic.util.bean.lang.Optional">
+                                <AnnotationElements/>
+                            </Annotation>
+                            <Annotation Name="com.spectralogic.util.db.lang.shared.ExcludeFromDatabasePersistence">
+                                <AnnotationElements/>
+                            </Annotation>
+                            <Annotation Name="com.spectralogic.util.marshal.ExcludeFromMarshaler">
+                                <AnnotationElements>
+                                    <AnnotationElement Name="Value" Value="VALUE_IS_NULL" ValueType="com.spectralogic.util.marshal.ExcludeFromMarshaler$When"/>
+                                </AnnotationElements>
+                            </Annotation>
+                        </Annotations>
+                    </Element>
+                    <Element Name="Id" Type="java.util.UUID">
+                        <Annotations/>
+                    </Element>
+                    <Element Name="LastPreferredChunkSizeInBytes" Type="java.lang.Long">
+                        <Annotations>
+                            <Annotation Name="com.spectralogic.util.bean.lang.Optional">
+                                <AnnotationElements/>
+                            </Annotation>
+                        </Annotations>
+                    </Element>
+                    <Element Name="LogicalUsedCapacity" Type="java.lang.Long">
+                        <Annotations>
+                            <Annotation Name="com.spectralogic.util.bean.lang.Optional">
+                                <AnnotationElements/>
+                            </Annotation>
+                            <Annotation Name="com.spectralogic.util.db.lang.shared.ExcludeFromDatabasePersistence">
+                                <AnnotationElements/>
+                            </Annotation>
+                            <Annotation Name="com.spectralogic.util.marshal.ExcludeFromMarshaler">
+                                <AnnotationElements>
+                                    <AnnotationElement Name="Value" Value="VALUE_IS_NULL" ValueType="com.spectralogic.util.marshal.ExcludeFromMarshaler$When"/>
+                                </AnnotationElements>
+                            </Annotation>
+                        </Annotations>
+                    </Element>
+                    <Element Name="Name" Type="java.lang.String">
+                        <Annotations>
+                            <Annotation Name="com.spectralogic.util.bean.lang.SortBy">
+                                <AnnotationElements>
+                                    <AnnotationElement Name="Direction" Value="ASCENDING" ValueType="com.spectralogic.util.bean.lang.SortBy$Direction"/>
+                                    <AnnotationElement Name="Value" Value="1" ValueType="java.lang.Integer"/>
+                                </AnnotationElements>
+                            </Annotation>
+                            <Annotation Name="com.spectralogic.util.db.lang.MustMatchRegularExpression">
+                                <AnnotationElements>
+                                    <AnnotationElement Name="Value" Value="[A-Za-z0-9\.\-\_]{1,63}" ValueType="java.lang.String"/>
+                                </AnnotationElements>
+                            </Annotation>
+                        </Annotations>
+                    </Element>
+                    <Element Name="UserId" Type="java.util.UUID">
+                        <Annotations>
+                            <Annotation Name="com.spectralogic.util.db.lang.References">
+                                <AnnotationElements>
+                                    <AnnotationElement Name="Value" Value="com.spectralogic.s3.common.dao.domain.ds3.User" ValueType="java.lang.Class"/>
+                                </AnnotationElements>
+                            </Annotation>
+                        </Annotations>
+                    </Element>
+                </Elements>
+            </Type>
+        </Types>
+    </Contract>
+</Data>


### PR DESCRIPTION
**Changes**
- Deleting unused code
- in-lining code when utils are only called from one place
- fixed required constructor args to always take values not pointers

**Before**
```
func NewPutBucketSpectraS3Request(name *string) *PutBucketSpectraS3Request {
    return &PutBucketSpectraS3Request{
        Name: name,
    }
}
```

**After**
```
func NewPutBucketSpectraS3Request(name string) *PutBucketSpectraS3Request {
    return &PutBucketSpectraS3Request{
        Name: name,
    }
}
```