### PR TITLE
SA-217: Fixed minor bug in generation of Go parsing code

### DIFF
--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/parser/BaseTypeParserGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/parser/BaseTypeParserGenerator.kt
@@ -92,6 +92,11 @@ open class BaseTypeParserGenerator : TypeParserModelGenerator<TypeParser>, TypeP
         if (ds3Element.type.equals("array")) {
             val childType = toGoType(ds3Element.componentType!!)
 
+            // Handle if the slice is a string
+            if (childType == "string") {
+                return ParseChildNodeAddStringToSlice(xmlTag, modelName, paramName)
+            }
+
             // Handle if the slice is a Ds3Type defined enum
             if (isElementEnum(ds3Element.componentType!!, typeMap)) {
                 return ParseChildNodeAddEnumToSlice(xmlTag, modelName, paramName, childType)

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/models/parser/ParseChildNodeImpls.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/models/parser/ParseChildNodeImpls.kt
@@ -114,6 +114,23 @@ data class ParseChildNodeAddEnumToSlice(
 }
 
 /**
+ * Creates the Go code for parsing a single child node as a string and adding it to a
+ * slice. This is used when there are multiple child nodes of type string with no
+ * encapsulating xml tag.
+ */
+data class ParseChildNodeAddStringToSlice(
+        override val xmlTag: String,
+        val modelName: String,
+        val paramName: String) : ParseElement {
+
+    override val parsingCode: String
+        get() {
+            return "var str = parseString(child.Content)\n" +
+                    goIndent(3) + "$modelName.$paramName = append($modelName.$paramName, str)"
+        }
+}
+
+/**
  * Creates the Go code for parsing a single child node and adding it to a slice. This
  * is used when there are multiple child nodes of the same type with no encapsulating
  * xml tag.

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/parser/BaseTypeParserGenerator_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/parser/BaseTypeParserGenerator_Test.java
@@ -191,7 +191,8 @@ public class BaseTypeParserGenerator_Test {
                 DS3_TYPE_ELEMENT,
                 LIST_ENUM_ELEMENT,
                 COMMON_PREFIX_ELEMENT,
-                DS3_PTR_TYPE_ELEMENT);
+                DS3_PTR_TYPE_ELEMENT,
+                LIST_STRING_ELEMENT);
 
         final String modelName = "modelName";
 
@@ -206,7 +207,8 @@ public class BaseTypeParserGenerator_Test {
                 new ParseChildNodeAsDs3Type(DS3_TYPE_ELEMENT.getName(), modelName, DS3_TYPE_ELEMENT.getName()),
                 new ParseChildNodeAddEnumToSlice(LIST_ENUM_ELEMENT.getName(), modelName, LIST_ENUM_ELEMENT.getName(), removePath(LIST_ENUM_ELEMENT.getComponentType())),
                 new ParseChildNodeAsCommonPrefix(modelName, "CommonPrefixes"),
-                new ParseChildNodeAsNullableDs3Type(DS3_PTR_TYPE_ELEMENT.getName(), modelName, DS3_PTR_TYPE_ELEMENT.getName(), removePath(DS3_PTR_TYPE_ELEMENT.getType())));
+                new ParseChildNodeAsNullableDs3Type(DS3_PTR_TYPE_ELEMENT.getName(), modelName, DS3_PTR_TYPE_ELEMENT.getName(), removePath(DS3_PTR_TYPE_ELEMENT.getType())),
+                new ParseChildNodeAddStringToSlice(LIST_STRING_ELEMENT.getName(), modelName, LIST_STRING_ELEMENT.getName()));
 
         final ImmutableMap<String, Ds3Type> typeMape = ImmutableMap.of(
                 ENUM_ELEMENT.getType(), new Ds3Type(ENUM_ELEMENT.getType(), "", ImmutableList.of(), ImmutableList.of(ENUM_CONSTANT)));

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/models/parser/ParseChildNodeImpls_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/models/parser/ParseChildNodeImpls_Test.java
@@ -89,6 +89,16 @@ public class ParseChildNodeImpls_Test {
     }
 
     @Test
+    public void ParseChildNodeAddStringToSliceTest() {
+        final String expected = String.format("var str = parseString(child.Content)\n" +
+                "            %s.%s = append(%s.%s, str)", MODEL_NAME, PARAM_NAME, MODEL_NAME, PARAM_NAME);
+
+        final ParseElement parseElement = new ParseChildNodeAddStringToSlice(XML_TAG, MODEL_NAME, PARAM_NAME);
+        assertThat(parseElement.getXmlTag(), is(XML_TAG));
+        assertThat(parseElement.getParsingCode(), is(expected));
+    }
+
+    @Test
     public void ParseChildNodeAsEnumTest() {
         final String expected = String.format("parseEnum(child.Content, &%s.%s, aggErr)", MODEL_NAME, PARAM_NAME);
 

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/utils/GoModelFixturesUtil.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/utils/GoModelFixturesUtil.java
@@ -59,6 +59,7 @@ public class GoModelFixturesUtil {
     public final static Ds3Element DS3_PTR_TYPE_ELEMENT = new Ds3Element("Ds3TypePtrElement", "com.test.TestDs3PtrType", "", true);
     public final static Ds3Element LIST_ENUM_ELEMENT = new Ds3Element("ListEnumElement", "array", "com.test.TestEnum", false);
     public final static Ds3Element COMMON_PREFIX_ELEMENT = new Ds3Element("CommonPrefixes", "array", "java.lang.String", ImmutableList.of(COMMON_PREFIX_ANNOTATION), false);
+    public final static Ds3Element LIST_STRING_ELEMENT = new Ds3Element("ListStringElement", "array", "java.lang.String", false);
 
     public final static Ds3Element STR_ATTR = new Ds3Element("StringAttribute", "java.lang.String", "", ImmutableList.of(ATTR_ANNOTATION), false);
     public final static Ds3Element STR_PTR_ATTR = new Ds3Element("StringPtrAttribute", "java.lang.String", "", ImmutableList.of(ATTR_ANNOTATION), true);


### PR DESCRIPTION
Found minor bug in generation of Go parsing code for change related to TapeType -> String.  This exposed an issue when parsing a response payload that contain a list of tags (content of type string) that are not encapsulated in a tag.  This fixes the parsing code to properly handle this scenario.

Generated code: https://github.com/SpectraLogic/ds3_go_sdk/pull/50