### PR TITLE
5.0 API generation for Java module

### DIFF
--- a/contracts/5_0_x_contract.xml
+++ b/contracts/5_0_x_contract.xml
@@ -3195,6 +3195,12 @@
         </Request>
         <ResponseCodes>
           <ResponseCode>
+            <Code>200</Code> <!-- Manually added the expected 200 response -->
+            <ResponseTypes>
+              <ResponseType Type="com.spectralogic.s3.server.domain.JobWithChunksApiBean"/>
+            </ResponseTypes>
+          </ResponseCode>
+          <ResponseCode>
             <Code>400</Code>
             <ResponseTypes>
               <ResponseType Type="com.spectralogic.s3.server.domain.HttpErrorResultApiBean"/>
@@ -4613,6 +4619,12 @@
             </ResponseTypes>
           </ResponseCode>
           <ResponseCode>
+            <Code>400</Code>
+            <ResponseTypes>
+              <ResponseType Type="com.spectralogic.s3.server.domain.HttpErrorResultApiBean"/>
+            </ResponseTypes>
+          </ResponseCode>
+          <ResponseCode>
             <Code>404</Code>
             <ResponseTypes>
               <ResponseType Type="com.spectralogic.s3.server.domain.HttpErrorResultApiBean"/>
@@ -5008,7 +5020,6 @@
       <RequestHandler Classification="spectrads3" Name="com.spectralogic.s3.server.handler.reqhandler.spectrads3.pool.ImportAllPoolsRequestHandler">
         <Request Action="BULK_MODIFY" HttpVerb="PUT" IncludeIdInPath="false" Operation="IMPORT" Resource="POOL" ResourceType="NON_SINGLETON">
           <OptionalQueryParams>
-            <Param Name="ConflictResolutionMode" Type="java.lang.String"/>
             <Param Name="DataPolicyId" Type="java.util.UUID"/>
             <Param Name="Priority" Type="com.spectralogic.s3.common.dao.domain.ds3.BlobStoreTaskPriority"/>
             <Param Name="StorageDomainId" Type="java.util.UUID"/>
@@ -5028,12 +5039,11 @@
             </ResponseTypes>
           </ResponseCode>
         </ResponseCodes>
-        <Version>1.A2C4FD5193ABBFDE8B56745D670AB25A</Version>
+        <Version>1.179F228C42340ABB9EEB830006BC5F2A</Version>
       </RequestHandler>
       <RequestHandler Classification="spectrads3" Name="com.spectralogic.s3.server.handler.reqhandler.spectrads3.pool.ImportPoolRequestHandler">
         <Request Action="MODIFY" HttpVerb="PUT" IncludeIdInPath="true" Operation="IMPORT" Resource="POOL" ResourceType="NON_SINGLETON">
           <OptionalQueryParams>
-            <Param Name="ConflictResolutionMode" Type="java.lang.String"/>
             <Param Name="DataPolicyId" Type="java.util.UUID"/>
             <Param Name="Priority" Type="com.spectralogic.s3.common.dao.domain.ds3.BlobStoreTaskPriority"/>
             <Param Name="StorageDomainId" Type="java.util.UUID"/>
@@ -5053,7 +5063,7 @@
             </ResponseTypes>
           </ResponseCode>
         </ResponseCodes>
-        <Version>1.764B90CE7E2C3DEF7EA8E81F9B8DFDB1</Version>
+        <Version>1.3DDC7451EA1620AE50203012113A61CC</Version>
       </RequestHandler>
       <RequestHandler Classification="spectrads3" Name="com.spectralogic.s3.server.handler.reqhandler.spectrads3.pool.ModifyAllPoolsRequestHandler">
         <Request Action="BULK_MODIFY" HttpVerb="PUT" IncludeIdInPath="false" Resource="POOL" ResourceType="NON_SINGLETON">
@@ -6432,7 +6442,6 @@
       <RequestHandler Classification="spectrads3" Name="com.spectralogic.s3.server.handler.reqhandler.spectrads3.tape.ImportAllTapesRequestHandler">
         <Request Action="BULK_MODIFY" HttpVerb="PUT" IncludeIdInPath="false" Operation="IMPORT" Resource="TAPE" ResourceType="NON_SINGLETON">
           <OptionalQueryParams>
-            <Param Name="ConflictResolutionMode" Type="java.lang.String"/>
             <Param Name="DataPolicyId" Type="java.util.UUID"/>
             <Param Name="Priority" Type="com.spectralogic.s3.common.dao.domain.ds3.BlobStoreTaskPriority"/>
             <Param Name="StorageDomainId" Type="java.util.UUID"/>
@@ -6452,12 +6461,11 @@
             </ResponseTypes>
           </ResponseCode>
         </ResponseCodes>
-        <Version>1.E8AEEFAEC67C2B8BD701A35920F06D08</Version>
+        <Version>1.FF1951EAE0ACBAB8DB513DF209D32122</Version>
       </RequestHandler>
       <RequestHandler Classification="spectrads3" Name="com.spectralogic.s3.server.handler.reqhandler.spectrads3.tape.ImportTapeRequestHandler">
         <Request Action="MODIFY" HttpVerb="PUT" IncludeIdInPath="true" Operation="IMPORT" Resource="TAPE" ResourceType="NON_SINGLETON">
           <OptionalQueryParams>
-            <Param Name="ConflictResolutionMode" Type="java.lang.String"/>
             <Param Name="DataPolicyId" Type="java.util.UUID"/>
             <Param Name="Priority" Type="com.spectralogic.s3.common.dao.domain.ds3.BlobStoreTaskPriority"/>
             <Param Name="StorageDomainId" Type="java.util.UUID"/>
@@ -6483,7 +6491,7 @@
             </ResponseTypes>
           </ResponseCode>
         </ResponseCodes>
-        <Version>1.D02425C0AF41D18225D75C3B2C8D5AE5</Version>
+        <Version>1.B73F07D16A191E0EFD397E3DCB5CE051</Version>
       </RequestHandler>
       <RequestHandler Classification="spectrads3" Name="com.spectralogic.s3.server.handler.reqhandler.spectrads3.tape.InspectAllTapesRequestHandler">
         <Request Action="BULK_MODIFY" HttpVerb="PUT" IncludeIdInPath="false" Operation="INSPECT" Resource="TAPE" ResourceType="NON_SINGLETON">
@@ -9143,18 +9151,6 @@
               </Annotation>
             </Annotations>
           </Element>
-          <Element Name="AlwaysReplicateDeletes" Type="boolean">
-            <Annotations>
-              <Annotation Name="com.spectralogic.util.bean.lang.DefaultBooleanValue">
-                <AnnotationElements>
-                  <AnnotationElement Name="Value" Value="true" ValueType="java.lang.Boolean"/>
-                </AnnotationElements>
-              </Annotation>
-              <Annotation Name="com.spectralogic.util.db.lang.shared.ExcludeFromDatabasePersistence">
-                <AnnotationElements/>
-              </Annotation>
-            </Annotations>
-          </Element>
           <Element Name="BlobbingEnabled" Type="boolean">
             <Annotations>
               <Annotation Name="com.spectralogic.util.bean.lang.DefaultBooleanValue">
@@ -9234,18 +9230,6 @@
           </Element>
           <Element Name="Id" Type="java.util.UUID">
             <Annotations/>
-          </Element>
-          <Element Name="LtfsObjectNamingAllowed" Type="boolean">
-            <Annotations>
-              <Annotation Name="com.spectralogic.util.bean.lang.DefaultBooleanValue">
-                <AnnotationElements>
-                  <AnnotationElement Name="Value" Value="true" ValueType="java.lang.Boolean"/>
-                </AnnotationElements>
-              </Annotation>
-              <Annotation Name="com.spectralogic.util.db.lang.shared.ExcludeFromDatabasePersistence">
-                <AnnotationElements/>
-              </Annotation>
-            </Annotations>
           </Element>
           <Element Name="MaxVersionsToKeep" Type="int">
             <Annotations>
@@ -10216,15 +10200,6 @@
           </Element>
           <Element Name="Type" Type="com.spectralogic.s3.common.dao.domain.ds3.S3ObjectType">
             <Annotations/>
-          </Element>
-          <Element Name="Version" Type="long">
-            <Annotations>
-              <Annotation Name="com.spectralogic.util.bean.lang.DefaultLongValue">
-                <AnnotationElements>
-                  <AnnotationElement Name="Value" Value="1" ValueType="java.lang.Long"/>
-                </AnnotationElements>
-              </Annotation>
-            </Annotations>
           </Element>
         </Elements>
       </Type>
@@ -15102,7 +15077,7 @@
               </Annotation>
             </Annotations>
           </Element>
-          <Element Name="Version" Type="long">
+          <Element Name="VersionId" Type="java.util.UUID">
             <Annotations>
               <Annotation Name="com.spectralogic.util.bean.lang.SortBy">
                 <AnnotationElements>
@@ -16732,15 +16707,6 @@
           </Element>
           <Element Name="Type" Type="com.spectralogic.s3.common.dao.domain.ds3.S3ObjectType">
             <Annotations/>
-          </Element>
-          <Element Name="Version" Type="long">
-            <Annotations>
-              <Annotation Name="com.spectralogic.util.bean.lang.DefaultLongValue">
-                <AnnotationElements>
-                  <AnnotationElement Name="Value" Value="1" ValueType="java.lang.Long"/>
-                </AnnotationElements>
-              </Annotation>
-            </Annotations>
           </Element>
         </Elements>
       </Type>

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/JavaCodeGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/JavaCodeGenerator.java
@@ -514,7 +514,7 @@ public class JavaCodeGenerator implements CodeGenerator {
         if (hasStringRequestPayload(ds3Request)) {
             return new StringRequestPayloadGenerator();
         }
-        if (isBulkRequest(ds3Request)) {
+        if (isBulkRequest(ds3Request) || isStageObjectsJob(ds3Request)) {
             return new BulkRequestGenerator();
         }
         if (hasSimpleObjectsRequestPayload(ds3Request) || isCreateVerifyJobRequest(ds3Request)) {
@@ -552,7 +552,7 @@ public class JavaCodeGenerator implements CodeGenerator {
      * @throws IOException
      */
     private Template getRequestTemplate(final Ds3Request ds3Request) throws IOException {
-        if (isBulkRequest(ds3Request)) {
+        if (isBulkRequest(ds3Request) || isStageObjectsJob(ds3Request)) {
             return config.getTemplate("request/bulk_request_template.ftl");
         }
         if (hasIdsRequestPayload(ds3Request)) {

--- a/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/requestmodels/GetObjectRequestGenerator.java
+++ b/ds3-autogen-java/src/main/java/com/spectralogic/ds3autogen/java/generators/requestmodels/GetObjectRequestGenerator.java
@@ -59,7 +59,12 @@ public class GetObjectRequestGenerator extends BaseRequestGenerator {
             final String requestName,
             final Ds3DocSpec docSpec) {
         final ImmutableList<Arguments> constructorArgs = toConstructorArgumentsList(ds3Request);
-        final ImmutableList<Arguments> optionalArgs = toOptionalArgumentsList(ds3Request.getOptionalQueryParams());
+
+        // Add the Job and Offset optional params to non-deprecated constructors
+        final ImmutableList<Arguments> optionalConstructorArgs = toOptionalArgumentsList(ds3Request.getOptionalQueryParams()).stream()
+                .filter(arg -> arg.getName().equalsIgnoreCase("Job") || arg.getName().equalsIgnoreCase("Offset"))
+                .collect(GuavaCollectors.immutableList());
+
         final ImmutableList<QueryParam> queryParams = toQueryParamsList(ds3Request);
 
         final ImmutableList.Builder<RequestConstructor> constructorBuilder = ImmutableList.builder();
@@ -76,7 +81,7 @@ public class GetObjectRequestGenerator extends BaseRequestGenerator {
         constructorBuilder.add(
                 createChannelConstructor(
                         constructorArgs,
-                        optionalArgs,
+                        optionalConstructorArgs,
                         queryParams,
                         requestName,
                         docSpec));
@@ -84,7 +89,7 @@ public class GetObjectRequestGenerator extends BaseRequestGenerator {
         constructorBuilder.add(
                 createOutputStreamConstructor(
                         constructorArgs,
-                        optionalArgs,
+                        optionalConstructorArgs,
                         queryParams,
                         requestName,
                         docSpec));

--- a/ds3-autogen-java/src/main/resources/tmpls/java/models/bulk_object_template.ftl
+++ b/ds3-autogen-java/src/main/resources/tmpls/java/models/bulk_object_template.ftl
@@ -26,7 +26,7 @@ ${javaHelper.getModelVariable(elmt)}
 
     @Override
     public int hashCode() {
-        return java.util.Objects.hash(id, inCache, latest, length, name, offset, physicalPlacement, version);
+        return java.util.Objects.hash(id, inCache, latest, length, name, offset, physicalPlacement, versionId);
     }
 
     @Override
@@ -44,7 +44,7 @@ ${javaHelper.getModelVariable(elmt)}
                 && nullableEquals(this.getName(), bulkObject.getName())
                 && this.getOffset() == bulkObject.getOffset()
                 && this.getPhysicalPlacement() == bulkObject.getPhysicalPlacement()
-                && this.getVersion() == bulkObject.getVersion();
+                && nullableEquals(this.getVersionId(), bulkObject.getVersionId());
     }
 
     /**

--- a/ds3-autogen-java/src/main/resources/tmpls/java/models/s3object_model_template.ftl
+++ b/ds3-autogen-java/src/main/resources/tmpls/java/models/s3object_model_template.ftl
@@ -27,7 +27,7 @@ ${javaHelper.getModelVariable(elmt)}
 
     @Override
     public int hashCode() {
-        return Objects.hash(bucketId, name, id, latest, creationDate, type, version);
+        return Objects.hash(bucketId, name, id, latest, creationDate, type);
     }
 
     @Override
@@ -43,7 +43,6 @@ ${javaHelper.getModelVariable(elmt)}
                 && this.id.equals(s3obj.getId())
                 && this.latest == s3obj.getLatest()
                 && this.name.equals(s3obj.getName())
-                && this.type == s3obj.getType()
-                && this.version == s3obj.getVersion();
+                && this.type == s3obj.getType();
     }
 }

--- a/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaFunctionalTests.java
+++ b/ds3-autogen-java/src/test/java/com/spectralogic/ds3autogen/java/JavaFunctionalTests.java
@@ -57,7 +57,7 @@ import static org.mockito.Mockito.mock;
 public class JavaFunctionalTests {
 
     private static final Logger LOG = LoggerFactory.getLogger(JavaFunctionalTests.class);
-    private final static GeneratedCodeLogger CODE_LOGGER = new GeneratedCodeLogger(FileTypeToLog.PARSER, LOG);
+    private final static GeneratedCodeLogger CODE_LOGGER = new GeneratedCodeLogger(FileTypeToLog.REQUEST, LOG);
 
     @Rule
     public TemporaryFolder tempFolder = new TemporaryFolder();
@@ -1172,6 +1172,7 @@ public class JavaFunctionalTests {
         assertTrue(isOptParamOfType("Job", "String", requestName, requestGeneratedCode, false));
         assertTrue(isOptParamOfType("Offset", "long", requestName, requestGeneratedCode, false));
         assertTrue(isOptParamOfType("ByteRanges", "Collection<Range>", requestName, requestGeneratedCode, true));
+        assertTrue(isOptParamOfType("VersionId", "String", requestName, requestGeneratedCode, false));
         assertTrue(isReqParamOfType("BucketName", "String", requestName, requestGeneratedCode, false));
         assertTrue(isReqParamOfType("ObjectName", "String", requestName, requestGeneratedCode, false));
         assertTrue(isReqParamOfType("Channel", "WritableByteChannel", requestName, requestGeneratedCode, false));
@@ -2642,5 +2643,122 @@ public class JavaFunctionalTests {
 
         codeGenerator.generate(spec, fileUtils, Paths.get("."), new Ds3DocSpecEmptyImpl());
 
+    }
+
+    @Test
+    public void ejectStorageDomainTest() throws IOException, TemplateModelException {
+        final String requestName = "EjectStorageDomainBlobsSpectraS3Request";
+        final FileUtils fileUtils = mock(FileUtils.class);
+        final TestGeneratedCode testGeneratedCode = new TestGeneratedCode(
+                fileUtils,
+                requestName,
+                "./ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/");
+
+        testGeneratedCode.generateCode(fileUtils, "/input/ejectStorageDomainBlobs.xml");
+
+        final String requestGeneratedCode = testGeneratedCode.getRequestGeneratedCode();
+        CODE_LOGGER.logFile(requestGeneratedCode, FileTypeToLog.REQUEST);
+
+        assertTrue(extendsClass(requestName, "AbstractRequest", requestGeneratedCode));
+        assertTrue(isOfPackage("com.spectralogic.ds3client.commands.spectrads3", requestGeneratedCode));
+
+        assertTrue(hasImport("com.spectralogic.ds3client.networking.HttpVerb", requestGeneratedCode));
+        assertTrue(hasImport("com.spectralogic.ds3client.models.bulk.Ds3Object", requestGeneratedCode));
+        assertTrue(hasImport("com.spectralogic.ds3client.models.bulk.Ds3ObjectList", requestGeneratedCode));
+        assertTrue(hasImport("com.spectralogic.ds3client.serializer.XmlOutput", requestGeneratedCode));
+        assertTrue(hasImport("com.spectralogic.ds3client.utils.Guard", requestGeneratedCode));
+        assertTrue(hasImport("java.io.ByteArrayInputStream", requestGeneratedCode));
+        assertTrue(hasImport("java.io.InputStream", requestGeneratedCode));
+        assertTrue(hasImport("java.util.List", requestGeneratedCode));
+        assertTrue(hasImport("java.nio.charset.Charset", requestGeneratedCode));
+        assertTrue(hasImport("com.spectralogic.ds3client.commands.interfaces.AbstractRequest", requestGeneratedCode));
+
+        assertTrue(hasCopyright(requestGeneratedCode));
+
+        assertTrue(isOptParamOfType("ejectLabel", "String", requestName, requestGeneratedCode, false));
+        assertTrue(isOptParamOfType("ejectLocation", "String", requestName, requestGeneratedCode, false));
+
+        assertTrue(isReqParamOfType("bucketId", "String", requestName, requestGeneratedCode, false));
+        assertTrue(isReqParamOfType("storageDomain", "String", requestName, requestGeneratedCode, false));
+        assertTrue(isReqParamOfType("objects", "List<Ds3Object>", requestName, requestGeneratedCode, false));
+
+        assertTrue(requestGeneratedCode.contains("public InputStream getStream() {"));
+        assertTrue(requestGeneratedCode.contains("public long getSize() {"));
+
+        final String responseGeneratedCode = testGeneratedCode.getResponseGeneratedCode();
+        CODE_LOGGER.logFile(responseGeneratedCode, FileTypeToLog.RESPONSE);
+
+        final String responseName = requestName.replace("Request", "Response");
+        assertTrue(extendsClass(responseName, "AbstractResponse", responseGeneratedCode));
+
+        final String ds3ClientGeneratedCode = testGeneratedCode.getDs3ClientGeneratedCode();
+        CODE_LOGGER.logFile(ds3ClientGeneratedCode, FileTypeToLog.CLIENT);
+        testDs3Client(requestName, ds3ClientGeneratedCode);
+
+        final String ds3ClientImplGeneratedCode = testGeneratedCode.getDs3ClientImplGeneratedCode();
+        CODE_LOGGER.logFile(ds3ClientImplGeneratedCode, FileTypeToLog.CLIENT);
+        testDs3ClientImpl(requestName, ds3ClientImplGeneratedCode);
+
+        final String responseParserCode = testGeneratedCode.getResponseParserGeneratedCode();
+        CODE_LOGGER.logFile(responseParserCode, FileTypeToLog.PARSER);
+        assertTrue(isOfPackage("com.spectralogic.ds3client.commands.parsers", responseParserCode));
+    }
+
+    @Test
+    public void stageObjectsJob() throws IOException, TemplateModelException {
+        final String requestName = "StageObjectsJobSpectraS3Request";
+        final FileUtils fileUtils = mock(FileUtils.class);
+        final TestGeneratedCode testGeneratedCode = new TestGeneratedCode(
+                fileUtils,
+                requestName,
+                "./ds3-sdk/src/main/java/com/spectralogic/ds3client/commands/spectrads3/");
+
+        testGeneratedCode.generateCode(fileUtils, "/input/stageObjectsJob.xml");
+
+        final String requestGeneratedCode = testGeneratedCode.getRequestGeneratedCode();
+        CODE_LOGGER.logFile(requestGeneratedCode, FileTypeToLog.REQUEST);
+
+        assertTrue(extendsClass(requestName, "BulkRequest", requestGeneratedCode));
+        assertTrue(isOfPackage("com.spectralogic.ds3client.commands.spectrads3", requestGeneratedCode));
+
+        assertTrue(hasImport("com.spectralogic.ds3client.BulkCommand", requestGeneratedCode));
+        assertTrue(hasImport("com.spectralogic.ds3client.commands.interfaces.BulkRequest", requestGeneratedCode));
+        assertTrue(hasImport("com.spectralogic.ds3client.models.Priority", requestGeneratedCode));
+        assertTrue(hasImport("com.spectralogic.ds3client.models.bulk.Ds3Object", requestGeneratedCode));
+
+        assertTrue(hasCopyright(requestGeneratedCode));
+
+        assertTrue(isOptParamOfType("name", "String", requestName, requestGeneratedCode, false));
+        assertTrue(isOptParamOfType("priority", "Priority", requestName, requestGeneratedCode, true));
+
+        assertTrue(isReqParamOfType("bucketName", "String", requestName, requestGeneratedCode, true));
+        assertTrue(isReqParamOfType("objects", "Iterable<Ds3Object>", requestName, requestGeneratedCode, true));
+
+        assertTrue(requestGeneratedCode.contains("public StageObjectsJobSpectraS3Request(final String bucketName, final Iterable<Ds3Object> objects) {"));
+        assertTrue(requestGeneratedCode.contains("this.getQueryParams().put(\"operation\", \"start_bulk_stage\");"));
+
+        assertTrue(requestGeneratedCode.contains("public BulkCommand getCommand() {"));
+        assertTrue(requestGeneratedCode.contains("return BulkCommand.GET;"));
+
+        assertFalse(requestGeneratedCode.contains("public HttpVerb getVerb() {"));
+
+
+        final String responseGeneratedCode = testGeneratedCode.getResponseGeneratedCode();
+        CODE_LOGGER.logFile(responseGeneratedCode, FileTypeToLog.RESPONSE);
+
+        final String responseName = requestName.replace("Request", "Response");
+        assertTrue(extendsClass(responseName, "AbstractResponse", responseGeneratedCode));
+
+        final String ds3ClientGeneratedCode = testGeneratedCode.getDs3ClientGeneratedCode();
+        CODE_LOGGER.logFile(ds3ClientGeneratedCode, FileTypeToLog.CLIENT);
+        testDs3Client(requestName, ds3ClientGeneratedCode);
+
+        final String ds3ClientImplGeneratedCode = testGeneratedCode.getDs3ClientImplGeneratedCode();
+        CODE_LOGGER.logFile(ds3ClientImplGeneratedCode, FileTypeToLog.CLIENT);
+        testDs3ClientImpl(requestName, ds3ClientImplGeneratedCode);
+
+        final String responseParserCode = testGeneratedCode.getResponseParserGeneratedCode();
+        CODE_LOGGER.logFile(responseParserCode, FileTypeToLog.PARSER);
+        assertTrue(isOfPackage("com.spectralogic.ds3client.commands.parsers", responseParserCode));
     }
 }

--- a/ds3-autogen-java/src/test/resources/input/ejectStorageDomainBlobs.xml
+++ b/ds3-autogen-java/src/test/resources/input/ejectStorageDomainBlobs.xml
@@ -1,0 +1,35 @@
+<Data>
+    <Contract>
+        <RequestHandlers>
+            <RequestHandler Classification="spectrads3" Name="com.spectralogic.s3.server.handler.reqhandler.spectrads3.tape.EjectStorageDomainBlobsRequestHandler">
+                <Request Action="BULK_MODIFY" HttpVerb="PUT" IncludeIdInPath="false" Operation="EJECT" Resource="TAPE" ResourceType="NON_SINGLETON">
+                    <OptionalQueryParams>
+                        <Param Name="EjectLabel" Type="java.lang.String"/>
+                        <Param Name="EjectLocation" Type="java.lang.String"/>
+                    </OptionalQueryParams>
+                    <RequiredQueryParams>
+                        <Param Name="Blobs" Type="void"/>
+                        <Param Name="BucketId" Type="java.util.UUID"/>
+                        <Param Name="Operation" Type="com.spectralogic.s3.server.request.rest.RestOperationType"/>
+                        <Param Name="StorageDomain" Type="java.lang.String"/>
+                    </RequiredQueryParams>
+                </Request>
+                <ResponseCodes>
+                    <ResponseCode>
+                        <Code>204</Code>
+                        <ResponseTypes>
+                            <ResponseType Type="null"/>
+                        </ResponseTypes>
+                    </ResponseCode>
+                    <ResponseCode>
+                        <Code>400</Code>
+                        <ResponseTypes>
+                            <ResponseType Type="com.spectralogic.s3.server.domain.HttpErrorResultApiBean"/>
+                        </ResponseTypes>
+                    </ResponseCode>
+                </ResponseCodes>
+                <Version>1.221F7DCAF04AE6EB1BADF4997871733E</Version>
+            </RequestHandler>
+        </RequestHandlers>
+    </Contract>
+</Data>

--- a/ds3-autogen-java/src/test/resources/input/getObjectRequestHandler.xml
+++ b/ds3-autogen-java/src/test/resources/input/getObjectRequestHandler.xml
@@ -6,6 +6,7 @@
                     <OptionalQueryParams>
                         <Param Name="Job" Type="java.util.UUID"/>
                         <Param Name="Offset" Type="long"/>
+                        <Param Name="VersionId" Type="java.util.UUID"/>
                     </OptionalQueryParams>
                     <RequiredQueryParams/>
                 </Request>
@@ -35,13 +36,13 @@
                         </ResponseTypes>
                     </ResponseCode>
                     <ResponseCode>
-                        <Code>503</Code>
+                        <Code>404</Code>
                         <ResponseTypes>
                             <ResponseType Type="com.spectralogic.s3.server.domain.HttpErrorResultApiBean"/>
                         </ResponseTypes>
                     </ResponseCode>
                 </ResponseCodes>
-                <Version>1.F50E6F8DEFB864FE89D9385A71A6C25A</Version>
+                <Version>1.9E10AB31443900A845A6A64AACDA46A8</Version>
             </RequestHandler>
         </RequestHandlers>
     </Contract>

--- a/ds3-autogen-java/src/test/resources/input/stageObjectsJob.xml
+++ b/ds3-autogen-java/src/test/resources/input/stageObjectsJob.xml
@@ -1,0 +1,32 @@
+<Data>
+    <Contract>
+        <RequestHandlers>
+            <RequestHandler Classification="spectrads3" Name="com.spectralogic.s3.server.handler.reqhandler.spectrads3.job.StageObjectsJobRequestHandler">
+                <Request Action="MODIFY" HttpVerb="PUT" IncludeIdInPath="true" Operation="START_BULK_STAGE" Resource="BUCKET" ResourceType="NON_SINGLETON">
+                    <OptionalQueryParams>
+                        <Param Name="Name" Type="java.lang.String"/>
+                        <Param Name="Priority" Type="com.spectralogic.s3.common.dao.domain.ds3.BlobStoreTaskPriority"/>
+                    </OptionalQueryParams>
+                    <RequiredQueryParams>
+                        <Param Name="Operation" Type="com.spectralogic.s3.server.request.rest.RestOperationType"/>
+                    </RequiredQueryParams>
+                </Request>
+                <ResponseCodes>
+                    <ResponseCode>
+                        <Code>200</Code> <!-- Manually added the expected 200 response -->
+                        <ResponseTypes>
+                            <ResponseType Type="com.spectralogic.s3.server.domain.JobWithChunksApiBean"/>
+                        </ResponseTypes>
+                    </ResponseCode>
+                    <ResponseCode>
+                        <Code>400</Code>
+                        <ResponseTypes>
+                            <ResponseType Type="com.spectralogic.s3.server.domain.HttpErrorResultApiBean"/>
+                        </ResponseTypes>
+                    </ResponseCode>
+                </ResponseCodes>
+                <Version>1.0D522E432703A7E48DBEDD1A6BB5CEF8</Version>
+            </RequestHandler>
+        </RequestHandlers>
+    </Contract>
+</Data>

--- a/ds3-autogen-test-util/src/main/java/com/spectralogic/ds3autogen/testutil/Ds3ModelFixtures.java
+++ b/ds3-autogen-test-util/src/main/java/com/spectralogic/ds3autogen/testutil/Ds3ModelFixtures.java
@@ -329,7 +329,7 @@ public class Ds3ModelFixtures {
 
     /**
      * Creates the AmazonS3 Get Object request GetObjectRequestHandler
-     * as described in the Contract
+     * as described in the 5.0.x Contract
      * @return An AmazonS3 Get Object request
      */
     public static Ds3Request getRequestAmazonS3GetObject() {
@@ -357,7 +357,8 @@ public class Ds3ModelFixtures {
                                 ImmutableList.of(new Ds3ResponseType("com.spectralogic.s3.server.domain.HttpErrorResultApiBean", null)))),
                 ImmutableList.of(
                         new Ds3Param("Job", "java.util.UUID", false),
-                        new Ds3Param("Offset", "long", false)),
+                        new Ds3Param("Offset", "long", false),
+                        new Ds3Param("VersionId", "java.util.UUID", false)),
                 null);
     }
 
@@ -517,7 +518,7 @@ public class Ds3ModelFixtures {
 
     /**
      * Creates the SpectraDs3 Eject Storage Domain Blobs request handler as
-     * described in the contract, excluding the response codes.
+     * described in the 5.0.x contract, excluding the response codes.
      */
     public static Ds3Request getEjectStorageDomainBlobsRequest() {
         return new Ds3Request(
@@ -538,8 +539,8 @@ public class Ds3ModelFixtures {
                 ImmutableList.of(
                         new Ds3Param("Blobs", "void", false),
                         new Ds3Param("BucketId", "java.util.UUID", false),
-                        OPERATION_PARAM,
-                        STORAGE_DOMAIN_ID_PARAM));
+                        new Ds3Param("StorageDomain", "java.lang.String", false),
+                        OPERATION_PARAM));
     }
 
     /**

--- a/ds3-autogen-utils/src/main/java/com/spectralogic/ds3autogen/utils/Ds3RequestClassificationUtil.java
+++ b/ds3-autogen-utils/src/main/java/com/spectralogic/ds3autogen/utils/Ds3RequestClassificationUtil.java
@@ -90,7 +90,7 @@ public final class Ds3RequestClassificationUtil {
                 && ds3Request.getOperation() == Operation.EJECT
                 && ds3Request.getResource() == Resource.TAPE
                 && ds3Request.getResourceType() == ResourceType.NON_SINGLETON
-                && paramListContainsParam(ds3Request.getRequiredQueryParams(), "StorageDomainId", "java.util.UUID")
+                && paramListContainsParam(ds3Request.getRequiredQueryParams(), "StorageDomain", "java.lang.String")
                 && paramListContainsParam(ds3Request.getRequiredQueryParams(), "Blobs", "void");
     }
 
@@ -105,6 +105,18 @@ public final class Ds3RequestClassificationUtil {
                 && (ds3Request.getOperation() == Operation.GET_PHYSICAL_PLACEMENT
                         || ds3Request.getOperation() == Operation.VERIFY_PHYSICAL_PLACEMENT
                         || ds3Request.getOperation() == Operation.START_BULK_VERIFY);
+    }
+
+    /**
+     * Determines if this request is SpectraS3 StageObjectsJobRequestHandler
+     */
+    public static boolean isStageObjectsJob(final Ds3Request ds3Request) {
+        return ds3Request.getClassification() == Classification.spectrads3
+                && ds3Request.getHttpVerb() == HttpVerb.PUT
+                && ds3Request.getIncludeInPath()
+                && ds3Request.getOperation() == Operation.START_BULK_STAGE
+                && ds3Request.getResource() == Resource.BUCKET
+                && ds3Request.getResourceType() == ResourceType.NON_SINGLETON;
     }
 
     /**

--- a/ds3-autogen-utils/src/main/java/com/spectralogic/ds3autogen/utils/Helper.java
+++ b/ds3-autogen-utils/src/main/java/com/spectralogic/ds3autogen/utils/Helper.java
@@ -90,7 +90,7 @@ public final class Helper {
     }
 
     public static String getBulkVerb(final Operation operation) {
-        if (operation == Operation.START_BULK_GET) {
+        if (operation == Operation.START_BULK_GET || operation == Operation.START_BULK_STAGE) {
             return "GET";
         } else if (operation == Operation.START_BULK_PUT) {
             return "PUT";


### PR DESCRIPTION
**Changes**
- Updating 5.0 contract
- Special casing new command Stage Objects Job Request same as Get Bulk Job Request.
- Fixing Get Object request generation where new VersionId was being added as a constructor parameter rather than just an optional parameter.
- Updated request classification functions to match 5.0 changes

**Note**
Changes to the request classification utils breaks tests in modules that are still on 4.1.x API target