### PR TITLE
SA-195 & SA-196: Special cased commands with request payload of id list in python modules

### DIFF
--- a/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/PythonCodeGenerator.java
+++ b/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/PythonCodeGenerator.java
@@ -232,7 +232,18 @@ public class PythonCodeGenerator implements CodeGenerator, PythonCodeGeneratorIn
                 || isBulkReplicateRequest(ds3Request)) {
             return new StringPayloadGenerator();
         }
+        if (hasIdsRequestPayload(ds3Request)) {
+            return getIdsRequestGenerator();
+        }
         return new BaseRequestGenerator();
+    }
+
+    /**
+     * Retrieves the generator for the clear blob and mark blob commands
+     */
+    @Override
+    public BaseRequestGenerator getIdsRequestGenerator() {
+        return new IdListRequestPayloadGenerator();
     }
 
     /**

--- a/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/generators/request/IdListRequestPayloadGenerator.java
+++ b/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/generators/request/IdListRequestPayloadGenerator.java
@@ -1,0 +1,64 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2018 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.python.generators.request;
+
+import com.google.common.collect.ImmutableList;
+import com.spectralogic.ds3autogen.api.models.Arguments;
+import com.spectralogic.ds3autogen.api.models.apispec.Ds3Request;
+import com.spectralogic.ds3autogen.python.model.request.ConstructorParam;
+import com.spectralogic.ds3autogen.utils.collections.GuavaCollectors;
+import com.spectralogic.ds3autogen.utils.comparators.CustomArgumentComparator;
+
+import static com.spectralogic.ds3autogen.python.helpers.PythonHelper.pythonIndent;
+import static com.spectralogic.ds3autogen.utils.Helper.camelToUnderscore;
+import static com.spectralogic.ds3autogen.utils.RequestConverterUtil.getNonVoidArgsFromParamList;
+
+/**
+ * Generates Python request handlers that take in a list of strings and marshals them into a list of ids.
+ */
+public class IdListRequestPayloadGenerator extends BaseRequestGenerator {
+
+    protected static final String PAYLOAD_NAME = "id_list";
+
+    /**
+     * Gets the sorted list of required constructor parameters including the request payload
+     */
+    @Override
+    public ImmutableList<ConstructorParam> toRequiredConstructorParams(final Ds3Request ds3Request) {
+        final ImmutableList.Builder<Arguments> builder = ImmutableList.builder();
+        builder.addAll(getNonVoidArgsFromParamList(ds3Request.getRequiredQueryParams()));
+        builder.addAll(getAssignmentArguments(ds3Request));
+        builder.add(new Arguments("string", PAYLOAD_NAME));
+
+        return builder.build().stream()
+                .sorted(new CustomArgumentComparator())
+                .map(arg -> new ConstructorParam(camelToUnderscore(arg.getName()), false))
+                .collect(GuavaCollectors.immutableList());
+    }
+
+    /**
+     * Gets the python code that handles processing the request payload and headers
+     */
+    @Override
+    public String getAdditionalContent(final Ds3Request ds3Request, final String requestName) {
+        return "if " + PAYLOAD_NAME + " is not None:\n" +
+                pythonIndent(3) + "if not (isinstance(cur_id, basestring) for cur_id in " + PAYLOAD_NAME + "):\n" +
+                pythonIndent(4) + "raise TypeError(\n" +
+                pythonIndent(5) + "'" + requestName + " should have request payload of type: list of strings')\n" +
+                pythonIndent(3) + "xml_id_list = IdsList(" + PAYLOAD_NAME + ")\n" +
+                pythonIndent(3) + "self.body = xmldom.tostring(xml_id_list.to_xml())\n";
+    }
+}

--- a/ds3-autogen-python/src/main/kotlin/com/spectralogic/ds3autogen/python/PythonCodeGeneratorInterface.kt
+++ b/ds3-autogen-python/src/main/kotlin/com/spectralogic/ds3autogen/python/PythonCodeGeneratorInterface.kt
@@ -21,7 +21,6 @@ import com.spectralogic.ds3autogen.api.models.apispec.Ds3Request
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3Type
 import com.spectralogic.ds3autogen.api.models.docspec.Ds3DocSpec
 import com.spectralogic.ds3autogen.python.generators.request.BaseRequestGenerator
-import com.spectralogic.ds3autogen.python.generators.request.RequestModelGenerator
 import com.spectralogic.ds3autogen.python.model.request.BaseRequest
 import freemarker.template.Configuration
 import freemarker.template.Template
@@ -39,6 +38,8 @@ interface PythonCodeGeneratorInterface {
     fun getCommandTemplate(config: Configuration) : Template
 
     fun getPutObjectRequestGenerator() : BaseRequestGenerator
+
+    fun getIdsRequestGenerator(): BaseRequestGenerator
 
     fun getRequestGenerator(ds3Request: Ds3Request) : BaseRequestGenerator
 

--- a/ds3-autogen-python/src/main/resources/tmpls/python/commands/all_commands.ftl
+++ b/ds3-autogen-python/src/main/resources/tmpls/python/commands/all_commands.ftl
@@ -17,6 +17,22 @@ from ds3network import *
 <#include "static_classes.ftl" />
 
 
+class IdsList(object):
+    def __init__(self, id_list):
+        for cur_id in id_list:
+            if not isinstance(cur_id, basestring):
+                raise TypeError("Ids should only contain strings")
+        self.id_list = id_list
+
+    def to_xml(self):
+        xml_id_list = xmldom.Element('Ids')
+        for cur_id in self.id_list:
+            xml_cur_id = xmldom.Element('Id')
+            xml_cur_id.text = cur_id
+            xml_id_list.append(xml_cur_id)
+        return xml_id_list
+
+
 # Type Descriptors
 
 

--- a/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/PythonCodeGenerator_Test.java
+++ b/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/PythonCodeGenerator_Test.java
@@ -72,6 +72,17 @@ public class PythonCodeGenerator_Test {
         assertThat(generator.getRequestGenerator(getGetBlobPersistence()), instanceOf(StringPayloadGenerator.class));
         assertThat(generator.getRequestGenerator(getReplicatePutJob()), instanceOf(StringPayloadGenerator.class));
 
+        assertThat(generator.getRequestGenerator(clearSuspectBlobAzureTargetsRequest()), instanceOf(IdListRequestPayloadGenerator.class));
+        assertThat(generator.getRequestGenerator(clearSuspectBlobDs3TargetsRequest()), instanceOf(IdListRequestPayloadGenerator.class));
+        assertThat(generator.getRequestGenerator(clearSuspectBlobPoolsRequest()), instanceOf(IdListRequestPayloadGenerator.class));
+        assertThat(generator.getRequestGenerator(clearSuspectBlobS3TargetsRequest()), instanceOf(IdListRequestPayloadGenerator.class));
+        assertThat(generator.getRequestGenerator(clearSuspectBlobTapesRequest()), instanceOf(IdListRequestPayloadGenerator.class));
+        assertThat(generator.getRequestGenerator(markSuspectBlobAzureTargetsAsDegradedRequest()), instanceOf(IdListRequestPayloadGenerator.class));
+        assertThat(generator.getRequestGenerator(markSuspectBlobDs3TargetsAsDegradedRequest()), instanceOf(IdListRequestPayloadGenerator.class));
+        assertThat(generator.getRequestGenerator(markSuspectBlobPoolsAsDegradedRequest()), instanceOf(IdListRequestPayloadGenerator.class));
+        assertThat(generator.getRequestGenerator(markSuspectBlobS3TargetsAsDegradedRequest()), instanceOf(IdListRequestPayloadGenerator.class));
+        assertThat(generator.getRequestGenerator(markSuspectBlobTapesAsDegradedRequest()), instanceOf(IdListRequestPayloadGenerator.class));
+
         assertThat(generator.getRequestGenerator(getRequestBulkGet()), instanceOf(ObjectsPayloadGenerator.class));
         assertThat(generator.getRequestGenerator(getRequestBulkPut()), instanceOf(ObjectsPayloadGenerator.class));
         assertThat(generator.getRequestGenerator(getRequestVerifyPhysicalPlacement()), instanceOf(ObjectsPayloadGenerator.class));

--- a/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/PythonFunctionalTests.java
+++ b/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/PythonFunctionalTests.java
@@ -308,4 +308,31 @@ public class PythonFunctionalTests {
         //Test Client
         hasClient(ImmutableList.of(requestName), ds3Code);
     }
+
+    @Test
+    public void clearSuspectBlobAzureTargetsRequest() throws IOException, TemplateModelException {
+        final String requestName = "ClearSuspectBlobAzureTargetsSpectraS3Request";
+        final FileUtils fileUtils = mock(FileUtils.class);
+        final TestPythonGeneratedCode codeGenerator = new TestPythonGeneratedCode(fileUtils);
+
+        codeGenerator.generateCode(fileUtils, "/input/requests/clearSuspectBlobAzureTargets.xml");
+        final String ds3Code = codeGenerator.getDs3Code();
+
+        CODE_LOGGER.logFile(ds3Code, FileTypeToLog.REQUEST);
+
+        final ImmutableList<String> optArgs = ImmutableList.of("force");
+        final String requestPayload = "id_list";
+
+        hasRequestHandler(requestName, HttpVerb.DELETE, ImmutableList.of(), optArgs, ImmutableList.of(), requestPayload, ds3Code);
+
+        assertTrue(ds3Code.contains("if id_list is not None:\n" +
+                "            if not (isinstance(cur_id, basestring) for cur_id in id_list):\n" +
+                "                raise TypeError(\n" +
+                "                    'ClearSuspectBlobAzureTargetsSpectraS3Request should have request payload of type: list of strings')\n" +
+                "            xml_id_list = IdsList(id_list)\n" +
+                "            self.body = xmldom.tostring(xml_id_list.to_xml())"));
+
+        //Test Client
+        hasClient(ImmutableList.of(requestName), ds3Code);
+    }
 }

--- a/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/generators/request/IdListRequestPayloadGenerator_Test.java
+++ b/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/generators/request/IdListRequestPayloadGenerator_Test.java
@@ -1,0 +1,56 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2018 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.python.generators.request;
+
+import com.google.common.collect.ImmutableList;
+import com.spectralogic.ds3autogen.python.model.request.ConstructorParam;
+import com.spectralogic.ds3autogen.utils.collections.GuavaCollectors;
+import org.junit.Test;
+
+import static com.spectralogic.ds3autogen.testutil.Ds3ModelFixtures.clearSuspectBlobAzureTargetsRequest;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class IdListRequestPayloadGenerator_Test {
+
+    private static final IdListRequestPayloadGenerator generator = new IdListRequestPayloadGenerator();
+
+    @Test
+    public void getAdditionalContentTest() {
+        final String expected = "if id_list is not None:\n" +
+                "            if not (isinstance(cur_id, basestring) for cur_id in id_list):\n" +
+                "                raise TypeError(\n" +
+                "                    'ClearSuspectBlobAzureTargetsSpectraS3Request should have request payload of type: list of strings')\n" +
+                "            xml_id_list = IdsList(id_list)\n" +
+                "            self.body = xmldom.tostring(xml_id_list.to_xml())\n";
+        final String result = generator.getAdditionalContent(clearSuspectBlobAzureTargetsRequest(), "ClearSuspectBlobAzureTargetsSpectraS3Request");
+        assertThat(result, is(expected));
+    }
+
+    @Test
+    public void toRequiredConstructorParamsTest() {
+        final ImmutableList<ConstructorParam> reqParams = generator
+                .toRequiredConstructorParams(clearSuspectBlobAzureTargetsRequest());
+
+        final ImmutableList<String> result = reqParams.stream()
+                .map(ConstructorParam::toPythonCode)
+                .collect(GuavaCollectors.immutableList());
+
+        assertThat(result.size(), is(1));
+        assertThat(result, hasItem("id_list"));
+    }
+}

--- a/ds3-autogen-python/src/test/resources/input/requests/clearSuspectBlobAzureTargets.xml
+++ b/ds3-autogen-python/src/test/resources/input/requests/clearSuspectBlobAzureTargets.xml
@@ -1,0 +1,35 @@
+<Data>
+    <Contract>
+        <RequestHandlers>
+            <RequestHandler Classification="spectrads3" Name="com.spectralogic.s3.server.handler.reqhandler.spectrads3.degradation.ClearSuspectBlobAzureTargetsRequestHandler">
+                <Request Action="BULK_DELETE" HttpVerb="DELETE" IncludeIdInPath="false" Resource="SUSPECT_BLOB_AZURE_TARGET" ResourceType="NON_SINGLETON">
+                    <OptionalQueryParams>
+                        <Param Name="Force" Type="void"/>
+                    </OptionalQueryParams>
+                    <RequiredQueryParams/>
+                </Request>
+                <ResponseCodes>
+                    <ResponseCode>
+                        <Code>204</Code>
+                        <ResponseTypes>
+                            <ResponseType Type="null"/>
+                        </ResponseTypes>
+                    </ResponseCode>
+                    <ResponseCode>
+                        <Code>400</Code>
+                        <ResponseTypes>
+                            <ResponseType Type="com.spectralogic.s3.server.domain.HttpErrorResultApiBean"/>
+                        </ResponseTypes>
+                    </ResponseCode>
+                    <ResponseCode>
+                        <Code>409</Code>
+                        <ResponseTypes>
+                            <ResponseType Type="com.spectralogic.s3.server.domain.HttpErrorResultApiBean"/>
+                        </ResponseTypes>
+                    </ResponseCode>
+                </ResponseCodes>
+                <Version>1.F51C99474F629A2CFD5CDB6BC5CB7C6D</Version>
+            </RequestHandler>
+        </RequestHandlers>
+    </Contract>
+</Data>

--- a/ds3-autogen-python3/src/main/kotlin/com/spectralogic/ds3autogen/python3/Python3CodeGenerator.kt
+++ b/ds3-autogen-python3/src/main/kotlin/com/spectralogic/ds3autogen/python3/Python3CodeGenerator.kt
@@ -17,11 +17,12 @@ package com.spectralogic.ds3autogen.python3
 
 import com.spectralogic.ds3autogen.python.PythonCodeGenerator
 import com.spectralogic.ds3autogen.python.generators.request.BaseRequestGenerator
+import com.spectralogic.ds3autogen.python3.generators.request.P3IdListRequestGenerator
 import com.spectralogic.ds3autogen.python3.generators.request.P3PutObjectRequestGenerator
 import freemarker.template.Configuration
 import freemarker.template.Template
 
-class Python3CodeGenerator() : PythonCodeGenerator() {
+class Python3CodeGenerator : PythonCodeGenerator() {
 
     /**
      * Retrieves the base command template used to generate the Python 3 ds3.py
@@ -35,5 +36,12 @@ class Python3CodeGenerator() : PythonCodeGenerator() {
      */
     override fun getPutObjectRequestGenerator() : BaseRequestGenerator {
         return P3PutObjectRequestGenerator()
+    }
+
+    /**
+     * Retrieves the generator for the Python 3 clear blob and mark blob commands
+     */
+    override fun getIdsRequestGenerator(): BaseRequestGenerator {
+        return P3IdListRequestGenerator()
     }
 }

--- a/ds3-autogen-python3/src/main/kotlin/com/spectralogic/ds3autogen/python3/generators/request/P3IdListRequestGenerator.kt
+++ b/ds3-autogen-python3/src/main/kotlin/com/spectralogic/ds3autogen/python3/generators/request/P3IdListRequestGenerator.kt
@@ -1,0 +1,38 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2018 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.python3.generators.request
+
+import com.spectralogic.ds3autogen.api.models.apispec.Ds3Request
+import com.spectralogic.ds3autogen.python.generators.request.IdListRequestPayloadGenerator
+import com.spectralogic.ds3autogen.python.helpers.PythonHelper.pythonIndent
+
+/**
+ * Creates the Python 3 request model for the clear blob and mark blob commands
+ */
+class P3IdListRequestGenerator : IdListRequestPayloadGenerator() {
+
+    /**
+     * Gets the Python 3 code that handles processing the request payload and headers
+     */
+    override fun getAdditionalContent(ds3Request: Ds3Request, requestName : String) : String {
+        return "if $PAYLOAD_NAME is not None:\n" +
+                pythonIndent(3) + "if not (isinstance(cur_id, str) for cur_id in $PAYLOAD_NAME):\n" +
+                pythonIndent(4) + "raise TypeError(\n" +
+                pythonIndent(5) + "'" + requestName + " should have request payload of type: list of strings')\n" +
+                pythonIndent(3) + "xml_id_list = IdsList($PAYLOAD_NAME)\n" +
+                pythonIndent(3) + "self.body = xmldom.tostring(xml_id_list.to_xml())\n"
+    }
+}

--- a/ds3-autogen-python3/src/main/resources/tmpls/python3/commands/p3_all_commands.ftl
+++ b/ds3-autogen-python3/src/main/resources/tmpls/python3/commands/p3_all_commands.ftl
@@ -17,6 +17,22 @@ from .ds3network import *
 <#include "../../python/commands/static_classes.ftl" />
 
 
+class IdsList(object):
+    def __init__(self, id_list):
+        for cur_id in id_list:
+            if not isinstance(cur_id, str):
+                raise TypeError("Ids should only contain strings")
+        self.id_list = id_list
+
+    def to_xml(self):
+        xml_id_list = xmldom.Element('Ids')
+        for cur_id in self.id_list:
+            xml_cur_id = xmldom.Element('Id')
+            xml_cur_id.text = cur_id
+            xml_id_list.append(xml_cur_id)
+        return xml_id_list
+
+
 # Type Descriptors
 
 

--- a/ds3-autogen-python3/src/test/java/com/spectralogic/ds3autogen/python3/Python3FunctionalTests.java
+++ b/ds3-autogen-python3/src/test/java/com/spectralogic/ds3autogen/python3/Python3FunctionalTests.java
@@ -30,9 +30,7 @@ import java.io.IOException;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
 
 public class Python3FunctionalTests {
@@ -86,5 +84,23 @@ public class Python3FunctionalTests {
 
         assertTrue(ds3Code.contains("for key, val in headers.items():"));
         assertFalse(ds3Code.contains("for key, val in headers.iteritems():"));
+    }
+
+    @Test
+    public void clearSuspectBlobAzureTargetsRequest() throws IOException, TemplateModelException {
+        final FileUtils fileUtils = mock(FileUtils.class);
+        final TestPython3GeneratedCode codeGenerator = new TestPython3GeneratedCode(fileUtils);
+
+        codeGenerator.generateCode(fileUtils, "/input/requests/clearSuspectBlobAzureTargets.xml");
+        final String ds3Code = codeGenerator.getDs3Code();
+
+        CODE_LOGGER.logFile(ds3Code, FileTypeToLog.REQUEST);
+
+        assertTrue(ds3Code.contains("if id_list is not None:\n" +
+                "            if not (isinstance(cur_id, str) for cur_id in id_list):\n" +
+                "                raise TypeError(\n" +
+                "                    'ClearSuspectBlobAzureTargetsSpectraS3Request should have request payload of type: list of strings')\n" +
+                "            xml_id_list = IdsList(id_list)\n" +
+                "            self.body = xmldom.tostring(xml_id_list.to_xml())"));
     }
 }

--- a/ds3-autogen-python3/src/test/java/com/spectralogic/ds3autogen/python3/generators/request/P3IdListRequestGenerator_Test.java
+++ b/ds3-autogen-python3/src/test/java/com/spectralogic/ds3autogen/python3/generators/request/P3IdListRequestGenerator_Test.java
@@ -1,0 +1,39 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2018 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3autogen.python3.generators.request;
+
+import org.junit.Test;
+
+import static com.spectralogic.ds3autogen.testutil.Ds3ModelFixtures.clearSuspectBlobPoolsRequest;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class P3IdListRequestGenerator_Test {
+
+    private static final P3IdListRequestGenerator generator = new P3IdListRequestGenerator();
+
+    @Test
+    public void getAdditionalContent_Test() {
+        final String expected = "if id_list is not None:\n" +
+                "            if not (isinstance(cur_id, str) for cur_id in id_list):\n" +
+                "                raise TypeError(\n" +
+                "                    'ClearSuspectBlobPoolsSpectraS3Request should have request payload of type: list of strings')\n" +
+                "            xml_id_list = IdsList(id_list)\n" +
+                "            self.body = xmldom.tostring(xml_id_list.to_xml())\n";
+        final String result = generator.getAdditionalContent(clearSuspectBlobPoolsRequest(), "ClearSuspectBlobPoolsSpectraS3Request");
+        assertThat(result, is(expected));
+    }
+}

--- a/ds3-autogen-python3/src/test/resources/input/requests/clearSuspectBlobAzureTargets.xml
+++ b/ds3-autogen-python3/src/test/resources/input/requests/clearSuspectBlobAzureTargets.xml
@@ -1,0 +1,35 @@
+<Data>
+    <Contract>
+        <RequestHandlers>
+            <RequestHandler Classification="spectrads3" Name="com.spectralogic.s3.server.handler.reqhandler.spectrads3.degradation.ClearSuspectBlobAzureTargetsRequestHandler">
+                <Request Action="BULK_DELETE" HttpVerb="DELETE" IncludeIdInPath="false" Resource="SUSPECT_BLOB_AZURE_TARGET" ResourceType="NON_SINGLETON">
+                    <OptionalQueryParams>
+                        <Param Name="Force" Type="void"/>
+                    </OptionalQueryParams>
+                    <RequiredQueryParams/>
+                </Request>
+                <ResponseCodes>
+                    <ResponseCode>
+                        <Code>204</Code>
+                        <ResponseTypes>
+                            <ResponseType Type="null"/>
+                        </ResponseTypes>
+                    </ResponseCode>
+                    <ResponseCode>
+                        <Code>400</Code>
+                        <ResponseTypes>
+                            <ResponseType Type="com.spectralogic.s3.server.domain.HttpErrorResultApiBean"/>
+                        </ResponseTypes>
+                    </ResponseCode>
+                    <ResponseCode>
+                        <Code>409</Code>
+                        <ResponseTypes>
+                            <ResponseType Type="com.spectralogic.s3.server.domain.HttpErrorResultApiBean"/>
+                        </ResponseTypes>
+                    </ResponseCode>
+                </ResponseCodes>
+                <Version>1.F51C99474F629A2CFD5CDB6BC5CB7C6D</Version>
+            </RequestHandler>
+        </RequestHandlers>
+    </Contract>
+</Data>

--- a/ds3-autogen-test-util/src/main/java/com/spectralogic/ds3autogen/testutil/Ds3ModelFixtures.java
+++ b/ds3-autogen-test-util/src/main/java/com/spectralogic/ds3autogen/testutil/Ds3ModelFixtures.java
@@ -1031,6 +1031,27 @@ public class Ds3ModelFixtures {
     }
 
     /**
+     * Retrieves the 4.0.0 contract request for ClearSuspectBlobDs3TargetsRequestHandler
+     */
+    public static Ds3Request clearSuspectBlobDs3TargetsRequest() {
+        return new Ds3Request(
+                "com.spectralogic.s3.server.handler.reqhandler.spectrads3.degradation.ClearSuspectBlobDs3TargetsRequestHandler",
+                HttpVerb.DELETE,
+                Classification.spectrads3,
+                null,
+                null,
+                Action.BULK_DELETE,
+                Resource.SUSPECT_BLOB_DS3_TARGET,
+                ResourceType.NON_SINGLETON,
+                null,
+                false,
+                null, // ds3ResponseCodes are in the Contract, but are currently omitted
+                ImmutableList.of(FORCE_PARAM), //optional params
+                ImmutableList.of() //required params
+        );
+    }
+
+    /**
      * Retrieves the 4.0.0 contract request for ClearSuspectBlobS3TargetsRequestHandler
      */
     public static Ds3Request clearSuspectBlobS3TargetsRequest() {

--- a/ds3-autogen-utils/src/main/java/com/spectralogic/ds3autogen/utils/Ds3RequestClassificationUtil.java
+++ b/ds3-autogen-utils/src/main/java/com/spectralogic/ds3autogen/utils/Ds3RequestClassificationUtil.java
@@ -401,6 +401,7 @@ public final class Ds3RequestClassificationUtil {
     public static boolean hasIdsRequestPayload(final Ds3Request ds3Request) {
         return isClearSuspectBlobAzureTargetsRequest(ds3Request)
                 || isClearSuspectBlobPoolsRequest(ds3Request)
+                || isClearSuspectBlobDs3TargetsRequest(ds3Request)
                 || isClearSuspectBlobS3TargetsRequest(ds3Request)
                 || isClearSuspectBlobTapesRequest(ds3Request)
                 || isMarkSuspectBlobAzureTargetsAsDegradedRequest(ds3Request)
@@ -408,6 +409,18 @@ public final class Ds3RequestClassificationUtil {
                 || isMarkSuspectBlobPoolsAsDegradedRequest(ds3Request)
                 || isMarkSuspectBlobS3TargetsAsDegradedRequest(ds3Request)
                 || isMarkSuspectBlobTapesAsDegradedRequest(ds3Request);
+    }
+
+    /**
+     * Determines if a Ds3Request is the SpectraDs3 command ClearSuspectBlobDs3TargetsRequestHandler
+     */
+    static boolean isClearSuspectBlobDs3TargetsRequest(final Ds3Request ds3Request) {
+        return ds3Request.getClassification() == Classification.spectrads3
+                && ds3Request.getAction() == Action.BULK_DELETE
+                && ds3Request.getHttpVerb() == HttpVerb.DELETE
+                && !ds3Request.getIncludeInPath()
+                && ds3Request.getResource() == Resource.SUSPECT_BLOB_DS3_TARGET
+                && ds3Request.getResourceType() == ResourceType.NON_SINGLETON;
     }
 
     /**

--- a/ds3-autogen-utils/src/test/java/com/spectralogic/ds3autogen/utils/Ds3RequestClassificationUtil_Test.java
+++ b/ds3-autogen-utils/src/test/java/com/spectralogic/ds3autogen/utils/Ds3RequestClassificationUtil_Test.java
@@ -1052,6 +1052,7 @@ public class Ds3RequestClassificationUtil_Test {
     public void hasIdsRequestPayload_Test() {
         assertTrue(hasIdsRequestPayload(clearSuspectBlobAzureTargetsRequest()));
         assertTrue(hasIdsRequestPayload(clearSuspectBlobPoolsRequest()));
+        assertTrue(hasIdsRequestPayload(clearSuspectBlobDs3TargetsRequest()));
         assertTrue(hasIdsRequestPayload(clearSuspectBlobS3TargetsRequest()));
         assertTrue(hasIdsRequestPayload(clearSuspectBlobTapesRequest()));
         assertTrue(hasIdsRequestPayload(markSuspectBlobAzureTargetsAsDegradedRequest()));


### PR DESCRIPTION
**Changes**
- Updated request classification util to include `ClearSuspectBlobDs3TargetsRequest` as having a request payload of ids
- Added `IdsList` class to python modules for use in marshaling the new request payload. _Note: there is a separate implementation in Python and Python 3 given that `basestring` was renamed to `str` in Python 3._
- Special cased commands with id lists as request payloads to properly handle request payloads.

**Generated Code**
Generates Python SDK code found in PR: https://github.com/SpectraLogic/ds3_python_sdk/pull/126
Generates Python 3 SDK code found in PR: https://github.com/SpectraLogic/ds3_python3_sdk/pull/20