### PR TITLE
SA-217: Adding type converter to parser module

### DIFF
--- a/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/NetFunctionalTests.java
+++ b/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/NetFunctionalTests.java
@@ -1205,7 +1205,7 @@ public class NetFunctionalTests {
         assertTrue(TestHelper.hasOptionalParam(requestName, "SerialNumber", "string", requestCode));
         assertTrue(TestHelper.hasOptionalParam(requestName, "State", "TapeState", requestCode));
         assertTrue(TestHelper.hasOptionalParam(requestName, "StorageDomainId", "Guid", requestCode));
-        assertTrue(TestHelper.hasOptionalParam(requestName, "Type", "TapeType", requestCode));
+        assertTrue(TestHelper.hasOptionalParam(requestName, "Type", "string", requestCode));
         assertTrue(TestHelper.hasOptionalParam(requestName, "WriteProtected", "bool", requestCode));
 
         assertTrue(TestHelper.hasConstructor(requestName, ImmutableList.of(), requestCode));

--- a/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/Ds3SpecNormalizer.java
+++ b/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/Ds3SpecNormalizer.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableList;
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3ApiSpec;
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3Request;
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3ResponseCode;
+import com.spectralogic.ds3autogen.converters.TypeConverter;
 
 import static com.spectralogic.ds3autogen.converters.NameConverter.renameRequests;
 import static com.spectralogic.ds3autogen.converters.RemoveDollarSignConverter.removeDollarSigns;
@@ -48,11 +49,15 @@ public final class Ds3SpecNormalizer {
             final Ds3ApiSpec spec,
             final boolean generateInternal) {
         verifySingleResponsePayloadRequests(spec.getRequests());
-        return updateElementsInSpec( //Updates Ds3Elements to account for ExcludeFromMarshaler values
+
+        final TypeConverter typeConverter = new TypeConverter();
+
+        return typeConverter.modifyTypes( //Converts contract types to sdk types as specified in file typeMap.json
+                updateElementsInSpec( //Updates Ds3Elements to account for ExcludeFromMarshaler values
                 renameRequests( //Rename requests from RequestHandler to Request
                 convertResponseTypes( //Converts response types with components into new encapsulating types
                 removeDollarSigns( //Converts all type names containing '$' into proper type names
-                removeInternalRequestsFromSpec(spec, generateInternal))))); //Removes/keeps spectra internal requests
+                removeInternalRequestsFromSpec(spec, generateInternal)))))); //Removes/keeps spectra internal requests
     }
 
     /**

--- a/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/models/xml/typemap/TypeMap.java
+++ b/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/models/xml/typemap/TypeMap.java
@@ -1,0 +1,36 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.models.xml.typemap;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+public class TypeMap {
+
+    @JsonProperty("TypeMap")
+    private ImmutableList<TypeMapElement> typeMap;
+
+    public ImmutableMap<String, String> toMap() {
+        final ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+        typeMap.forEach(element -> builder.put(element.getContractType(), element.getSdkType()));
+        return builder.build();
+    }
+
+    public void setTypeMap(ImmutableList<TypeMapElement> typeMap) {
+        this.typeMap = typeMap;
+    }
+}

--- a/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/models/xml/typemap/TypeMapElement.java
+++ b/ds3-autogen-parser/src/main/java/com/spectralogic/ds3autogen/models/xml/typemap/TypeMapElement.java
@@ -1,0 +1,28 @@
+package com.spectralogic.ds3autogen.models.xml.typemap;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class TypeMapElement {
+
+    @JsonProperty("ContractType")
+    private String contractType;
+
+    @JsonProperty("SdkType")
+    private String sdkType;
+
+    public String getContractType() {
+        return contractType;
+    }
+
+    public void setContractType(String contractType) {
+        this.contractType = contractType;
+    }
+
+    public String getSdkType() {
+        return sdkType;
+    }
+
+    public void setSdkType(String sdkType) {
+        this.sdkType = sdkType;
+    }
+}

--- a/ds3-autogen-parser/src/main/kotlin/com/spectralogic/ds3autogen/converters/TypeConverter.kt
+++ b/ds3-autogen-parser/src/main/kotlin/com/spectralogic/ds3autogen/converters/TypeConverter.kt
@@ -1,0 +1,133 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.converters
+
+import com.google.common.collect.ImmutableList
+import com.google.common.collect.ImmutableMap
+import com.spectralogic.ds3autogen.api.models.apispec.*
+import com.spectralogic.ds3autogen.typemap.SdkTypeMapper
+import com.spectralogic.ds3autogen.utils.ConverterUtil.isEmpty
+import com.spectralogic.ds3autogen.utils.collections.GuavaCollectors
+
+/**
+ * Modifies contract types into sdk types as specified within the Ds3ApiSpec.
+ * This affects types within request parameters, response types, and response payload elements.
+ * @param typeMapper maps contract type names to be changed into sdk types for code generation
+ */
+class TypeConverter(private val typeMapper: SdkTypeMapper) {
+    constructor(): this(SdkTypeMapper()) // Uses the default type mapper
+
+    fun modifyTypes(spec: Ds3ApiSpec): Ds3ApiSpec {
+        typeMapper.init()
+        return Ds3ApiSpec(updateDs3Requests(spec.requests), updateDs3TypeMap(spec.types))
+    }
+
+    private fun updateDs3Requests(ds3requests: ImmutableList<Ds3Request>?): ImmutableList<Ds3Request> {
+        if (isEmpty(ds3requests)) {
+            return ImmutableList.of()
+        }
+        return ds3requests!!.stream()
+                .map(this::updateDs3Request)
+                .collect(GuavaCollectors.immutableList())
+    }
+
+    private fun updateDs3Request(ds3Request: Ds3Request): Ds3Request {
+        return Ds3Request(
+                ds3Request.name,
+                ds3Request.httpVerb,
+                ds3Request.classification,
+                ds3Request.bucketRequirement,
+                ds3Request.objectRequirement,
+                ds3Request.action,
+                ds3Request.resource,
+                ds3Request.resourceType,
+                ds3Request.operation,
+                ds3Request.includeInPath,
+                updateResposneCodes(ds3Request.ds3ResponseCodes),
+                updateParams(ds3Request.optionalQueryParams),
+                updateParams(ds3Request.requiredQueryParams)
+        )
+    }
+
+    private fun updateParams(params: ImmutableList<Ds3Param>?): ImmutableList<Ds3Param> {
+        if (isEmpty(params)) {
+            return ImmutableList.of()
+        }
+
+        return params!!.stream()
+                .map { param -> Ds3Param(param.name, typeMapper.toType(param.type), param.nullable) }
+                .collect(GuavaCollectors.immutableList())
+    }
+
+    private fun updateResposneCodes(responseCodes: ImmutableList<Ds3ResponseCode>?): ImmutableList<Ds3ResponseCode> {
+        if (isEmpty(responseCodes)) {
+            return ImmutableList.of()
+        }
+
+        return responseCodes!!.stream()
+                .map { code -> Ds3ResponseCode(code.code, updateResponseTypes(code.ds3ResponseTypes)) }
+                .collect(GuavaCollectors.immutableList())
+    }
+
+    private fun updateResponseTypes(responseTypes: ImmutableList<Ds3ResponseType>?): ImmutableList<Ds3ResponseType> {
+        if (isEmpty(responseTypes)) {
+            return ImmutableList.of()
+        }
+
+        return responseTypes!!.stream()
+                .map { responseType -> Ds3ResponseType(
+                        typeMapper.toType(responseType.type),
+                        typeMapper.toNullableType(responseType.componentType),
+                        responseType.originalTypeName) }
+                .collect(GuavaCollectors.immutableList())
+    }
+
+    private fun updateDs3TypeMap(typeMap: ImmutableMap<String, Ds3Type>?): ImmutableMap<String, Ds3Type> {
+        if (isEmpty(typeMap)) {
+            return ImmutableMap.of()
+        }
+
+        val builder = ImmutableMap.builder<String, Ds3Type>()
+        typeMap!!.forEach { name, type -> builder.put(name, updateDs3Type(type)) }
+
+        return builder.build()
+    }
+
+    private fun updateDs3Type(ds3Type: Ds3Type): Ds3Type {
+        return Ds3Type(
+                ds3Type.name,
+                ds3Type.nameToMarshal,
+                updateDs3Elements(ds3Type.elements),
+                ds3Type.enumConstants
+        )
+    }
+
+    private fun updateDs3Elements(elements: ImmutableList<Ds3Element>?): ImmutableList<Ds3Element> {
+        if (isEmpty(elements)) {
+            return ImmutableList.of()
+        }
+
+        return elements!!.stream()
+                .map { element -> Ds3Element(
+                        element.name,
+                        typeMapper.toNullableType(element.type),
+                        typeMapper.toNullableType(element.componentType),
+                        element.ds3Annotations,
+                        element.nullable
+                ) }
+                .collect(GuavaCollectors.immutableList())
+    }
+}

--- a/ds3-autogen-parser/src/main/kotlin/com/spectralogic/ds3autogen/typemap/SdkTypeMapper.kt
+++ b/ds3-autogen-parser/src/main/kotlin/com/spectralogic/ds3autogen/typemap/SdkTypeMapper.kt
@@ -1,0 +1,67 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.typemap
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.guava.GuavaModule
+import com.spectralogic.ds3autogen.models.xml.typemap.TypeMap
+import com.spectralogic.ds3autogen.utils.ConverterUtil.isEmpty
+
+private const val DEFAULT_TYPE_MAP_FILE = "/typeMap.json"
+
+/**
+ * Used to map contract types into sdk types. This is used when the
+ * provided contract type is to be overridden with a manually determined type.
+ */
+class SdkTypeMapper(private val typeMapFileName: String) {
+    constructor() : this(DEFAULT_TYPE_MAP_FILE)
+
+    /** map of contract names to be changed (keys), into sdk types (values) */
+    private lateinit var typeMapper: Map<String, String>
+
+    /**
+     * Initialize the type mapper via parsing the json file containing the type re-mapping
+     */
+    fun init() {
+        val stream = SdkTypeMapper::class.java.getResourceAsStream(typeMapFileName)
+        val objectMapper = ObjectMapper()
+        objectMapper.registerModule(GuavaModule())
+        typeMapper = objectMapper.readValue<TypeMap>(stream, TypeMap::class.java).toMap()
+    }
+
+    /**
+     * Returns the sdk type to be generated from the contract type. If there is no type
+     * mapping, then the original string is returned.
+     */
+    fun toType(contractType: String): String {
+        val curType = contractType.substringAfterLast('.')
+        return if (typeMapper.containsKey(curType)) typeMapper[curType]!! else contractType
+    }
+
+    fun toNullableType(contractType: String?): String? {
+        if (isEmpty(contractType)) {
+            return contractType
+        }
+        return toType(contractType!!)
+    }
+
+    /**
+     * Retrieves the underlying map used in the re-typing process. This is used for testing.
+     */
+    fun getMap(): Map<String, String> {
+        return typeMapper
+    }
+}

--- a/ds3-autogen-parser/src/main/kotlin/com/spectralogic/ds3autogen/typemap/SdkTypeMapper.kt
+++ b/ds3-autogen-parser/src/main/kotlin/com/spectralogic/ds3autogen/typemap/SdkTypeMapper.kt
@@ -61,7 +61,5 @@ class SdkTypeMapper(private val typeMapFileName: String) {
     /**
      * Retrieves the underlying map used in the re-typing process. This is used for testing.
      */
-    fun getMap(): Map<String, String> {
-        return typeMapper
-    }
+    fun getMap(): Map<String, String> = typeMapper
 }

--- a/ds3-autogen-parser/src/main/resources/typeMap.json
+++ b/ds3-autogen-parser/src/main/resources/typeMap.json
@@ -1,0 +1,8 @@
+{
+  "TypeMap": [
+    {
+      "ContractType": "TapeType",
+      "SdkType": "java.lang.String"
+    }
+  ]
+}

--- a/ds3-autogen-parser/src/test/kotlin/com/spectralogic/ds3autogen/converters/TypeConverterTest.kt
+++ b/ds3-autogen-parser/src/test/kotlin/com/spectralogic/ds3autogen/converters/TypeConverterTest.kt
@@ -1,0 +1,99 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.converters
+
+import com.google.common.collect.ImmutableList
+import com.google.common.collect.ImmutableMap
+import com.spectralogic.ds3autogen.api.models.apispec.*
+import com.spectralogic.ds3autogen.api.models.enums.*
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.entry
+import org.junit.Test
+
+class TypeConverterTest {
+
+    @Test
+    fun modifyTypesTest() {
+        val request = Ds3Request(
+                "com.test.TestRequest",
+                HttpVerb.PUT,
+                Classification.spectrads3,
+                null,
+                null,
+                Action.BULK_MODIFY,
+                Resource.TAPE,
+                ResourceType.NON_SINGLETON,
+                Operation.EJECT,
+                false,
+                ImmutableList.of(
+                        Ds3ResponseCode(200,
+                                ImmutableList.of(Ds3ResponseType("com.test.TapeType", null)))),
+                ImmutableList.of(
+                        Ds3Param("TapeType", "com.test.TapeType", true),
+                        Ds3Param("EjectLocation", "java.lang.String", true)),
+                ImmutableList.of(
+                    Ds3Param("Blobs", "void", false),
+                    Ds3Param("TapeType", "com.test.TapeType", false)))
+
+        val type = Ds3Type(
+                "com.test.TestType",
+                ImmutableList.of(
+                        Ds3Element("TapeTypeElement", "com.test.TapeType", null, false),
+                        Ds3Element("TapeTypeArray", "array", "com.test.TapeType", false),
+                        Ds3Element("IntElement", "int", null, false)
+                )
+        )
+
+        val spec = Ds3ApiSpec(ImmutableList.of(request), ImmutableMap.of(type.name, type))
+
+        val converter = TypeConverter()
+
+        val result = converter.modifyTypes(spec)
+
+        assertThat(result.requests).containsExactly(
+                Ds3Request(
+                        "com.test.TestRequest",
+                        HttpVerb.PUT,
+                        Classification.spectrads3,
+                        null,
+                        null,
+                        Action.BULK_MODIFY,
+                        Resource.TAPE,
+                        ResourceType.NON_SINGLETON,
+                        Operation.EJECT,
+                        false,
+                        ImmutableList.of(
+                                Ds3ResponseCode(200,
+                                        ImmutableList.of(Ds3ResponseType("java.lang.String", null)))),
+                        ImmutableList.of(
+                                Ds3Param("TapeType", "java.lang.String", true),
+                                Ds3Param("EjectLocation", "java.lang.String", true)),
+                        ImmutableList.of(
+                                Ds3Param("Blobs", "void", false),
+                                Ds3Param("TapeType", "java.lang.String", false)))
+        )
+
+        assertThat(result.types).containsExactly(
+                entry(type.name, Ds3Type(
+                        "com.test.TestType",
+                        ImmutableList.of(
+                                Ds3Element("TapeTypeElement", "java.lang.String", null, false),
+                                Ds3Element("TapeTypeArray", "array", "java.lang.String", false),
+                                Ds3Element("IntElement", "int", null, false)
+                        )))
+        )
+    }
+}

--- a/ds3-autogen-parser/src/test/kotlin/com/spectralogic/ds3autogen/typemap/SdkTypeMapperTest.kt
+++ b/ds3-autogen-parser/src/test/kotlin/com/spectralogic/ds3autogen/typemap/SdkTypeMapperTest.kt
@@ -1,0 +1,59 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.typemap
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.entry
+import org.junit.Test
+
+class SdkTypeMapperTest {
+
+    @Test
+    fun userSpecifiedTypeMapTest() {
+        val mapper = SdkTypeMapper("/testTypeMap.json")
+        mapper.init()
+
+        // verify entries were parsed correctly
+        assertThat(mapper.getMap()).containsOnly(
+                entry("ContractType1", "SdkType1"),
+                entry("ContractType2", "SdkType2"),
+                entry("ContractType3", "SdkType3"))
+
+        // verify paths are properly handled
+        assertThat(mapper.toType("com.test.ContractType1")).isEqualTo("SdkType1")
+
+        // verify non-mapped entries are not modified
+        assertThat(mapper.toType("NonMappedType")).isEqualTo("NonMappedType")
+        assertThat(mapper.toType("com.test.NonMappedType")).isEqualTo("com.test.NonMappedType")
+    }
+
+    @Test
+    fun defaultTypeMapTest() {
+        val mapper = SdkTypeMapper()
+        mapper.init()
+
+        // verify entries were parsed correctly
+        assertThat(mapper.getMap()).containsOnly(
+                entry("TapeType", "java.lang.String"))
+
+        // verify paths are properly handled
+        assertThat(mapper.toType("com.test.TapeType")).isEqualTo("java.lang.String")
+
+        // verify non-mapped entries are not modified
+        assertThat(mapper.toType("NonMappedType")).isEqualTo("NonMappedType")
+        assertThat(mapper.toType("com.test.NonMappedType")).isEqualTo("com.test.NonMappedType")
+    }
+}

--- a/ds3-autogen-parser/src/test/resources/testTypeMap.json
+++ b/ds3-autogen-parser/src/test/resources/testTypeMap.json
@@ -1,0 +1,16 @@
+{
+  "TypeMap": [
+    {
+      "ContractType": "ContractType1",
+      "SdkType": "SdkType1"
+    },
+    {
+      "ContractType": "ContractType2",
+      "SdkType": "SdkType2"
+    },
+    {
+      "ContractType": "ContractType3",
+      "SdkType": "SdkType3"
+    }
+  ]
+}


### PR DESCRIPTION
**Changes**
Added type converting to parsing module in autogen so that specified types can be modified across all SDKs consistently. Types to be changed are specified within a json file.  Created default type mapping file which contains TapeType -> String