### PR TITLE
NETSDK-147: Fixing request generation with partial object payloads in .Net module

### DIFF
--- a/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/NetCodeGenerator.java
+++ b/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/NetCodeGenerator.java
@@ -464,7 +464,7 @@ public class NetCodeGenerator implements CodeGenerator {
         if (isBulkGetRequest(ds3Request)) { //Note: this must come before hasGetObjectsWithLengthOffsetRequestPayload
             return new BulkGetRequestGenerator();
         }
-        if (hasGetObjectsWithLengthOffsetRequestPayload(ds3Request) || isStageObjectsJob(ds3Request)) {
+        if (hasGetObjectsWithLengthOffsetRequestPayload(ds3Request)) {
             return new PartialObjectRequestPayloadGenerator();
         }
         if (isCreateObjectRequest(ds3Request)) {
@@ -473,8 +473,7 @@ public class NetCodeGenerator implements CodeGenerator {
         if (isCreateMultiPartUploadPartRequest(ds3Request)) {
             return new StreamRequestPayloadGenerator();
         }
-        if (hasSimpleObjectsRequestPayload(ds3Request)
-                || isMultiFileDeleteRequest(ds3Request)) {
+        if (isMultiFileDeleteRequest(ds3Request)) {
             return new ObjectsRequestPayloadGenerator();
         }
         if (hasStringRequestPayload(ds3Request)) {
@@ -503,8 +502,8 @@ public class NetCodeGenerator implements CodeGenerator {
         if (isBulkGetRequest(ds3Request)) { //Note: this must come before hasGetObjectsWithLengthOffsetRequestPayload
             return config.getTemplate("request/bulk_get_request.ftl");
         }
-        if (isStageObjectsJob(ds3Request)) {
-            return config.getTemplate("request/stage_objects_request.ftl");
+        if (isEjectStorageDomainBlobsRequest(ds3Request)) { //Note: this must come before hasGetObjectsWithLengthOffsetRequestPayload
+            return config.getTemplate("request/eject_storage_domain_blobs_request.ftl");
         }
         if (hasGetObjectsWithLengthOffsetRequestPayload(ds3Request)) {
             return config.getTemplate("request/partial_objects_request_payload.ftl");

--- a/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/requestmodels/PartialObjectRequestPayloadGenerator.java
+++ b/ds3-autogen-net/src/main/java/com/spectralogic/ds3autogen/net/generators/requestmodels/PartialObjectRequestPayloadGenerator.java
@@ -46,7 +46,7 @@ public class PartialObjectRequestPayloadGenerator extends BaseRequestGenerator {
     public ImmutableList<Arguments> toRequiredArgumentsList(final Ds3Request ds3Request) {
         final ImmutableList.Builder<Arguments> builder = ImmutableList.builder();
         builder.addAll(GeneratorUtils.getRequiredArgs(ds3Request));
-        builder.add(new Arguments("IEnumerable<string>", "FullObjects"));
+        builder.add(new Arguments("IEnumerable<Ds3Object>", "FullObjects"));
         builder.add(new Arguments("IEnumerable<Ds3PartialObject>", "PartialObjects"));
         return builder.build();
     }

--- a/ds3-autogen-net/src/main/resources/tmpls/net/request/bulk_get_request.ftl
+++ b/ds3-autogen-net/src/main/resources/tmpls/net/request/bulk_get_request.ftl
@@ -38,8 +38,18 @@ namespace Ds3.Calls
 
         <#include "common/constructor.ftl" />
 
-        public ${name}(string bucketName, List<Ds3Object> ds3Objects)
-            : this(bucketName, ds3Objects.Select(o => o.Name), Enumerable.Empty<Ds3PartialObject>())
+        public ${name}(string bucketName, IEnumerable<string> fullObjects, IEnumerable<Ds3PartialObject> partialObjects)
+            : this(bucketName, fullObjects.Select(name => new Ds3Object(name, null)), partialObjects)
+        {
+        }
+
+        public ${name}(string bucketName, IEnumerable<Ds3Object> ds3Objects)
+            : this(bucketName, ds3Objects, Enumerable.Empty<Ds3PartialObject>())
+        {
+        }
+
+        public ${name}(string bucketName, IEnumerable<string> objectNames)
+            : this(bucketName, objectNames.Select(name => new Ds3Object(name, null)), Enumerable.Empty<Ds3PartialObject>())
         {
         }
 

--- a/ds3-autogen-net/src/main/resources/tmpls/net/request/eject_storage_domain_blobs_request.ftl
+++ b/ds3-autogen-net/src/main/resources/tmpls/net/request/eject_storage_domain_blobs_request.ftl
@@ -17,8 +17,13 @@ namespace Ds3.Calls
 
         <#include "common/constructor.ftl" />
 
-        public ${name}(string bucketName, List<Ds3Object> ds3Objects)
-            : this(bucketName, ds3Objects.Select(o => o.Name), Enumerable.Empty<Ds3PartialObject>())
+        public ${name}(string bucketName, IEnumerable<Ds3Object> ds3Objects, string storageDomain)
+            : this(bucketName, ds3Objects, Enumerable.Empty<Ds3PartialObject>(), storageDomain)
+        {
+        }
+
+        public ${name}(string bucketName, IEnumerable<string> objectNames, string storageDomain)
+            : this(bucketName, objectNames.Select(name => new Ds3Object(name, null)), Enumerable.Empty<Ds3PartialObject>(), storageDomain)
         {
         }
 

--- a/ds3-autogen-net/src/main/resources/tmpls/net/request/partial_objects_request_payload.ftl
+++ b/ds3-autogen-net/src/main/resources/tmpls/net/request/partial_objects_request_payload.ftl
@@ -17,8 +17,13 @@ namespace Ds3.Calls
 
         <#include "common/constructor.ftl" />
 
-        public ${name}(string bucketName, List<Ds3Object> ds3Objects)
-            : this(bucketName, ds3Objects.Select(o => o.Name), Enumerable.Empty<Ds3PartialObject>())
+        public ${name}(string bucketName, IEnumerable<Ds3Object> ds3Objects)
+            : this(bucketName, ds3Objects, Enumerable.Empty<Ds3PartialObject>())
+        {
+        }
+
+        public ${name}(string bucketName, IEnumerable<string> objectNames)
+            : this(bucketName, objectNames.Select(name => new Ds3Object(name, null)), Enumerable.Empty<Ds3PartialObject>())
         {
         }
 

--- a/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/NetCodeGenerator_Test.java
+++ b/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/NetCodeGenerator_Test.java
@@ -42,13 +42,12 @@ public class NetCodeGenerator_Test {
 
         // Request with payload List<Ds3Partial>
         assertThat(getTemplateModelGenerator(getRequestBulkGet()), instanceOf(BulkGetRequestGenerator.class));
-        assertThat(getTemplateModelGenerator(createVerifyJobRequest()), instanceOf(PartialObjectRequestPayloadGenerator.class));
 
-        // Requests with payloads List<string>
-        assertThat(getTemplateModelGenerator(getEjectStorageDomainBlobsRequest()), instanceOf(ObjectsRequestPayloadGenerator.class));
-        assertThat(getTemplateModelGenerator(getRequestVerifyPhysicalPlacement()), instanceOf(ObjectsRequestPayloadGenerator.class));
-        assertThat(getTemplateModelGenerator(getPhysicalPlacementForObjects()), instanceOf(ObjectsRequestPayloadGenerator.class));
-        assertThat(getTemplateModelGenerator(verifyPhysicalPlacementForObjectsWithFullDetailsRequest()), instanceOf(ObjectsRequestPayloadGenerator.class));
+        assertThat(getTemplateModelGenerator(createVerifyJobRequest()), instanceOf(PartialObjectRequestPayloadGenerator.class));
+        assertThat(getTemplateModelGenerator(getEjectStorageDomainBlobsRequest()), instanceOf(PartialObjectRequestPayloadGenerator.class));
+        assertThat(getTemplateModelGenerator(getRequestVerifyPhysicalPlacement()), instanceOf(PartialObjectRequestPayloadGenerator.class));
+        assertThat(getTemplateModelGenerator(getPhysicalPlacementForObjects()), instanceOf(PartialObjectRequestPayloadGenerator.class));
+        assertThat(getTemplateModelGenerator(verifyPhysicalPlacementForObjectsWithFullDetailsRequest()), instanceOf(PartialObjectRequestPayloadGenerator.class));
 
         // Request with object name list payload
         assertThat(getTemplateModelGenerator(getRequestMultiFileDelete()), instanceOf(ObjectsRequestPayloadGenerator.class));

--- a/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/NetFunctionalTests.java
+++ b/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/NetFunctionalTests.java
@@ -43,7 +43,7 @@ import static org.mockito.Mockito.mock;
 public class NetFunctionalTests {
 
     private final static Logger LOG = LoggerFactory.getLogger(NetFunctionalTests.class);
-    private final static GeneratedCodeLogger CODE_LOGGER = new GeneratedCodeLogger(FileTypeToLog.RESPONSE, LOG);
+    private final static GeneratedCodeLogger CODE_LOGGER = new GeneratedCodeLogger(FileTypeToLog.REQUEST, LOG);
 
     @Rule
     public TemporaryFolder tempFolder = new TemporaryFolder();
@@ -413,7 +413,7 @@ public class NetFunctionalTests {
         assertTrue(TestHelper.hasProperty("Path", "string", requestCode));
 
         assertTrue(TestHelper.hasRequiredParam("BucketName", "string", requestCode));
-        assertTrue(TestHelper.hasRequiredParam("FullObjects", "IEnumerable<string>", requestCode));
+        assertTrue(TestHelper.hasRequiredParam("FullObjects", "IEnumerable<Ds3Object>", requestCode));
         assertTrue(TestHelper.hasRequiredParam("PartialObjects", "IEnumerable<Ds3PartialObject>", requestCode));
 
         assertTrue(TestHelper.hasOptionalParam(requestName, "ChunkClientProcessingOrderGuarantee?", "JobChunkClientProcessingOrderGuarantee?", requestCode));
@@ -423,13 +423,13 @@ public class NetFunctionalTests {
 
         final ImmutableList<Arguments> constructorArgs = ImmutableList.of(
                 new Arguments("String", "BucketName"),
-                new Arguments("IEnumerable<string>", "FullObjects"),
+                new Arguments("IEnumerable<Ds3Object>", "FullObjects"),
                 new Arguments("IEnumerable<Ds3PartialObject>", "PartialObjects"));
         assertTrue(TestHelper.hasConstructor(requestName, constructorArgs, requestCode));
 
         final ImmutableList<Arguments> secondConstructorArgs = ImmutableList.of(
                 new Arguments("String", "BucketName"),
-                new Arguments("List<Ds3Object>", "Ds3Objects"));
+                new Arguments("IEnumerable<Ds3Object>", "Ds3Objects"));
         assertTrue(TestHelper.hasConstructor(requestName, secondConstructorArgs, requestCode));
 
         assertTrue(requestCode.contains("this.QueryParams.Add(\"operation\", \"start_bulk_get\");"));
@@ -611,7 +611,7 @@ public class NetFunctionalTests {
         assertTrue(TestHelper.hasProperty("Path", "string", requestCode));
 
         assertTrue(TestHelper.hasRequiredParam("BucketName", "string", requestCode));
-        assertTrue(TestHelper.hasRequiredParam("FullObjects", "IEnumerable<string>", requestCode));
+        assertTrue(TestHelper.hasRequiredParam("FullObjects", "IEnumerable<Ds3Object>", requestCode));
         assertTrue(TestHelper.hasRequiredParam("PartialObjects", "IEnumerable<Ds3PartialObject>", requestCode));
 
         assertTrue(TestHelper.hasOptionalParam(requestName, "Aggregating", "bool", requestCode));
@@ -620,13 +620,13 @@ public class NetFunctionalTests {
 
         final ImmutableList<Arguments> constructorArgs = ImmutableList.of(
                 new Arguments("String", "BucketName"),
-                new Arguments("IEnumerable<string>", "FullObjects"),
+                new Arguments("IEnumerable<Ds3Object>", "FullObjects"),
                 new Arguments("IEnumerable<Ds3PartialObject>", "PartialObjects"));
         assertTrue(TestHelper.hasConstructor(requestName, constructorArgs, requestCode));
 
         final ImmutableList<Arguments> secondConstructorArgs = ImmutableList.of(
                 new Arguments("String", "BucketName"),
-                new Arguments("List<Ds3Object>", "Ds3Objects"));
+                new Arguments("IEnumerable<Ds3Object>", "Ds3Objects"));
         assertTrue(TestHelper.hasConstructor(requestName, secondConstructorArgs, requestCode));
 
         assertTrue(requestCode.contains("this.QueryParams.Add(\"operation\", \"start_bulk_verify\");"));
@@ -695,7 +695,8 @@ public class NetFunctionalTests {
         assertFalse(TestHelper.hasRequiredParam("Blobs", "bool", requestCode));
         assertTrue(TestHelper.hasRequiredParam("BucketId", "string", requestCode));
         assertTrue(TestHelper.hasRequiredParam("StorageDomain", "string", requestCode));
-        assertTrue(TestHelper.hasRequiredParam("Objects", "IEnumerable<Ds3Object>", requestCode));
+        assertTrue(TestHelper.hasRequiredParam("FullObjects", "IEnumerable<Ds3Object>", requestCode));
+        assertTrue(TestHelper.hasRequiredParam("PartialObjects", "IEnumerable<Ds3PartialObject>", requestCode));
 
         assertTrue(TestHelper.hasOptionalParam(requestName, "EjectLabel", "string", requestCode));
         assertTrue(TestHelper.hasOptionalParam(requestName, "EjectLocation", "string", requestCode));
@@ -703,12 +704,13 @@ public class NetFunctionalTests {
         final ImmutableList<Arguments> constructorArgs = ImmutableList.of(
                 new Arguments("Guid", "BucketId"),
                 new Arguments("string", "StorageDomain"),
-                new Arguments("IEnumerable<Ds3Object>", "Objects"));
+                new Arguments("IEnumerable<Ds3Object>", "FullObjects"),
+                new Arguments("IEnumerable<Ds3PartialObject>", "PartialObjects"));
         assertTrue(TestHelper.hasConstructor(requestName, constructorArgs, requestCode));
         assertTrue(TestHelper.hasConstructor(requestName, modifyType(constructorArgs, "Guid", "string"), requestCode));
 
         assertTrue(requestCode.contains("internal override Stream GetContentStream()"));
-        assertTrue(requestCode.contains("return RequestPayloadUtil.MarshalDs3ObjectNames(this.Objects);"));
+        assertTrue(requestCode.contains("return RequestPayloadUtil.MarshalFullAndPartialObjects(this.FullObjects, this.PartialObjects);"));
 
         assertTrue(requestCode.contains("internal override long GetContentLength()"));
         assertTrue(requestCode.contains("return GetContentStream().Length;"));
@@ -817,13 +819,15 @@ public class NetFunctionalTests {
         assertTrue(TestHelper.hasProperty("Path", "string", requestCode));
 
         assertTrue(TestHelper.hasRequiredParam("BucketName", "string", requestCode));
-        assertTrue(TestHelper.hasRequiredParam("Objects", "IEnumerable<Ds3Object>", requestCode));
+        assertTrue(TestHelper.hasRequiredParam("FullObjects", "IEnumerable<Ds3Object>", requestCode));
+        assertTrue(TestHelper.hasRequiredParam("PartialObjects", "IEnumerable<Ds3PartialObject>", requestCode));
 
         assertTrue(TestHelper.hasOptionalParam(requestName, "StorageDomainId", "Guid", requestCode));
 
         final ImmutableList<Arguments> constructorArgs = ImmutableList.of(
                 new Arguments("string", "BucketName"),
-                new Arguments("IEnumerable<Ds3Object>", "Objects"));
+                new Arguments("IEnumerable<Ds3Object>", "FullObjects"),
+                new Arguments("IEnumerable<Ds3PartialObject>", "PartialObjects"));
         assertTrue(TestHelper.hasConstructor(requestName, constructorArgs, requestCode));
 
         //Generate Client code
@@ -878,13 +882,15 @@ public class NetFunctionalTests {
         assertTrue(TestHelper.hasProperty("Path", "string", requestCode));
 
         assertTrue(TestHelper.hasRequiredParam("BucketName", "string", requestCode));
-        assertTrue(TestHelper.hasRequiredParam("Objects", "IEnumerable<Ds3Object>", requestCode));
+        assertTrue(TestHelper.hasRequiredParam("FullObjects", "IEnumerable<Ds3Object>", requestCode));
+        assertTrue(TestHelper.hasRequiredParam("PartialObjects", "IEnumerable<Ds3PartialObject>", requestCode));
 
         assertTrue(TestHelper.hasOptionalParam(requestName, "StorageDomainId", "Guid", requestCode));
 
         final ImmutableList<Arguments> constructorArgs = ImmutableList.of(
                 new Arguments("string", "BucketName"),
-                new Arguments("IEnumerable<Ds3Object>", "Objects"));
+                new Arguments("IEnumerable<Ds3Object>", "FullObjects"),
+                new Arguments("IEnumerable<Ds3PartialObject>", "PartialObjects"));
         assertTrue(TestHelper.hasConstructor(requestName, constructorArgs, requestCode));
 
         //Generate Client code
@@ -939,14 +945,16 @@ public class NetFunctionalTests {
         assertTrue(TestHelper.hasProperty("Path", "string", requestCode));
 
         assertTrue(TestHelper.hasRequiredParam("BucketName", "string", requestCode));
-        assertTrue(TestHelper.hasRequiredParam("Objects", "IEnumerable<Ds3Object>", requestCode));
+        assertTrue(TestHelper.hasRequiredParam("FullObjects", "IEnumerable<Ds3Object>", requestCode));
+        assertTrue(TestHelper.hasRequiredParam("PartialObjects", "IEnumerable<Ds3PartialObject>", requestCode));
         assertFalse(TestHelper.hasRequiredParam("FullDetails", "bool", requestCode));
 
         assertTrue(TestHelper.hasOptionalParam(requestName, "StorageDomainId", "Guid", requestCode));
 
         final ImmutableList<Arguments> constructorArgs = ImmutableList.of(
                 new Arguments("string", "BucketName"),
-                new Arguments("IEnumerable<Ds3Object>", "Objects"));
+                new Arguments("IEnumerable<Ds3Object>", "FullObjects"),
+                new Arguments("IEnumerable<Ds3PartialObject>", "PartialObjects"));
         assertTrue(TestHelper.hasConstructor(requestName, constructorArgs, requestCode));
 
         //Generate Client code
@@ -1680,7 +1688,7 @@ public class NetFunctionalTests {
         assertTrue(TestHelper.hasProperty("Path", "string", requestCode));
 
         assertTrue(TestHelper.hasRequiredParam("BucketName", "string", requestCode));
-        assertTrue(TestHelper.hasRequiredParam("FullObjects", "IEnumerable<string>", requestCode));
+        assertTrue(TestHelper.hasRequiredParam("FullObjects", "IEnumerable<Ds3Object>", requestCode));
         assertTrue(TestHelper.hasRequiredParam("PartialObjects", "IEnumerable<Ds3PartialObject>", requestCode));
 
         assertFalse(TestHelper.hasOptionalParam(requestName, "ChunkClientProcessingOrderGuarantee?", "JobChunkClientProcessingOrderGuarantee?", requestCode));
@@ -1690,13 +1698,13 @@ public class NetFunctionalTests {
 
         final ImmutableList<Arguments> constructorArgs = ImmutableList.of(
                 new Arguments("String", "BucketName"),
-                new Arguments("IEnumerable<string>", "FullObjects"),
+                new Arguments("IEnumerable<Ds3Object>", "FullObjects"),
                 new Arguments("IEnumerable<Ds3PartialObject>", "PartialObjects"));
         assertTrue(TestHelper.hasConstructor(requestName, constructorArgs, requestCode));
 
         final ImmutableList<Arguments> secondConstructorArgs = ImmutableList.of(
                 new Arguments("String", "BucketName"),
-                new Arguments("List<Ds3Object>", "Ds3Objects"));
+                new Arguments("IEnumerable<Ds3Object>", "Ds3Objects"));
         assertTrue(TestHelper.hasConstructor(requestName, secondConstructorArgs, requestCode));
 
         assertTrue(requestCode.contains("this.QueryParams.Add(\"operation\", \"start_bulk_stage\");"));

--- a/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/generators/requestmodels/PartialObjectRequestPayloadGenerator_Test.java
+++ b/ds3-autogen-net/src/test/java/com/spectralogic/ds3autogen/net/generators/requestmodels/PartialObjectRequestPayloadGenerator_Test.java
@@ -48,7 +48,7 @@ public class PartialObjectRequestPayloadGenerator_Test {
         assertThat(result.get(0).getName(), is("BucketName"));
         assertThat(result.get(0).getType(), is("String"));
         assertThat(result.get(1).getName(), is("FullObjects"));
-        assertThat(result.get(1).getType(), is("IEnumerable<string>"));
+        assertThat(result.get(1).getType(), is("IEnumerable<Ds3Object>"));
         assertThat(result.get(2).getName(), is("PartialObjects"));
         assertThat(result.get(2).getType(), is("IEnumerable<Ds3PartialObject>"));
     }
@@ -60,7 +60,7 @@ public class PartialObjectRequestPayloadGenerator_Test {
         assertThat(result.get(0).getName(), is("BucketName"));
         assertThat(result.get(0).getType(), is("String"));
         assertThat(result.get(1).getName(), is("FullObjects"));
-        assertThat(result.get(1).getType(), is("IEnumerable<string>"));
+        assertThat(result.get(1).getType(), is("IEnumerable<Ds3Object>"));
         assertThat(result.get(2).getName(), is("PartialObjects"));
         assertThat(result.get(2).getType(), is("IEnumerable<Ds3PartialObject>"));
     }


### PR DESCRIPTION
Fixed the generation of requests that can have request payloads describing partial objects in .Net module.

Generates the code merged in Net SDK PR: https://github.com/SpectraLogic/ds3_net_sdk/pull/298