### PR TITLE
Updated PutObjectRequest in Go module to be compatible with Go helpers

### DIFF
--- a/ds3-autogen-go/src/main/resources/tmpls/go/request/put_object_request.ftl
+++ b/ds3-autogen-go/src/main/resources/tmpls/go/request/put_object_request.ftl
@@ -4,8 +4,6 @@ import (
     "strings"
 )
 
-const ( AMZ_META_HEADER = "x-amz-meta-" )
-
 <#include "request_body.ftl" />
 
 <#include "with_checksum.ftl" />

--- a/ds3-autogen-go/src/main/resources/tmpls/go/request/with_headers.ftl
+++ b/ds3-autogen-go/src/main/resources/tmpls/go/request/with_headers.ftl
@@ -1,4 +1,4 @@
-func (${name?uncap_first} *PutObjectRequest) WithMetaData(key string, values ...string) *${name} {
+func (${name?uncap_first} *PutObjectRequest) WithMetaData(key string, values ...string) interface{} {
     if strings.HasPrefix(strings.ToLower(key), AMZ_META_HEADER) {
         ${name?uncap_first}.Metadata[key] = strings.Join(values, ",")
     } else {

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTests.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTests.java
@@ -933,8 +933,8 @@ public class GoFunctionalTests {
         assertTrue(requestCode.contains("putObjectRequest.Checksum.Type = checksumType"));
 
         // test metadata
-        assertTrue(requestCode.contains("const ( AMZ_META_HEADER = \"x-amz-meta-\" )"));
-        assertTrue(requestCode.contains("func (putObjectRequest *PutObjectRequest) WithMetaData(key string, values ...string) *PutObjectRequest {"));
+        assertFalse(requestCode.contains("const ( AMZ_META_HEADER = \"x-amz-meta-\" )"));
+        assertTrue(requestCode.contains("func (putObjectRequest *PutObjectRequest) WithMetaData(key string, values ...string) interface{} {"));
         assertTrue(requestCode.contains("if strings.HasPrefix(strings.ToLower(key), AMZ_META_HEADER) {"));
         assertTrue(requestCode.contains("putObjectRequest.Metadata[key] = strings.Join(values, \",\")"));
         assertTrue(requestCode.contains("putObjectRequest.Metadata[strings.ToLower(AMZ_META_HEADER + key)] = strings.Join(values, \",\")"));


### PR DESCRIPTION
In template for `PutObjectRequest` handler in Go module:
- removed definition of `AMZ_META_HEADER` as its been placed in util
- updated `WithMetaData` to return interface for re-usability.