### PR TITLE
Updating head object response generation in java for 4.1 API

### DIFF
--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responsemodels/HeadObjectResponseGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/responsemodels/HeadObjectResponseGenerator.java
@@ -36,7 +36,9 @@ public class HeadObjectResponseGenerator extends BaseResponseGenerator {
         final ImmutableList<Arguments> params = ImmutableList.of(
                 new Arguments("Metadata", "Metadata"),
                 new Arguments("long", "ObjectSize"),
-                new Arguments("Status", "Status"));
+                new Arguments("Status", "Status"),
+                new Arguments("ChecksumType.Type", "BlobChecksumType"),
+                new Arguments("ImmutableMap<Long, String>", "BlobChecksums"));
 
         return ImmutableList.sortedCopyOf(new CustomArgumentComparator(), params);
     }
@@ -49,6 +51,7 @@ public class HeadObjectResponseGenerator extends BaseResponseGenerator {
         return ImmutableSet.of(
                 getParentImport(),
                 "com.spectralogic.ds3client.networking.Metadata",
-                "com.spectralogic.ds3client.models.ChecksumType");
+                "com.spectralogic.ds3client.models.ChecksumType",
+                "com.google.common.collect.ImmutableMap");
     }
 }

--- a/ds3-autogen-java/src/main/resources/tmpls/java/responseparser/head_object_parser.ftl
+++ b/ds3-autogen-java/src/main/resources/tmpls/java/responseparser/head_object_parser.ftl
@@ -4,9 +4,11 @@ package ${packageName};
 
 import com.spectralogic.ds3client.commands.interfaces.MetadataImpl;
 import com.spectralogic.ds3client.networking.Metadata;
+import com.google.common.collect.ImmutableMap;
+import com.spectralogic.ds3client.models.ChecksumType;
 <#include "../imports.ftl"/>
 
-import static com.spectralogic.ds3client.commands.parsers.utils.ResponseParserUtils.getSizeFromHeaders;
+import static com.spectralogic.ds3client.commands.parsers.utils.ResponseParserUtils.*;
 
 public class ${name} extends ${parentClass}<${responseName}> {
     private final int[] expectedStatusCodes = new int[]{${expectedStatusCodes}};

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaFunctionalTests.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaFunctionalTests.java
@@ -57,7 +57,7 @@ import static org.mockito.Mockito.mock;
 public class JavaFunctionalTests {
 
     private static final Logger LOG = LoggerFactory.getLogger(JavaFunctionalTests.class);
-    private final static GeneratedCodeLogger CODE_LOGGER = new GeneratedCodeLogger(FileTypeToLog.REQUEST, LOG);
+    private final static GeneratedCodeLogger CODE_LOGGER = new GeneratedCodeLogger(FileTypeToLog.PARSER, LOG);
 
     @Rule
     public TemporaryFolder tempFolder = new TemporaryFolder();
@@ -2034,10 +2034,13 @@ public class JavaFunctionalTests {
 
         assertTrue(hasImport("com.spectralogic.ds3client.commands.interfaces.AbstractResponse", responseGeneratedCode));
         assertTrue(hasImport("com.spectralogic.ds3client.networking.Metadata", responseGeneratedCode));
+        assertTrue(hasImport("com.google.common.collect.ImmutableMap", responseGeneratedCode));
 
         assertTrue(isReqParamOfType("metadata", "Metadata", responseName, responseGeneratedCode, false));
         assertTrue(isReqParamOfType("objectSize", "long", responseName, responseGeneratedCode, false));
         assertTrue(isReqParamOfType("status", "Status", responseName, responseGeneratedCode, false));
+        assertTrue(isReqParamOfType("blobChecksumType", "ChecksumType.Type", responseName, responseGeneratedCode, false));
+        assertTrue(isReqParamOfType("blobChecksums", "ImmutableMap<Long, String>", responseName, responseGeneratedCode, false));
 
         assertTrue(responseGeneratedCode.contains("public enum Status { EXISTS, DOESNTEXIST, UNKNOWN }"));
 
@@ -2063,10 +2066,19 @@ public class JavaFunctionalTests {
         assertTrue(hasImport("com.spectralogic.ds3client.commands.parsers.utils.ResponseParserUtils", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.commands.interfaces.MetadataImpl", responseParserCode));
         assertTrue(hasImport("com.spectralogic.ds3client.networking.Metadata", responseParserCode));
-        assertTrue(responseParserCode.contains("import static com.spectralogic.ds3client.commands.parsers.utils.ResponseParserUtils.getSizeFromHeaders;"));
+        assertTrue(hasImport("com.google.common.collect.ImmutableMap", responseParserCode));
+        assertTrue(hasImport("com.spectralogic.ds3client.models.ChecksumType", responseParserCode));
+        assertTrue(responseParserCode.contains("import static com.spectralogic.ds3client.commands.parsers.utils.ResponseParserUtils.*;"));
+        assertFalse(responseParserCode.contains("import static com.spectralogic.ds3client.commands.parsers.utils.ResponseParserUtils.getSizeFromHeaders;"));
 
-        assertTrue(responseParserCode.contains("return new HeadObjectResponse(metadata, objectSize, HeadObjectResponse.Status.EXISTS, this.getChecksum(), this.getChecksumType());"));
-        assertTrue(responseParserCode.contains("return new HeadObjectResponse(metadata, objectSize, HeadObjectResponse.Status.DOESNTEXIST, this.getChecksum(), this.getChecksumType());"));
+        // 200 response code
+        assertTrue(responseParserCode.contains("final ChecksumType.Type blobChecksumType = getBlobChecksumType(response.getHeaders());"));
+        assertTrue(responseParserCode.contains("final ImmutableMap<Long, String> blobChecksumMap = getBlobChecksumMap(response.getHeaders());"));
+        assertTrue(responseParserCode.contains("return new HeadObjectResponse(blobChecksumMap, blobChecksumType, metadata, objectSize, HeadObjectResponse.Status.EXISTS, this.getChecksum(), this.getChecksumType());"));
+
+        // 404 response code
+        assertTrue(responseParserCode.contains("return new HeadObjectResponse(ImmutableMap.of(), ChecksumType.Type.NONE, metadata, objectSize, HeadObjectResponse.Status.DOESNTEXIST, this.getChecksum(), this.getChecksumType());"));
+
         assertTrue(responseParserCode.contains("private final int[] expectedStatusCodes = new int[]{200, 404};"));
     }
 

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responsemodels/HeadObjectResponseGenerator_Test.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/generators/responsemodels/HeadObjectResponseGenerator_Test.java
@@ -31,21 +31,32 @@ public class HeadObjectResponseGenerator_Test {
     @Test
     public void getAllImports_Test() {
         final ImmutableSet<String> result = generator.getAllImports(null);
-        assertThat(result.size(), is(3));
+        assertThat(result.size(), is(4));
         assertThat(result, hasItem("com.spectralogic.ds3client.networking.Metadata"));
         assertThat(result, hasItem("com.spectralogic.ds3client.commands.interfaces.AbstractResponse"));
         assertThat(result, hasItem("com.spectralogic.ds3client.models.ChecksumType"));
+        assertThat(result, hasItem("com.google.common.collect.ImmutableMap"));
     }
 
     @Test
     public void toParamList_Test() {
         final ImmutableList<Arguments> result = generator.toParamList(null);
-        assertThat(result.size(), is(3));
-        assertThat(result.get(0).getName(), is("Metadata"));
-        assertThat(result.get(0).getType(), is("Metadata"));
-        assertThat(result.get(1).getName(), is("ObjectSize"));
-        assertThat(result.get(1).getType(), is("long"));
-        assertThat(result.get(2).getName(), is("Status"));
-        assertThat(result.get(2).getType(), is("Status"));
+        assertThat(result.size(), is(5));
+
+        // Verify that parameters were sorted alphabetically by name
+        assertThat(result.get(0).getName(), is("BlobChecksums"));
+        assertThat(result.get(0).getType(), is("ImmutableMap<Long, String>"));
+
+        assertThat(result.get(1).getName(), is("BlobChecksumType"));
+        assertThat(result.get(1).getType(), is("ChecksumType.Type"));
+
+        assertThat(result.get(2).getName(), is("Metadata"));
+        assertThat(result.get(2).getType(), is("Metadata"));
+
+        assertThat(result.get(3).getName(), is("ObjectSize"));
+        assertThat(result.get(3).getType(), is("long"));
+
+        assertThat(result.get(4).getName(), is("Status"));
+        assertThat(result.get(4).getType(), is("Status"));
     }
 }


### PR DESCRIPTION
**Changes**
Generates the Head Object response handler and response parser to include the blob checksum header parsing.

Generates the code in Java SDK PR: https://github.com/SpectraLogic/ds3_java_sdk/pull/541

**Generated Response Handler Code**
```
package com.spectralogic.ds3client.commands;

import com.spectralogic.ds3client.commands.interfaces.AbstractResponse;
import com.spectralogic.ds3client.networking.Metadata;
import com.spectralogic.ds3client.models.ChecksumType;
import com.google.common.collect.ImmutableMap;

public class HeadObjectResponse extends AbstractResponse {

    public enum Status { EXISTS, DOESNTEXIST, UNKNOWN }
    
    private final ImmutableMap<Long, String> blobChecksums;

    private final ChecksumType.Type blobChecksumType;

    private final Metadata metadata;

    private final long objectSize;

    private final Status status;

    public HeadObjectResponse(final ImmutableMap<Long, String> blobChecksums, final ChecksumType.Type blobChecksumType, final Metadata metadata, final long objectSize, final Status status, final String checksum, final ChecksumType.Type checksumType) {
        super(checksum, checksumType);
        this.blobChecksums = blobChecksums;
        this.blobChecksumType = blobChecksumType;
        this.metadata = metadata;
        this.objectSize = objectSize;
        this.status = status;
    }

    public ImmutableMap<Long, String> getBlobChecksums() {
        return this.blobChecksums;
    }

    public ChecksumType.Type getBlobChecksumType() {
        return this.blobChecksumType;
    }

    public Metadata getMetadata() {
        return this.metadata;
    }

    public long getObjectSize() {
        return this.objectSize;
    }

    public Status getStatus() {
        return this.status;
    }

}
```
**Generated Response Parser Code**
```
package com.spectralogic.ds3client.commands.parsers;

import com.spectralogic.ds3client.commands.interfaces.MetadataImpl;
import com.spectralogic.ds3client.networking.Metadata;
import com.google.common.collect.ImmutableMap;
import com.spectralogic.ds3client.models.ChecksumType;
import com.spectralogic.ds3client.commands.HeadObjectResponse;
import com.spectralogic.ds3client.commands.parsers.interfaces.AbstractResponseParser;
import com.spectralogic.ds3client.commands.parsers.utils.ResponseParserUtils;
import com.spectralogic.ds3client.networking.WebResponse;
import java.io.IOException;

import static com.spectralogic.ds3client.commands.parsers.utils.ResponseParserUtils.*;

public class HeadObjectResponseParser extends AbstractResponseParser<HeadObjectResponse> {
    private final int[] expectedStatusCodes = new int[]{200, 404};

    @Override
    public HeadObjectResponse parseXmlResponse(final WebResponse response) throws IOException {
        final int statusCode = response.getStatusCode();
        if (ResponseParserUtils.validateStatusCode(statusCode, expectedStatusCodes)) {
            final Metadata metadata = new MetadataImpl(response.getHeaders());
            final long objectSize = getSizeFromHeaders(response.getHeaders());
            switch (statusCode) {
            case 200:
                final ChecksumType.Type blobChecksumType = getBlobChecksumType(response.getHeaders());
                final ImmutableMap<Long, String> blobChecksumMap = getBlobChecksumMap(response.getHeaders());
                return new HeadObjectResponse(blobChecksumMap, blobChecksumType, metadata, objectSize, HeadObjectResponse.Status.EXISTS, this.getChecksum(), this.getChecksumType());

            case 404:
                return new HeadObjectResponse(ImmutableMap.of(), ChecksumType.Type.NONE, metadata, objectSize, HeadObjectResponse.Status.DOESNTEXIST, this.getChecksum(), this.getChecksumType());

            default:
                assert false: "validateStatusCode should have made it impossible to reach this line";
            }
        }

        throw ResponseParserUtils.createFailedRequest(response, expectedStatusCodes);
    }
```