### PR TITLE
GOSDK-8: Added StringPtr function to all Go enum generation

### DIFF
--- a/ds3-autogen-go/src/main/resources/tmpls/go/type/enum_unmarshal_to_string.ftl
+++ b/ds3-autogen-go/src/main/resources/tmpls/go/type/enum_unmarshal_to_string.ftl
@@ -22,3 +22,11 @@ func (${name?uncap_first} ${name}) String() string {
             return ""
     }
 }
+
+func (${name?uncap_first} ${name}) StringPtr() *string {
+    if ${name?uncap_first} == UNDEFINED {
+        return nil
+    }
+    result := ${name?uncap_first}.String()
+    return &result
+}

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTypeTests.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTypeTests.java
@@ -71,6 +71,9 @@ public class GoFunctionalTypeTests {
         assertTrue(typeCode.contains("case DATABASE_PHYSICAL_SPACE_STATE_NEAR_LOW: return \"NEAR_LOW\""));
         assertTrue(typeCode.contains("case DATABASE_PHYSICAL_SPACE_STATE_NORMAL: return \"NORMAL\""));
 
+        // Verify conversion to string pointer
+        assertTrue(typeCode.contains("func (databasePhysicalSpaceState DatabasePhysicalSpaceState) StringPtr() *string {"));
+
         // Verify type parser file was not generated for enum type
         final String typeParserCode = codeGenerator.getTypeParserCode();
         CODE_LOGGER.logFile(typeParserCode, FileTypeToLog.MODEL_PARSERS);
@@ -112,6 +115,9 @@ public class GoFunctionalTypeTests {
         assertTrue(typeCode.contains("case CHECKSUM_TYPE_MD5: return \"MD5\""));
         assertTrue(typeCode.contains("case CHECKSUM_TYPE_SHA_256: return \"SHA_256\""));
         assertTrue(typeCode.contains("case CHECKSUM_TYPE_SHA_512: return \"SHA_512\""));
+
+        // Verify conversion to string pointer
+        assertTrue(typeCode.contains("func (checksumType ChecksumType) StringPtr() *string {"));
 
         // Verify type parser file was not generated for enum type
         final String typeParserCode = codeGenerator.getTypeParserCode();


### PR DESCRIPTION
**Changes**
Added function `StringPtr` to all Go enums which converts an enum into a string pointer. If the enum is undefined, then a null is returned by the function. This is used to unmarshal optional enums.

**Example Code**
```
package models

import (
    "errors"
    "fmt"
    "bytes"
    "log"
)

type SystemFailureType Enum

const (
    SYSTEM_FAILURE_TYPE_RECONCILE_TAPE_ENVIRONMENT_FAILED SystemFailureType = 1 + iota
    SYSTEM_FAILURE_TYPE_RECONCILE_POOL_ENVIRONMENT_FAILED SystemFailureType = 1 + iota
    SYSTEM_FAILURE_TYPE_CRITICAL_DATA_VERIFICATION_ERROR_REQUIRES_USER_CONFIRMATION SystemFailureType = 1 + iota
    SYSTEM_FAILURE_TYPE_MICROSOFT_AZURE_WRITES_REQUIRE_FEATURE_LICENSE SystemFailureType = 1 + iota
    SYSTEM_FAILURE_TYPE_AWS_S3_WRITES_REQUIRE_FEATURE_LICENSE SystemFailureType = 1 + iota
    SYSTEM_FAILURE_TYPE_DATABASE_RUNNING_OUT_OF_SPACE SystemFailureType = 1 + iota
)

func (systemFailureType *SystemFailureType) UnmarshalText(text []byte) error {
    var str string = string(bytes.ToUpper(text))
    switch str {
        case "": *systemFailureType = UNDEFINED
        case "RECONCILE_TAPE_ENVIRONMENT_FAILED": *systemFailureType = SYSTEM_FAILURE_TYPE_RECONCILE_TAPE_ENVIRONMENT_FAILED
        case "RECONCILE_POOL_ENVIRONMENT_FAILED": *systemFailureType = SYSTEM_FAILURE_TYPE_RECONCILE_POOL_ENVIRONMENT_FAILED
        case "CRITICAL_DATA_VERIFICATION_ERROR_REQUIRES_USER_CONFIRMATION": *systemFailureType = SYSTEM_FAILURE_TYPE_CRITICAL_DATA_VERIFICATION_ERROR_REQUIRES_USER_CONFIRMATION
        case "MICROSOFT_AZURE_WRITES_REQUIRE_FEATURE_LICENSE": *systemFailureType = SYSTEM_FAILURE_TYPE_MICROSOFT_AZURE_WRITES_REQUIRE_FEATURE_LICENSE
        case "AWS_S3_WRITES_REQUIRE_FEATURE_LICENSE": *systemFailureType = SYSTEM_FAILURE_TYPE_AWS_S3_WRITES_REQUIRE_FEATURE_LICENSE
        case "DATABASE_RUNNING_OUT_OF_SPACE": *systemFailureType = SYSTEM_FAILURE_TYPE_DATABASE_RUNNING_OUT_OF_SPACE
        default:
            *systemFailureType = UNDEFINED
            return errors.New(fmt.Sprintf("Cannot marshal '%s' into SystemFailureType", str))
    }
    return nil
}

func (systemFailureType SystemFailureType) String() string {
    switch systemFailureType {
        case SYSTEM_FAILURE_TYPE_RECONCILE_TAPE_ENVIRONMENT_FAILED: return "RECONCILE_TAPE_ENVIRONMENT_FAILED"
        case SYSTEM_FAILURE_TYPE_RECONCILE_POOL_ENVIRONMENT_FAILED: return "RECONCILE_POOL_ENVIRONMENT_FAILED"
        case SYSTEM_FAILURE_TYPE_CRITICAL_DATA_VERIFICATION_ERROR_REQUIRES_USER_CONFIRMATION: return "CRITICAL_DATA_VERIFICATION_ERROR_REQUIRES_USER_CONFIRMATION"
        case SYSTEM_FAILURE_TYPE_MICROSOFT_AZURE_WRITES_REQUIRE_FEATURE_LICENSE: return "MICROSOFT_AZURE_WRITES_REQUIRE_FEATURE_LICENSE"
        case SYSTEM_FAILURE_TYPE_AWS_S3_WRITES_REQUIRE_FEATURE_LICENSE: return "AWS_S3_WRITES_REQUIRE_FEATURE_LICENSE"
        case SYSTEM_FAILURE_TYPE_DATABASE_RUNNING_OUT_OF_SPACE: return "DATABASE_RUNNING_OUT_OF_SPACE"
        default:
            log.Printf("Error: invalid SystemFailureType represented by '%d'", systemFailureType)
            return ""
    }
}

func (systemFailureType SystemFailureType) StringPtr() *string {
    if systemFailureType == UNDEFINED {
        return nil
    }
    result := systemFailureType.String()
    return &result
}
```