### PR TITLE
SA-218: Removing generation of superfluous imports in Java models

### DIFF
--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/typemodels/ChecksumTypeGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/typemodels/ChecksumTypeGenerator.java
@@ -16,6 +16,7 @@
 package com.spectralogic.ds3autogen.java.generators.typemodels;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3EnumConstant;
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3Type;
 import com.spectralogic.ds3autogen.java.models.EnumConstant;
@@ -28,8 +29,8 @@ public class ChecksumTypeGenerator extends BaseTypeGenerator {
      * Returns an empty list as the ChecksumType does not have any imports
      */
     @Override
-    public ImmutableList<String> getAllImports(final Ds3Type ds3Type) {
-        return ImmutableList.of();
+    public ImmutableSet<String> getAllImports(final Ds3Type ds3Type) {
+        return ImmutableSet.of();
     }
 
     /**

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/typemodels/CommonPrefixGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/typemodels/CommonPrefixGenerator.java
@@ -16,6 +16,7 @@
 package com.spectralogic.ds3autogen.java.generators.typemodels;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3Element;
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3Type;
 import com.spectralogic.ds3autogen.java.models.Element;
@@ -65,13 +66,13 @@ public class CommonPrefixGenerator extends BaseTypeGenerator {
      * generate the java model code, including importing for common prefix
      */
     @Override
-    public ImmutableList<String> getAllImports(final Ds3Type ds3Type) {
+    public ImmutableSet<String> getAllImports(final Ds3Type ds3Type) {
         //If this is an enum, then there are no imports
         if (hasContent(ds3Type.getEnumConstants())) {
-            return ImmutableList.of();
+            return ImmutableSet.of();
         }
-        final ImmutableList.Builder<String> builder = ImmutableList.builder();
-        builder.addAll(getImportsFromDs3Elements(ds3Type.getElements()));
+        final ImmutableSet.Builder<String> builder = ImmutableSet.builder();
+        builder.addAll(getImportsFromAllDs3Elements(ds3Type.getElements()));
         builder.add("com.spectralogic.ds3client.models.common.CommonPrefixes");
         return builder.build();
     }

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/typemodels/TypeGeneratorUtil.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/typemodels/TypeGeneratorUtil.java
@@ -16,6 +16,7 @@
 package com.spectralogic.ds3autogen.java.generators.typemodels;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3Element;
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3EnumConstant;
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3Type;
@@ -49,5 +50,5 @@ public interface TypeGeneratorUtil {
      * Gets all the required imports that the Model will need in order to properly
      * generate the java model code
      */
-    ImmutableList<String> getAllImports(final Ds3Type ds3Type);
+    ImmutableSet<String> getAllImports(final Ds3Type ds3Type);
 }

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/Model.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/models/Model.java
@@ -16,6 +16,7 @@
 package com.spectralogic.ds3autogen.java.models;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 public class Model {
 
@@ -24,14 +25,14 @@ public class Model {
     private final String nameToMarshal;
     private final ImmutableList<Element> elements;
     private final ImmutableList<EnumConstant> enumConstants;
-    private final ImmutableList<String> imports;
+    private final ImmutableSet<String> imports;
 
     public Model(final String packageName,
                  final String name,
                  final String nameToMarshal,
                  final ImmutableList<Element> elements,
                  final ImmutableList<EnumConstant> enumConstants,
-                 final ImmutableList<String> imports) {
+                 final ImmutableSet<String> imports) {
         this.packageName = packageName;
         this.name = name;
         this.nameToMarshal = nameToMarshal;
@@ -52,7 +53,7 @@ public class Model {
         return elements;
     }
 
-    public ImmutableList<String> getImports() {
+    public ImmutableSet<String> getImports() {
         return imports;
     }
 

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/typemodels/BaseTypeGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/typemodels/BaseTypeGenerator_Test.java
@@ -16,6 +16,7 @@
 package com.spectralogic.ds3autogen.java.generators.typemodels;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3Element;
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3EnumConstant;
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3Type;
@@ -100,13 +101,13 @@ public class BaseTypeGenerator_Test {
 
     @Test
     public void getImportsFromDs3Elements_NullList_Test() {
-        final ImmutableList<String> result = getImportsFromDs3Elements(null);
+        final ImmutableSet<String> result = getImportsFromAllDs3Elements(null);
         assertThat(result.size(), is(0));
     }
 
     @Test
     public void getImportsFromDs3Elements_EmptyList_Test() {
-        final ImmutableList<String> result = getImportsFromDs3Elements(ImmutableList.of());
+        final ImmutableSet<String> result = getImportsFromAllDs3Elements(ImmutableList.of());
         assertThat(result.size(), is(0));
     }
 
@@ -115,9 +116,14 @@ public class BaseTypeGenerator_Test {
         final ImmutableList<Ds3Element> ds3Elements = ImmutableList.of(
                 new Ds3Element("Name1", "com.spectralogic.test.Type1", "ComponentType1", false),
                 new Ds3Element("Name2", "Type2", "com.spectralogic.test.ComponentType2", false),
-                new Ds3Element("Name3", "Type3", null, false));
+                new Ds3Element("Name3", "Type3", null, false),
+                new Ds3Element("Name4", "java.lang.String", null, false),
+                new Ds3Element("Name5", "java.lang.Double", null, true),
+                new Ds3Element("Name6", "java.lang.Long", null, false),
+                new Ds3Element("Name7", "java.lang.Integer", null, true),
+                new Ds3Element("Name4", "Type4", "java.lang.String", false));
 
-        final ImmutableList<String> result = getImportsFromDs3Elements(ds3Elements);
+        final ImmutableSet<String> result = getImportsFromAllDs3Elements(ds3Elements);
         assertThat(result.size(), is(3));
         assertTrue(result.contains("java.util.List"));
         assertTrue(result.contains("com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper"));
@@ -141,7 +147,7 @@ public class BaseTypeGenerator_Test {
                 ds3Elements,
                 ds3EnumConstants);
 
-        final ImmutableList<String> result = generator.getAllImports(enumType);
+        final ImmutableSet<String> result = generator.getAllImports(enumType);
         assertThat(result.size(), is(0));
     }
 
@@ -158,7 +164,7 @@ public class BaseTypeGenerator_Test {
                 ds3Elements,
                 null);
 
-        final ImmutableList<String> result = generator.getAllImports(ds3Type);
+        final ImmutableSet<String> result = generator.getAllImports(ds3Type);
         assertThat(result.size(), is(3));
         assertTrue(result.contains("java.util.List"));
         assertTrue(result.contains("java.util.ArrayList"));

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/typemodels/ChecksumTypeGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/typemodels/ChecksumTypeGenerator_Test.java
@@ -16,6 +16,7 @@
 package com.spectralogic.ds3autogen.java.generators.typemodels;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3Element;
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3EnumConstant;
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3Type;
@@ -42,7 +43,7 @@ public class ChecksumTypeGenerator_Test {
                 ds3Elements,
                 null);
 
-        final ImmutableList<String> result = generator.getAllImports(ds3Type);
+        final ImmutableSet<String> result = generator.getAllImports(ds3Type);
         assertThat(result.size(), is(0));
     }
 

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/typemodels/CommonPrefixGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/typemodels/CommonPrefixGenerator_Test.java
@@ -16,6 +16,7 @@
 package com.spectralogic.ds3autogen.java.generators.typemodels;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3Element;
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3Type;
 import com.spectralogic.ds3autogen.java.models.Element;
@@ -73,7 +74,7 @@ public class CommonPrefixGenerator_Test {
                 ds3Elements,
                 null);
 
-        final ImmutableList<String> result = generator.getAllImports(ds3Type);
+        final ImmutableSet<String> result = generator.getAllImports(ds3Type);
 
         assertThat(result.size(), is(4));
         assertThat(result, hasItem("java.util.List"));


### PR DESCRIPTION
**Changes**
- Updated imports in Java model generator from `ImmutableList` to `ImmutableSet`
- Removed imports of java objects representing primitives from model generation

This generates the code found in Java SDK PR: https://github.com/SpectraLogic/ds3_java_sdk/pull/530