### PR TITLE
Fixing missing buffer_size in python SDK client generation

### DIFF
--- a/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/generators/client/BaseClientGenerator.java
+++ b/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/generators/client/BaseClientGenerator.java
@@ -62,6 +62,6 @@ public class BaseClientGenerator implements ClientModelGenerator<BaseClient>, Cl
 
     @Override
     public String getResponseParameters() {
-        return "self.net_client.get_response(request), request";
+        return "resp, request";
     }
 }

--- a/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/generators/client/GetObjectCommandGenerator.java
+++ b/ds3-autogen-python/src/main/java/com/spectralogic/ds3autogen/python/generators/client/GetObjectCommandGenerator.java
@@ -24,6 +24,6 @@ public class GetObjectCommandGenerator extends BaseClientGenerator {
 
     @Override
     public String getResponseParameters() {
-        return "self.net_client.get_response(request), request, buffer_size";
+        return "resp, request, buffer_size";
     }
 }

--- a/ds3-autogen-python/src/main/resources/tmpls/python/commands/client/client_class.ftl
+++ b/ds3-autogen-python/src/main/resources/tmpls/python/commands/client/client_class.ftl
@@ -13,5 +13,5 @@ class Client(object):
         if not isinstance(request, ${cmd.requestType}):
             raise TypeError('request for ${cmd.commandName} should be of type ${cmd.requestType} but was ' + request.__class__.__name__)
         with self.net_client.open_response(request) as resp:
-            return ${cmd.responseName}(resp, request)
+            return ${cmd.responseName}(${cmd.responseParams})
 </#list>

--- a/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/generators/client/BaseClientGenerator_Test.java
+++ b/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/generators/client/BaseClientGenerator_Test.java
@@ -68,7 +68,7 @@ public class BaseClientGenerator_Test {
 
     @Test
     public void getResponseParametersTest() {
-        final String expected = "self.net_client.get_response(request), request";
+        final String expected = "resp, request";
         assertThat(generator.getResponseParameters(), is(expected));
     }
 }

--- a/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/generators/client/GetObjectCommandGenerator_Test.java
+++ b/ds3-autogen-python/src/test/java/com.spectralogic.ds3autogen.python/generators/client/GetObjectCommandGenerator_Test.java
@@ -32,7 +32,7 @@ public class GetObjectCommandGenerator_Test {
 
     @Test
     public void getResponseParametersTest() {
-        final String expected = "self.net_client.get_response(request), request, buffer_size";
+        final String expected = "resp, request, buffer_size";
         assertThat(generator.getResponseParameters(), is(expected));
     }
 }


### PR DESCRIPTION
Fixing python SDK generation where the client template was accidentally changed to pass static response parameters rather than generated parameters. This caused the get_object call to longer be passed the optional buffer_size parameter. This is a regression caused by https://github.com/SpectraLogic/ds3_autogen/pull/502.

This was fixed in the python3 SDK with https://github.com/SpectraLogic/ds3_python3_sdk/pull/70.