### PR TITLE
SA-238: Removed constant from PutObjectRequest template in Go module

### DIFF
--- a/ds3-autogen-go/src/main/resources/tmpls/go/request/put_object_request.ftl
+++ b/ds3-autogen-go/src/main/resources/tmpls/go/request/put_object_request.ftl
@@ -4,8 +4,6 @@ import (
     "strings"
 )
 
-const ( AMZ_META_HEADER = "x-amz-meta-" )
-
 <#include "request_body.ftl" />
 
 <#include "with_checksum.ftl" />

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTests.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTests.java
@@ -933,7 +933,7 @@ public class GoFunctionalTests {
         assertTrue(requestCode.contains("putObjectRequest.Checksum.Type = checksumType"));
 
         // test metadata
-        assertTrue(requestCode.contains("const ( AMZ_META_HEADER = \"x-amz-meta-\" )"));
+        assertFalse(requestCode.contains("const ( AMZ_META_HEADER = \"x-amz-meta-\" )"));
         assertTrue(requestCode.contains("func (putObjectRequest *PutObjectRequest) WithMetaData(key string, values ...string) *PutObjectRequest {"));
         assertTrue(requestCode.contains("if strings.HasPrefix(strings.ToLower(key), AMZ_META_HEADER) {"));
         assertTrue(requestCode.contains("putObjectRequest.Metadata[key] = strings.Join(values, \",\")"));


### PR DESCRIPTION
Removing generation of constant `AMZ_META_HEADER` from within PutObjectRequest to reflect previous refactor.