### PR TITLE
PYTHONSDK-80: Fixed python response handlers with string response payloads

### DIFF
--- a/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/generators/response/BaseResponseGenerator.java
+++ b/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/generators/response/BaseResponseGenerator.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
 
 import static com.spectralogic.ds3autogen.python.utils.GeneratorUtils.getParserModelName;
 import static com.spectralogic.ds3autogen.utils.ConverterUtil.isEmpty;
+import static com.spectralogic.ds3autogen.utils.NormalizingContractNamesUtil.removePath;
 import static com.spectralogic.ds3autogen.utils.NormalizingContractNamesUtil.toResponseName;
 import static com.spectralogic.ds3autogen.utils.ResponsePayloadUtil.*;
 
@@ -89,6 +90,10 @@ public class BaseResponseGenerator implements ResponseModelGenerator<BaseRespons
         }
         final String responsePayload = getResponsePayload(ds3Request.getDs3ResponseCodes());
         final Integer responseCode = getPayloadResponseCode(ds3Request.getDs3ResponseCodes());
+
+        if (removePath(responsePayload).equalsIgnoreCase("String")) {
+            return new StringParsePayload(responseCode);
+        }
         return new BaseParsePayload(getParserModelName(responsePayload), responseCode);
     }
 

--- a/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/model/response/StringParsePayload.java
+++ b/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/model/response/StringParsePayload.java
@@ -1,0 +1,20 @@
+package com.spectralogic.ds3autogen.python.model.response;
+
+import static com.spectralogic.ds3autogen.python.helpers.PythonHelper.pythonIndent;
+
+public class StringParsePayload implements ParsePayload {
+    private final Integer code;
+
+    public StringParsePayload(final int code) {
+        this.code = code;
+    }
+
+    @Override
+    public String toPythonCode() {
+        final StringBuilder builder = new StringBuilder();
+        builder.append("if self.response.status == ").append(code).append(":\n")
+                .append(pythonIndent(3))
+                .append("self.result = response.read()");
+        return builder.toString();
+    }
+}

--- a/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/model/response/StringParsePayload.java
+++ b/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/model/response/StringParsePayload.java
@@ -11,8 +11,8 @@ public class StringParsePayload implements ParsePayload {
 
     @Override
     public String toPythonCode() {
-        final StringBuilder builder = new StringBuilder();
-        builder.append("if self.response.status == ").append(code).append(":\n")
+        final StringBuilder builder = new StringBuilder("if self.response.status == ");
+        builder.append(code).append(":\n")
                 .append(pythonIndent(3))
                 .append("self.result = response.read()");
         return builder.toString();

--- a/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/generators/response/BaseResponseGenerator_Test.java
+++ b/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/generators/response/BaseResponseGenerator_Test.java
@@ -22,12 +22,11 @@ import com.spectralogic.ds3autogen.api.models.apispec.Ds3Request;
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3Type;
 import com.spectralogic.ds3autogen.python.model.response.BaseParsePayload;
 import com.spectralogic.ds3autogen.python.model.response.NoPayload;
+import com.spectralogic.ds3autogen.python.model.response.StringParsePayload;
 import org.junit.Test;
 
 import static com.spectralogic.ds3autogen.python.generators.response.BaseResponseGenerator.*;
-import static com.spectralogic.ds3autogen.testutil.Ds3ModelFixtures.getBucketRequest;
-import static com.spectralogic.ds3autogen.testutil.Ds3ModelFixtures.getRequestAmazonS3GetObject;
-import static com.spectralogic.ds3autogen.testutil.Ds3ModelFixtures.getRequestGetJob;
+import static com.spectralogic.ds3autogen.testutil.Ds3ModelFixtures.*;
 import static com.spectralogic.ds3autogen.testutil.Ds3ModelPartialDataFixture.createDs3RequestTestData;
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.assertThat;
@@ -87,6 +86,12 @@ public class BaseResponseGenerator_Test {
     }
 
     @Test
+    public void getParsePayload_TypeString_Test() {
+        final Ds3Request request = getGetBlobPersistence();
+        assertThat(getParsePayload(request), instanceOf(StringParsePayload.class));
+    }
+
+    @Test
     public void toParseResponsePayload_NoPayload_Test() {
         final Ds3Request request = createDs3RequestTestData("com.test.Request", Classification.amazons3);
         assertThat(generator.toParseResponsePayload(request), is(""));
@@ -107,6 +112,15 @@ public class BaseResponseGenerator_Test {
                 "            self.result = parseModel(xmldom.fromstring(response.read()), JobWithChunksApiBean())";
 
         final Ds3Request request = getRequestGetJob();
+        assertThat(generator.toParseResponsePayload(request), is(expected));
+    }
+
+    @Test
+    public void toParseResponsePayload_WithStringPayload_Test() {
+        final String expected = "if self.response.status == 200:\n" +
+                "            self.result = response.read()";
+
+        final Ds3Request request = getGetBlobPersistence();
         assertThat(generator.toParseResponsePayload(request), is(expected));
     }
 


### PR DESCRIPTION
Generated code already merged:
https://github.com/SpectraLogic/ds3_python_sdk/pull/119
https://github.com/SpectraLogic/ds3_python3_sdk/pull/15