### PR TITLE
Fixed bug in Go response generation for Get Object on 206 response code

### DIFF
--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/response/GetObjectResponseGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/response/GetObjectResponseGenerator.kt
@@ -43,7 +43,7 @@ class GetObjectResponseGenerator : BaseResponseGenerator() {
      * code for parsing the specified response.
      */
     override fun toResponseCode(ds3ResponseCode: Ds3ResponseCode, responseName: String): ResponseCode {
-        if (ds3ResponseCode.code == 200) {
+        if (ds3ResponseCode.code == 200 || ds3ResponseCode.code == 206) {
             return ResponseCode(ds3ResponseCode.code, "return &$responseName{ Content: webResponse.Body(), Headers: webResponse.Header() }, nil")
         }
         return toStandardResponseCode(ds3ResponseCode, responseName)

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTests.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTests.java
@@ -36,7 +36,7 @@ import static org.mockito.Mockito.mock;
 public class GoFunctionalTests {
 
     private final static Logger LOG = LoggerFactory.getLogger(GoFunctionalTests.class);
-    private final static GeneratedCodeLogger CODE_LOGGER = new GeneratedCodeLogger(FileTypeToLog.REQUEST, LOG);
+    private final static GeneratedCodeLogger CODE_LOGGER = new GeneratedCodeLogger(FileTypeToLog.RESPONSE, LOG);
 
     @Test
     public void simpleRequestNoPayload() throws IOException, TemplateModelException {
@@ -571,7 +571,7 @@ public class GoFunctionalTests {
         assertTrue(responseCode.contains("func NewGetObjectResponse(webResponse WebResponse) (*GetObjectResponse, error) {"));
         assertTrue(responseCode.contains("expectedStatusCodes := []int { 200, 206 }"));
         assertTrue(responseCode.contains("return &GetObjectResponse{ Content: webResponse.Body(), Headers: webResponse.Header() }, nil"));
-        assertTrue(responseCode.contains("return &GetObjectResponse{Headers: webResponse.Header()}, nil"));
+        assertFalse(responseCode.contains("return &GetObjectResponse{Headers: webResponse.Header()}, nil"));
 
         assertFalse(responseCode.contains("parse(webResponse WebResponse)"));
 

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/response/GetObjectResponseGenerator_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/response/GetObjectResponseGenerator_Test.java
@@ -45,7 +45,7 @@ public class GetObjectResponseGenerator_Test {
 
     @Test
     public void toResponseCode_206_Test() {
-        final ResponseCode expected = new ResponseCode(206, "return &GetObjectResponse{Headers: webResponse.Header()}, nil");
+        final ResponseCode expected = new ResponseCode(206, "return &GetObjectResponse{ Content: webResponse.Body(), Headers: webResponse.Header() }, nil");
 
         final Ds3ResponseCode code = new Ds3ResponseCode(206,
                 ImmutableList.of(new Ds3ResponseType("null", null)));


### PR DESCRIPTION
**Changes**
Updated generation of Get Object response to properly retrieve content on partial object gets.

Generated code was merged to the Go SDK in PR https://github.com/SpectraLogic/ds3_go_sdk/pull/47