### PR TITLE
GOSDK-29: SDK leaks memory from unclosed HTTP response bodies

### DIFF
--- a/ds3-autogen-go/src/main/java/com/spectralogic/ds3autogen/go/GoCodeGenerator.java
+++ b/ds3-autogen-go/src/main/java/com/spectralogic/ds3autogen/go/GoCodeGenerator.java
@@ -251,7 +251,9 @@ public class GoCodeGenerator implements CodeGenerator {
      * Retrieves the appropriate template that will generate the Go response handler
      */
     private Template getResponseTemplate(final Ds3Request ds3Request) throws IOException {
-        //TODO special case if necessary
+        if (isGetObjectAmazonS3Request(ds3Request)) {
+            return config.getTemplate("response/response_get_object_template.ftl");
+        }
         return config.getTemplate("response/response_template.ftl");
     }
 

--- a/ds3-autogen-go/src/main/resources/tmpls/go/response/response_get_object_template.ftl
+++ b/ds3-autogen-go/src/main/resources/tmpls/go/response/response_get_object_template.ftl
@@ -6,7 +6,6 @@ type ${name} struct {
 ${parseResponseMethod}
 
 func New${name}(webResponse WebResponse) (*${name}, error) {
-    defer webResponse.Body().Close()
     expectedStatusCodes := []int { ${expectedCodes} }
 
     switch code := webResponse.StatusCode(); code {
@@ -15,6 +14,7 @@ func New${name}(webResponse WebResponse) (*${name}, error) {
         ${code.parseResponse}
     </#list>
     default:
+        defer webResponse.Body().Close()
         return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
     }
 }


### PR DESCRIPTION
Updating Go SDK to close file handles always within response handlers instead of in the response parsing to handle error scenarios and no response payload scenarios.

Generated code in https://github.com/SpectraLogic/ds3_go_sdk/pull/94