### PR TITLE
SA-232: 5.0 API generation for .Net module

### DIFF
--- a/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/NetCodeGenerator.java
+++ b/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/NetCodeGenerator.java
@@ -464,7 +464,7 @@ public class NetCodeGenerator implements CodeGenerator {
         if (isBulkGetRequest(ds3Request)) { //Note: this must come before hasGetObjectsWithLengthOffsetRequestPayload
             return new BulkGetRequestGenerator();
         }
-        if (hasGetObjectsWithLengthOffsetRequestPayload(ds3Request)) {
+        if (hasGetObjectsWithLengthOffsetRequestPayload(ds3Request) || isStageObjectsJob(ds3Request)) {
             return new PartialObjectRequestPayloadGenerator();
         }
         if (isCreateObjectRequest(ds3Request)) {
@@ -502,6 +502,9 @@ public class NetCodeGenerator implements CodeGenerator {
         }
         if (isBulkGetRequest(ds3Request)) { //Note: this must come before hasGetObjectsWithLengthOffsetRequestPayload
             return config.getTemplate("request/bulk_get_request.ftl");
+        }
+        if (isStageObjectsJob(ds3Request)) {
+            return config.getTemplate("request/stage_objects_request.ftl");
         }
         if (hasGetObjectsWithLengthOffsetRequestPayload(ds3Request)) {
             return config.getTemplate("request/partial_objects_request_payload.ftl");

--- a/ds3-autogen-net/src/main/resources/tmpls/net/request/stage_objects_request.ftl
+++ b/ds3-autogen-net/src/main/resources/tmpls/net/request/stage_objects_request.ftl
@@ -1,0 +1,37 @@
+<#include "../common/copyright.ftl" />
+
+using Ds3.Calls.Util;
+using Ds3.Models;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Ds3.Calls
+{
+    public class ${name} : Ds3Request
+    {
+        <#include "common/required_args.ftl" />
+
+        <#include "common/optional_args.ftl" />
+
+        <#include "common/constructor.ftl" />
+
+        public ${name}(string bucketName, List<Ds3Object> ds3Objects)
+            : this(bucketName, ds3Objects.Select(o => o.Name), Enumerable.Empty<Ds3PartialObject>())
+        {
+        }
+
+        <#include "common/http_verb_and_path.ftl" />
+
+        internal override Stream GetContentStream()
+        {
+            return RequestPayloadUtil.MarshalFullAndPartialObjects(this.FullObjects, this.PartialObjects);
+        }
+
+        internal override long GetContentLength()
+        {
+            return GetContentStream().Length;
+        }
+    }
+}

--- a/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/NetFunctionalTests.java
+++ b/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/NetFunctionalTests.java
@@ -43,7 +43,7 @@ import static org.mockito.Mockito.mock;
 public class NetFunctionalTests {
 
     private final static Logger LOG = LoggerFactory.getLogger(NetFunctionalTests.class);
-    private final static GeneratedCodeLogger CODE_LOGGER = new GeneratedCodeLogger(FileTypeToLog.PARSER, LOG);
+    private final static GeneratedCodeLogger CODE_LOGGER = new GeneratedCodeLogger(FileTypeToLog.RESPONSE, LOG);
 
     @Rule
     public TemporaryFolder tempFolder = new TemporaryFolder();
@@ -150,6 +150,7 @@ public class NetFunctionalTests {
         assertTrue(TestHelper.hasProperty("Verb", "HttpVerb", requestCode));
         assertTrue(TestHelper.hasProperty("Path", "string", requestCode));
 
+        assertTrue(TestHelper.hasOptionalParam(requestName, "VersionId", "string", requestCode));
         assertTrue(TestHelper.hasRequiredParam("BucketName", "string", requestCode));
         assertTrue(TestHelper.hasRequiredParam("ObjectName", "string", requestCode));
         assertTrue(TestHelper.hasRequiredParam("Job", "string", requestCode));
@@ -693,7 +694,7 @@ public class NetFunctionalTests {
 
         assertFalse(TestHelper.hasRequiredParam("Blobs", "bool", requestCode));
         assertTrue(TestHelper.hasRequiredParam("BucketId", "string", requestCode));
-        assertTrue(TestHelper.hasRequiredParam("StorageDomainId", "string", requestCode));
+        assertTrue(TestHelper.hasRequiredParam("StorageDomain", "string", requestCode));
         assertTrue(TestHelper.hasRequiredParam("Objects", "IEnumerable<Ds3Object>", requestCode));
 
         assertTrue(TestHelper.hasOptionalParam(requestName, "EjectLabel", "string", requestCode));
@@ -701,7 +702,7 @@ public class NetFunctionalTests {
 
         final ImmutableList<Arguments> constructorArgs = ImmutableList.of(
                 new Arguments("Guid", "BucketId"),
-                new Arguments("Guid", "StorageDomainId"),
+                new Arguments("string", "StorageDomain"),
                 new Arguments("IEnumerable<Ds3Object>", "Objects"));
         assertTrue(TestHelper.hasConstructor(requestName, constructorArgs, requestCode));
         assertTrue(TestHelper.hasConstructor(requestName, modifyType(constructorArgs, "Guid", "string"), requestCode));
@@ -1649,5 +1650,88 @@ public class NetFunctionalTests {
         CODE_LOGGER.logFile(parserCode, FileTypeToLog.PARSER);
         assertTrue(parserHasResponseCode(200, parserCode));
         assertTrue(parserHasPayload(responseType, responseType, parserCode));
+    }
+
+    @Test
+    public void stageObjectsJobTest() throws IOException, TemplateModelException {
+        final String requestName = "StageObjectsJobSpectraS3Request";
+        final FileUtils fileUtils = mock(FileUtils.class);
+        final TestGenerateCode codeGenerator = new TestGenerateCode(
+                fileUtils,
+                requestName,
+                "./Ds3/Calls/",
+                "MasterObjectList");
+
+        codeGenerator.generateCode(fileUtils, "/input/stageObjectsJob.xml");
+
+        //Generate Request code
+        final String requestCode = codeGenerator.getRequestCode();
+        CODE_LOGGER.logFile(requestCode, FileTypeToLog.REQUEST);
+
+        assertTrue(requestCode.contains("using Ds3.Calls.Util;"));
+        assertTrue(requestCode.contains("using Ds3.Models;"));
+        assertTrue(requestCode.contains("using System;"));
+        assertTrue(requestCode.contains("using System.Collections.Generic;"));
+        assertTrue(requestCode.contains("using System.IO;"));
+        assertTrue(requestCode.contains("using System.Linq;"));
+
+        assertTrue(TestHelper.extendsClass(requestName, "Ds3Request", requestCode));
+        assertTrue(TestHelper.hasProperty("Verb", "HttpVerb", requestCode));
+        assertTrue(TestHelper.hasProperty("Path", "string", requestCode));
+
+        assertTrue(TestHelper.hasRequiredParam("BucketName", "string", requestCode));
+        assertTrue(TestHelper.hasRequiredParam("FullObjects", "IEnumerable<string>", requestCode));
+        assertTrue(TestHelper.hasRequiredParam("PartialObjects", "IEnumerable<Ds3PartialObject>", requestCode));
+
+        assertFalse(TestHelper.hasOptionalParam(requestName, "ChunkClientProcessingOrderGuarantee?", "JobChunkClientProcessingOrderGuarantee?", requestCode));
+        assertFalse(TestHelper.hasOptionalParam(requestName, "Aggregating", "bool?", requestCode));
+        assertTrue(TestHelper.hasOptionalParam(requestName, "Name", "string", requestCode));
+        assertTrue(TestHelper.hasOptionalParam(requestName, "Priority", "Priority?", requestCode));
+
+        final ImmutableList<Arguments> constructorArgs = ImmutableList.of(
+                new Arguments("String", "BucketName"),
+                new Arguments("IEnumerable<string>", "FullObjects"),
+                new Arguments("IEnumerable<Ds3PartialObject>", "PartialObjects"));
+        assertTrue(TestHelper.hasConstructor(requestName, constructorArgs, requestCode));
+
+        final ImmutableList<Arguments> secondConstructorArgs = ImmutableList.of(
+                new Arguments("String", "BucketName"),
+                new Arguments("List<Ds3Object>", "Ds3Objects"));
+        assertTrue(TestHelper.hasConstructor(requestName, secondConstructorArgs, requestCode));
+
+        assertTrue(requestCode.contains("this.QueryParams.Add(\"operation\", \"start_bulk_stage\");"));
+        assertTrue(requestCode.contains("internal override Stream GetContentStream()"));
+        assertTrue(requestCode.contains("return RequestPayloadUtil.MarshalFullAndPartialObjects(this.FullObjects, this.PartialObjects);"));
+        assertFalse(requestCode.contains("private static string BuildChunkOrderingEnumString(JobChunkClientProcessingOrderGuarantee chunkClientProcessingOrderGuarantee)"));
+
+        //Generate Client code
+        final String commandName = requestName.replace("Request", "");
+        final String clientCode = codeGenerator.getClientCode();
+        CODE_LOGGER.logFile(clientCode, FileTypeToLog.CLIENT);
+
+        assertTrue(TestHelper.hasPayloadCommand(commandName, clientCode));
+
+        final String idsClientCode = codeGenerator.getIdsClientCode();
+        CODE_LOGGER.logFile(idsClientCode, FileTypeToLog.CLIENT);
+
+        assertTrue(TestHelper.hasIDsCommand(commandName, idsClientCode));
+
+        //Generate Responses
+        final String responseCode = codeGenerator.getResponseCode();
+        CODE_LOGGER.logFile(responseCode, FileTypeToLog.RESPONSE);
+
+        final String responseName = NormalizingContractNamesUtil.toResponseName(requestName);
+        final String responsePayloadType = "MasterObjectList";
+        assertTrue(TestHelper.hasConstructor(
+                responseName,
+                ImmutableList.of(new Arguments(responsePayloadType, "ResponsePayload")),
+                responseCode));
+        assertTrue(TestHelper.hasRequiredParam("ResponsePayload", responsePayloadType, responseCode));
+
+        //Generate Parser
+        final String parserCode = codeGenerator.getParserCode();
+        CODE_LOGGER.logFile(parserCode, FileTypeToLog.PARSER);
+        assertTrue(parserCode.contains("ResponseParseUtilities.HandleStatusCode(response, (HttpStatusCode)200, HttpStatusCode.ServiceUnavailable)"));
+        assertTrue(parserHasPayload("MasterObjectList", "MasterObjectList", parserCode));
     }
 }

--- a/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/generators/requestmodels/GetObjectRequestGenerator_Test.java
+++ b/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/generators/requestmodels/GetObjectRequestGenerator_Test.java
@@ -18,7 +18,7 @@ package com.spectralogic.ds3autogen.net.generators.requestmodels;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.spectralogic.ds3autogen.api.models.Arguments;
-import com.spectralogic.ds3autogen.api.models.apispec.Ds3Param;
+import com.spectralogic.ds3autogen.api.models.apispec.Ds3Request;
 import com.spectralogic.ds3autogen.net.model.common.NetNullableVariable;
 import org.junit.Test;
 
@@ -45,12 +45,12 @@ public class GetObjectRequestGenerator_Test {
 
     @Test
     public void toOptionalArgumentsList_FullList_Test() {
-        final ImmutableList<Ds3Param> params = ImmutableList.of(
-                new Ds3Param("SimpleArg", "SimpleType", false),
-                new Ds3Param("ArgWithPath", "com.test.TypeWithPath", false));
+        final Ds3Request request = getRequestAmazonS3GetObject();
+        final ImmutableList<NetNullableVariable> result = generator.toOptionalArgumentsList(request.getOptionalQueryParams(), ImmutableMap.of());
 
-        final ImmutableList<NetNullableVariable> result = generator.toOptionalArgumentsList(params, ImmutableMap.of());
-        assertThat(result.size(), is(0));
+        assertThat(result.size(), is(1));
+        assertThat(result.get(0).getName(), is("VersionId"));
+        assertThat(result.get(0).getNetType(), is("Guid?"));
     }
 
     @Test

--- a/ds3-autogen-net/src/test/resources/input/ejectStorageDomainBlobsRequest.xml
+++ b/ds3-autogen-net/src/test/resources/input/ejectStorageDomainBlobsRequest.xml
@@ -11,7 +11,7 @@
                         <Param Name="Blobs" Type="void"/>
                         <Param Name="BucketId" Type="java.util.UUID"/>
                         <Param Name="Operation" Type="com.spectralogic.s3.server.request.rest.RestOperationType"/>
-                        <Param Name="StorageDomainId" Type="java.util.UUID"/>
+                        <Param Name="StorageDomain" Type="java.lang.String"/>
                     </RequiredQueryParams>
                 </Request>
                 <ResponseCodes>
@@ -28,7 +28,7 @@
                         </ResponseTypes>
                     </ResponseCode>
                 </ResponseCodes>
-                <Version>1.D07A22B79C602A5E8C570C5E049FD7AB</Version>
+                <Version>1.221F7DCAF04AE6EB1BADF4997871733E</Version>
             </RequestHandler>
         </RequestHandlers>
     </Contract>

--- a/ds3-autogen-net/src/test/resources/input/getObjectRequest.xml
+++ b/ds3-autogen-net/src/test/resources/input/getObjectRequest.xml
@@ -6,6 +6,7 @@
                     <OptionalQueryParams>
                         <Param Name="Job" Type="java.util.UUID"/>
                         <Param Name="Offset" Type="long"/>
+                        <Param Name="VersionId" Type="java.util.UUID"/>
                     </OptionalQueryParams>
                     <RequiredQueryParams/>
                 </Request>
@@ -35,13 +36,13 @@
                         </ResponseTypes>
                     </ResponseCode>
                     <ResponseCode>
-                        <Code>503</Code>
+                        <Code>404</Code>
                         <ResponseTypes>
                             <ResponseType Type="com.spectralogic.s3.server.domain.HttpErrorResultApiBean"/>
                         </ResponseTypes>
                     </ResponseCode>
                 </ResponseCodes>
-                <Version>1.F50E6F8DEFB864FE89D9385A71A6C25A</Version>
+                <Version>1.9E10AB31443900A845A6A64AACDA46A8</Version>
             </RequestHandler>
         </RequestHandlers>
     </Contract>

--- a/ds3-autogen-net/src/test/resources/input/stageObjectsJob.xml
+++ b/ds3-autogen-net/src/test/resources/input/stageObjectsJob.xml
@@ -1,0 +1,169 @@
+<Data>
+    <Contract>
+        <RequestHandlers>
+            <RequestHandler Classification="spectrads3" Name="com.spectralogic.s3.server.handler.reqhandler.spectrads3.job.StageObjectsJobRequestHandler">
+                <Request Action="MODIFY" HttpVerb="PUT" IncludeIdInPath="true" Operation="START_BULK_STAGE" Resource="BUCKET" ResourceType="NON_SINGLETON">
+                    <OptionalQueryParams>
+                        <Param Name="Name" Type="java.lang.String"/>
+                        <Param Name="Priority" Type="com.spectralogic.s3.common.dao.domain.ds3.BlobStoreTaskPriority"/>
+                    </OptionalQueryParams>
+                    <RequiredQueryParams>
+                        <Param Name="Operation" Type="com.spectralogic.s3.server.request.rest.RestOperationType"/>
+                    </RequiredQueryParams>
+                </Request>
+                <ResponseCodes>
+                    <ResponseCode>
+                        <Code>200</Code> <!-- Manually added the expected 200 response -->
+                        <ResponseTypes>
+                            <ResponseType Type="com.spectralogic.s3.server.domain.JobWithChunksApiBean"/>
+                        </ResponseTypes>
+                    </ResponseCode>
+                    <ResponseCode>
+                        <Code>400</Code>
+                        <ResponseTypes>
+                            <ResponseType Type="com.spectralogic.s3.server.domain.HttpErrorResultApiBean"/>
+                        </ResponseTypes>
+                    </ResponseCode>
+                </ResponseCodes>
+                <Version>1.0D522E432703A7E48DBEDD1A6BB5CEF8</Version>
+            </RequestHandler>
+        </RequestHandlers>
+        <Types>
+            <Type Name="com.spectralogic.s3.server.domain.JobWithChunksApiBean" NameToMarshal="MasterObjectList">
+                <Elements>
+                    <Element Name="Aggregating" Type="boolean">
+                        <Annotations>
+                            <Annotation Name="com.spectralogic.util.marshal.MarshalXmlAsAttribute">
+                                <AnnotationElements/>
+                            </Annotation>
+                        </Annotations>
+                    </Element>
+                    <Element Name="BucketName" Type="java.lang.String">
+                        <Annotations>
+                            <Annotation Name="com.spectralogic.util.marshal.MarshalXmlAsAttribute">
+                                <AnnotationElements/>
+                            </Annotation>
+                        </Annotations>
+                    </Element>
+                    <Element Name="CachedSizeInBytes" Type="long">
+                        <Annotations>
+                            <Annotation Name="com.spectralogic.util.marshal.MarshalXmlAsAttribute">
+                                <AnnotationElements/>
+                            </Annotation>
+                        </Annotations>
+                    </Element>
+                    <Element Name="ChunkClientProcessingOrderGuarantee" Type="com.spectralogic.s3.common.dao.domain.ds3.JobChunkClientProcessingOrderGuarantee">
+                        <Annotations>
+                            <Annotation Name="com.spectralogic.util.marshal.MarshalXmlAsAttribute">
+                                <AnnotationElements/>
+                            </Annotation>
+                        </Annotations>
+                    </Element>
+                    <Element Name="CompletedSizeInBytes" Type="long">
+                        <Annotations>
+                            <Annotation Name="com.spectralogic.util.marshal.MarshalXmlAsAttribute">
+                                <AnnotationElements/>
+                            </Annotation>
+                        </Annotations>
+                    </Element>
+                    <Element Name="JobId" Type="java.util.UUID">
+                        <Annotations>
+                            <Annotation Name="com.spectralogic.util.marshal.MarshalXmlAsAttribute">
+                                <AnnotationElements/>
+                            </Annotation>
+                        </Annotations>
+                    </Element>
+                    <Element Name="Naked" Type="boolean">
+                        <Annotations>
+                            <Annotation Name="com.spectralogic.util.marshal.MarshalXmlAsAttribute">
+                                <AnnotationElements/>
+                            </Annotation>
+                        </Annotations>
+                    </Element>
+                    <Element Name="Name" Type="java.lang.String">
+                        <Annotations>
+                            <Annotation Name="com.spectralogic.util.marshal.MarshalXmlAsAttribute">
+                                <AnnotationElements/>
+                            </Annotation>
+                        </Annotations>
+                    </Element>
+                    <Element ComponentType="com.spectralogic.s3.server.domain.NodeApiBean" Name="Nodes" Type="array">
+                        <Annotations>
+                            <Annotation Name="com.spectralogic.util.marshal.CustomMarshaledName">
+                                <AnnotationElements>
+                                    <AnnotationElement Name="CollectionValue" Value="Nodes" ValueType="java.lang.String"/>
+                                    <AnnotationElement Name="CollectionValueRenderingMode" Value="SINGLE_BLOCK_FOR_ALL_ELEMENTS" ValueType="com.spectralogic.util.marshal.CustomMarshaledName$CollectionNameRenderingMode"/>
+                                    <AnnotationElement Name="Value" Value="Node" ValueType="java.lang.String"/>
+                                </AnnotationElements>
+                            </Annotation>
+                            <Annotation Name="com.spectralogic.util.marshal.ExcludeFromMarshaler">
+                                <AnnotationElements>
+                                    <AnnotationElement Name="Value" Value="VALUE_IS_NULL" ValueType="com.spectralogic.util.marshal.ExcludeFromMarshaler$When"/>
+                                </AnnotationElements>
+                            </Annotation>
+                        </Annotations>
+                    </Element>
+                    <Element ComponentType="com.spectralogic.s3.server.domain.JobChunkApiBean" Name="Objects" Type="array">
+                        <Annotations/>
+                    </Element>
+                    <Element Name="OriginalSizeInBytes" Type="long">
+                        <Annotations>
+                            <Annotation Name="com.spectralogic.util.marshal.MarshalXmlAsAttribute">
+                                <AnnotationElements/>
+                            </Annotation>
+                        </Annotations>
+                    </Element>
+                    <Element Name="Priority" Type="com.spectralogic.s3.common.dao.domain.ds3.BlobStoreTaskPriority">
+                        <Annotations>
+                            <Annotation Name="com.spectralogic.util.marshal.MarshalXmlAsAttribute">
+                                <AnnotationElements/>
+                            </Annotation>
+                        </Annotations>
+                    </Element>
+                    <Element Name="RequestType" Type="com.spectralogic.s3.common.dao.domain.ds3.JobRequestType">
+                        <Annotations>
+                            <Annotation Name="com.spectralogic.util.marshal.MarshalXmlAsAttribute">
+                                <AnnotationElements/>
+                            </Annotation>
+                        </Annotations>
+                    </Element>
+                    <Element Name="StartDate" Type="java.util.Date">
+                        <Annotations>
+                            <Annotation Name="com.spectralogic.util.marshal.MarshalXmlAsAttribute">
+                                <AnnotationElements/>
+                            </Annotation>
+                        </Annotations>
+                    </Element>
+                    <Element Name="Status" Type="com.spectralogic.s3.server.domain.JobStatus">
+                        <Annotations>
+                            <Annotation Name="com.spectralogic.util.marshal.MarshalXmlAsAttribute">
+                                <AnnotationElements/>
+                            </Annotation>
+                        </Annotations>
+                    </Element>
+                    <Element Name="UserId" Type="java.util.UUID">
+                        <Annotations>
+                            <Annotation Name="com.spectralogic.util.marshal.MarshalXmlAsAttribute">
+                                <AnnotationElements/>
+                            </Annotation>
+                        </Annotations>
+                    </Element>
+                    <Element Name="UserName" Type="java.lang.String">
+                        <Annotations>
+                            <Annotation Name="com.spectralogic.util.marshal.MarshalXmlAsAttribute">
+                                <AnnotationElements/>
+                            </Annotation>
+                        </Annotations>
+                    </Element>
+                    <Element Name="WriteOptimization" Type="com.spectralogic.s3.common.dao.domain.ds3.WriteOptimization">
+                        <Annotations>
+                            <Annotation Name="com.spectralogic.util.marshal.MarshalXmlAsAttribute">
+                                <AnnotationElements/>
+                            </Annotation>
+                        </Annotations>
+                    </Element>
+                </Elements>
+            </Type>
+        </Types>
+    </Contract>
+</Data>


### PR DESCRIPTION
**Changes**
- Special cased StageObjectsJob request handler
- Fixed incorrect generation of GetObject (AmazonS3) request handler due to new optional query param `VersionId`
- Updated test xml inputs to reflect changes in 5.0 API

Generates .Net SDK code found in PR: https://github.com/SpectraLogic/ds3_net_sdk/pull/296

**Note**
Tests are known to be broken in Go and Python modules as shared utilities are updated from 4.1 to 5.0 API target.