### PR TITLE
C SDK: Enabling aggregating on a job sets value to null instead of true

### DIFF
--- a/ds3-autogen-c/src/main/java/com/spectralogic/ds3autogen/c/converters/ParameterConverter.java
+++ b/ds3-autogen-c/src/main/java/com/spectralogic/ds3autogen/c/converters/ParameterConverter.java
@@ -38,6 +38,7 @@ public class ParameterConverter {
     public static String getParameterType(final Ds3Param ds3Param) {
         switch (ds3Param.getType()) {
             case "void":
+                return "void";
             case "java.lang.Boolean":
             case "boolean":
                 return "ds3_bool";

--- a/ds3-autogen-c/src/main/java/com/spectralogic/ds3autogen/c/helpers/RequestHelper.java
+++ b/ds3-autogen-c/src/main/java/com/spectralogic/ds3autogen/c/helpers/RequestHelper.java
@@ -112,6 +112,7 @@ public final class RequestHelper {
         }
 
         builder.addAll(request.getRequiredQueryParams().stream()
+                .filter( parm -> !parm.getParameterType().equals("void"))
                 .filter(parm -> !parm.getParameterType().equals("ds3_bool")) // for required bool / void query param nothing to specify
                 .filter(parm -> !parm.getParameterType().equals("operation")) // for required spectrads3 operation query param nothing to specify
                 .map(Parameter::toString)

--- a/ds3-autogen-c/src/main/java/com/spectralogic/ds3autogen/c/models/StructMember.java
+++ b/ds3-autogen-c/src/main/java/com/spectralogic/ds3autogen/c/models/StructMember.java
@@ -54,6 +54,9 @@ public class StructMember {
     }
 
     public String getName() {
+        if(name.equalsIgnoreCase("protected")) {
+            return name + "_flag";
+        }
         return name;
     }
 

--- a/ds3-autogen-c/src/main/resources/templates/source-templates/modify_request.ftl
+++ b/ds3-autogen-c/src/main/resources/templates/source-templates/modify_request.ftl
@@ -100,6 +100,14 @@ static void _set_query_param_flag(const ds3_request* _request, const char* key, 
     }
 }
 
+static void _set_query_param_ds3_bool(const ds3_request* _request, const char* key, ds3_bool value) {
+    if (value == True) {
+        _set_query_param(_request, key, "True");
+    } else {
+        _set_query_param(_request, key, "False");
+    }
+}
+
 static void _set_query_param_uint64_t(const ds3_request* _request, const char* key, uint64_t value) {
     char string_buffer[STRING_BUFFER_SIZE];
     memset(string_buffer, 0, sizeof(string_buffer));


### PR DESCRIPTION
Fixed generation of C boolean query parameters to allow for setting of true/false values. Also special cased the naming of the protected flag to avoid key word conflict.