### PR TITLE
GOSDK-25: Unmarshaling optional enums in response payloads causes panic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
+dist: trusty
 jdk:
   - oraclejdk8
 script: ./gradlew -S clean test

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/parser/BaseTypeParserGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/parser/BaseTypeParserGenerator.kt
@@ -108,7 +108,7 @@ open class BaseTypeParserGenerator : TypeParserModelGenerator<TypeParser>, TypeP
         // Handle case if the element is an enum
         if (isElementEnum(ds3Element.type!!, typeMap)) {
             if (ds3Element.nullable) {
-                return ParseChildNodeAsNullableEnum(xmlTag, modelName, paramName)
+                return ParseChildNodeAsNullableEnum(xmlTag, modelName, paramName, toGoType(ds3Element.type!!))
             }
             return ParseChildNodeAsEnum(xmlTag, modelName, paramName)
         }

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/models/parser/ParseChildNodeImpls.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/models/parser/ParseChildNodeImpls.kt
@@ -171,8 +171,7 @@ data class ParseChildNodeAsNullableEnum(
         val paramType: String) : ParseElement {
 
     override val parsingCode: String
-        get() { return "$modelName.$paramName = new($paramType)\n" +
-                goIndent(3) + "parseNullableEnum(child.Content, $modelName.$paramName, aggErr)" }
+        get() { return "$modelName.$paramName = new${paramType}FromContent(child.Content, aggErr)" }
 }
 
 data class ParseChildNodeAsCommonPrefix(

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/models/parser/ParseChildNodeImpls.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/models/parser/ParseChildNodeImpls.kt
@@ -167,10 +167,12 @@ data class ParseChildNodeAsEnum(
 data class ParseChildNodeAsNullableEnum(
         override val xmlTag: String,
         val modelName: String,
-        val paramName: String) : ParseElement {
+        val paramName: String,
+        val paramType: String) : ParseElement {
 
     override val parsingCode: String
-        get() { return "parseNullableEnum(child.Content, $modelName.$paramName, aggErr)" }
+        get() { return "$modelName.$paramName = new($paramType)\n" +
+                goIndent(3) + "parseNullableEnum(child.Content, $modelName.$paramName, aggErr)" }
 }
 
 data class ParseChildNodeAsCommonPrefix(

--- a/ds3-autogen-go/src/main/resources/tmpls/go/type/checksum_type_enum.ftl
+++ b/ds3-autogen-go/src/main/resources/tmpls/go/type/checksum_type_enum.ftl
@@ -8,3 +8,13 @@ const (
 )
 
 <#include "enum_unmarshal_to_string.ftl" />
+
+func new${name}FromContent(content []byte, aggErr *AggregateError) *${name} {
+    if len(content) == 0 {
+        // no value
+        return nil
+    }
+    result := new(${name})
+    parseEnum(content, result, aggErr)
+    return result
+}

--- a/ds3-autogen-go/src/main/resources/tmpls/go/type/enum_type.ftl
+++ b/ds3-autogen-go/src/main/resources/tmpls/go/type/enum_type.ftl
@@ -7,3 +7,13 @@ const (
 )
 
 <#include "enum_unmarshal_to_string.ftl" />
+
+func new${name}FromContent(content []byte, aggErr *AggregateError) *${name} {
+    if len(content) == 0 {
+        // no value
+        return nil
+    }
+    result := new(${name})
+    parseEnum(content, result, aggErr)
+    return result
+}

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/parser/BaseTypeParserGenerator_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/parser/BaseTypeParserGenerator_Test.java
@@ -202,7 +202,7 @@ public class BaseTypeParserGenerator_Test {
                 new ParseChildNodeAsPrimitiveType(INT_ELEMENT.getName(), modelName, INT_ELEMENT.getName(), "Int"),
                 new ParseChildNodeAddToSlice(LIST_ELEMENT.getName(), modelName, LIST_ELEMENT.getName(), removePath(LIST_ELEMENT.getComponentType())),
                 new ParseChildNodeAsEnum(ENUM_ELEMENT.getName(), modelName, ENUM_ELEMENT.getName()),
-                new ParseChildNodeAsNullableEnum(ENUM_PTR_ELEMENT.getName(), modelName, ENUM_PTR_ELEMENT.getName()),
+                new ParseChildNodeAsNullableEnum(ENUM_PTR_ELEMENT.getName(), modelName, ENUM_PTR_ELEMENT.getName(), removePath(ENUM_PTR_ATTR.getType())),
                 new ParseChildNodeAsSlice("TestCollectionValue", "CustomMarshaledName", modelName, LIST_WITH_ENCAPS_TAG_ELEMENT.getName(), removePath(LIST_WITH_ENCAPS_TAG_ELEMENT.getComponentType())),
                 new ParseChildNodeAsDs3Type(DS3_TYPE_ELEMENT.getName(), modelName, DS3_TYPE_ELEMENT.getName()),
                 new ParseChildNodeAddEnumToSlice(LIST_ENUM_ELEMENT.getName(), modelName, LIST_ENUM_ELEMENT.getName(), removePath(LIST_ENUM_ELEMENT.getComponentType())),
@@ -250,7 +250,7 @@ public class BaseTypeParserGenerator_Test {
                 new ParseChildNodeAsPrimitiveType(INT_ELEMENT.getName(), modelName, INT_ELEMENT.getName(), "Int"),
                 new ParseChildNodeAddToSlice(LIST_ELEMENT.getName(), modelName, LIST_ELEMENT.getName(), removePath(LIST_ELEMENT.getComponentType())),
                 new ParseChildNodeAsEnum(ENUM_ELEMENT.getName(), modelName, ENUM_ELEMENT.getName()),
-                new ParseChildNodeAsNullableEnum(ENUM_PTR_ELEMENT.getName(), modelName, ENUM_PTR_ELEMENT.getName()),
+                new ParseChildNodeAsNullableEnum(ENUM_PTR_ELEMENT.getName(), modelName, ENUM_PTR_ELEMENT.getName(), removePath(ENUM_PTR_ATTR.getType())),
                 new ParseChildNodeAsSlice("TestCollectionValue", "CustomMarshaledName", modelName, LIST_WITH_ENCAPS_TAG_ELEMENT.getName(), removePath(LIST_WITH_ENCAPS_TAG_ELEMENT.getComponentType())),
                 new ParseChildNodeAsDs3Type(DS3_TYPE_ELEMENT.getName(), modelName, DS3_TYPE_ELEMENT.getName()));
 

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/models/parser/ParseChildNodeImpls_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/models/parser/ParseChildNodeImpls_Test.java
@@ -19,13 +19,13 @@ import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 
 public class ParseChildNodeImpls_Test {
 
     private static final String XML_TAG = "XmlTag";
     private static final String MODEL_NAME = "modelName";
     private static final String PARAM_NAME = "ParamName";
+    private static final String PARAM_TYPE = "ParamType";
     private static final String PARSER_NAMESPACE = "ParserNamespace";
     private static final String CHILD_TYPE = "ChildType";
 
@@ -109,9 +109,10 @@ public class ParseChildNodeImpls_Test {
 
     @Test
     public void ParseChildNodeAsNullableEnumTest() {
-        final String expected = String.format("parseNullableEnum(child.Content, %s.%s, aggErr)", MODEL_NAME, PARAM_NAME);
+        final String expected = String.format("%s.%s = new(%s)\n" +
+                "            parseNullableEnum(child.Content, %s.%s, aggErr)", MODEL_NAME, PARAM_NAME, PARAM_TYPE, MODEL_NAME, PARAM_NAME);
 
-        final ParseElement parseElement = new ParseChildNodeAsNullableEnum(XML_TAG, MODEL_NAME, PARAM_NAME);
+        final ParseElement parseElement = new ParseChildNodeAsNullableEnum(XML_TAG, MODEL_NAME, PARAM_NAME, PARAM_TYPE);
         assertThat(parseElement.getXmlTag(), is(XML_TAG));
         assertThat(parseElement.getParsingCode(), is(expected));
     }

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/models/parser/ParseChildNodeImpls_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/models/parser/ParseChildNodeImpls_Test.java
@@ -109,8 +109,7 @@ public class ParseChildNodeImpls_Test {
 
     @Test
     public void ParseChildNodeAsNullableEnumTest() {
-        final String expected = String.format("%s.%s = new(%s)\n" +
-                "            parseNullableEnum(child.Content, %s.%s, aggErr)", MODEL_NAME, PARAM_NAME, PARAM_TYPE, MODEL_NAME, PARAM_NAME);
+        final String expected = String.format("%s.%s = new%sFromContent(child.Content, aggErr)", MODEL_NAME, PARAM_NAME, PARAM_TYPE);
 
         final ParseElement parseElement = new ParseChildNodeAsNullableEnum(XML_TAG, MODEL_NAME, PARAM_NAME, PARAM_TYPE);
         assertThat(parseElement.getXmlTag(), is(XML_TAG));


### PR DESCRIPTION
Adding instantiation step to nullable enums before attempting to set value.