### PR TITLE
GOSDK-12: Updating Go Get Object to allow multiple ranges to be specified

### DIFF
--- a/ds3-autogen-go/src/main/resources/tmpls/go/request/get_object_request.ftl
+++ b/ds3-autogen-go/src/main/resources/tmpls/go/request/get_object_request.ftl
@@ -2,17 +2,23 @@
 
 import (
     "fmt"
+    "strings"
 )
 
-type rangeHeader struct {
-    start, end int
+type Range struct {
+    Start int64
+    End int64
 }
 
 <#include "request_body.ftl" />
 
 <#include "with_checksum.ftl" />
 
-func (${name?uncap_first} *${name}) WithRange(start, end int) *${name} {
-    ${name?uncap_first}.Metadata["Range"] = fmt.Sprintf("bytes=%d-%d", start, end)
+func (${name?uncap_first} *${name}) WithRanges(ranges ...Range) *${name} {
+    var rangeElements []string
+    for _, cur := range ranges {
+        rangeElements = append(rangeElements, fmt.Sprintf("%d-%d", cur.Start, cur.End))
+    }
+    ${name?uncap_first}.Metadata["Range"] = fmt.Sprintf("bytes=%s", strings.Join(rangeElements[:], ","))
     return ${name?uncap_first}
 }

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTests.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTests.java
@@ -36,7 +36,7 @@ import static org.mockito.Mockito.mock;
 public class GoFunctionalTests {
 
     private final static Logger LOG = LoggerFactory.getLogger(GoFunctionalTests.class);
-    private final static GeneratedCodeLogger CODE_LOGGER = new GeneratedCodeLogger(FileTypeToLog.RESPONSE, LOG);
+    private final static GeneratedCodeLogger CODE_LOGGER = new GeneratedCodeLogger(FileTypeToLog.REQUEST, LOG);
 
     @Test
     public void simpleRequestNoPayload() throws IOException, TemplateModelException {
@@ -524,6 +524,7 @@ public class GoFunctionalTests {
 
         // test request imports
         assertTrue(requestCode.contains("\"fmt\""));
+        assertTrue(requestCode.contains("\"strings\""));
         assertFalse(requestCode.contains("\"ds3/networking\""));
 
         // test request struct
@@ -534,7 +535,7 @@ public class GoFunctionalTests {
         assertTrue(requestCode.contains("Offset *int64"));
         assertTrue(requestCode.contains("Metadata map[string]string"));
 
-        assertTrue(requestCode.contains("type rangeHeader struct {"));
+        assertTrue(requestCode.contains("type Range struct {"));
 
         // test constructor and with-constructors
         assertTrue(requestCode.contains("func NewGetObjectRequest(bucketName string, objectName string) *GetObjectRequest {"));
@@ -543,8 +544,10 @@ public class GoFunctionalTests {
         assertTrue(requestCode.contains("Checksum: NewNoneChecksum(),"));
         assertTrue(requestCode.contains("Metadata: make(map[string]string)"));
 
-        assertTrue(requestCode.contains("func (getObjectRequest *GetObjectRequest) WithRange(start, end int) *GetObjectRequest {"));
-        assertTrue(requestCode.contains("getObjectRequest.Metadata[\"Range\"] = fmt.Sprintf(\"bytes=%d-%d\", start, end)"));
+        assertTrue(requestCode.contains("func (getObjectRequest *GetObjectRequest) WithRanges(ranges ...Range) *GetObjectRequest {"));
+        assertTrue(requestCode.contains("getObjectRequest.Metadata[\"Range\"] = fmt.Sprintf(\"bytes=%s\", strings.Join(rangeElements[:], \",\"))"));
+        assertFalse(requestCode.contains("func (getObjectRequest *GetObjectRequest) WithRange(start, end int) *GetObjectRequest {"));
+        assertFalse(requestCode.contains("getObjectRequest.Metadata[\"Range\"] = fmt.Sprintf(\"bytes=%d-%d\", start, end)"));
 
         assertTrue(requestCode.contains("func (getObjectRequest *GetObjectRequest) WithChecksum(contentHash string, checksumType ChecksumType) *GetObjectRequest {"));
         assertTrue(requestCode.contains("getObjectRequest.Checksum.ContentHash = contentHash"));


### PR DESCRIPTION
Updates Go Get Object request to allow the setting of multiple ranges.

Generated code was merged into the Go SDK in PR: https://github.com/SpectraLogic/ds3_go_sdk/pull/49