### PR TITLE
Auto-generate strconv import in Go client files

### DIFF
--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/client/BaseClientGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/client/BaseClientGenerator.kt
@@ -30,8 +30,19 @@ open class BaseClientGenerator : ClientModelGenerator<Client> {
     override fun generate(ds3Requests: ImmutableList<Ds3Request>): Client {
         val commandsNoRedirect = toCommandList(ds3Requests, false)
         val commandsWithRedirect = toCommandList(ds3Requests, true)
+        val usesStrconv = anyCommandUsesStrconv(commandsNoRedirect) || anyCommandUsesStrconv(commandsWithRedirect)
 
-        return Client(commandsNoRedirect, commandsWithRedirect)
+        return Client(commandsNoRedirect, commandsWithRedirect, usesStrconv)
+    }
+
+    /**
+     * Determines whether any command in the list emits a request build line that
+     * references the Go strconv package. Required query params for primitive types
+     * (int, int64, bool, float64) are converted to strings using strconv, so the
+     * generated client file must import strconv when any such command is present.
+     */
+    fun anyCommandUsesStrconv(commands: ImmutableList<Command>): Boolean {
+        return commands.any { cmd -> cmd.requestBuildLine.any { it.line.contains("strconv.") } }
     }
 
     /**

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/models/client/Client.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/models/client/Client.kt
@@ -19,4 +19,5 @@ import com.google.common.collect.ImmutableList
 
 data class Client(
         val commandsNoRedirect: ImmutableList<Command>,
-        val commandsWithRedirect: ImmutableList<Command>)
+        val commandsWithRedirect: ImmutableList<Command>,
+        val usesStrconv: Boolean)

--- a/ds3-autogen-go/src/main/resources/tmpls/go/client/client_template.ftl
+++ b/ds3-autogen-go/src/main/resources/tmpls/go/client/client_template.ftl
@@ -6,6 +6,9 @@ import (
     "context"
     "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
     "github.com/SpectraLogic/ds3_go_sdk/ds3/networking"
+<#if usesStrconv>
+    "strconv"
+</#if>
 )
 
 <#list commandsNoRedirect as cmd>

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTests.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTests.java
@@ -86,6 +86,9 @@ public class GoFunctionalTests {
         assertTrue(client.contains("WithQueryParam(\"id\", request.Id)."));
         assertTrue(client.contains("WithOptionalQueryParam(\"upload_id\", request.UploadId)."));
         assertTrue(client.contains("WithOptionalQueryParam(\"offset\", networking.Int64PtrToStrPtr(request.Offset))."));
+
+        // Client must not import strconv when no command uses strconv-based conversions.
+        assertFalse(client.contains("\"strconv\""));
     }
 
     @Test
@@ -872,6 +875,9 @@ public class GoFunctionalTests {
         assertTrue(client.contains("WithQueryParam(\"part_number\", strconv.Itoa(request.PartNumber))."));
         assertTrue(client.contains("WithQueryParam(\"upload_id\", request.UploadId)."));
         assertTrue(client.contains("WithReader(request.Content)."));
+
+        // Client must import strconv when any command uses strconv-based conversions.
+        assertTrue(client.contains("\"strconv\""));
     }
 
     @Test


### PR DESCRIPTION
The Go client template hardcoded the import block without "strconv", even though required query params of type int/int64/bool/float64 emit strconv conversions. ds3Puts.go (and any future verb file with such params) had to be patched manually after each regeneration.

Add a usesStrconv flag to the Client model, compute it in BaseClientGenerator by scanning command build lines for "strconv.", and conditionally emit the import in client_template.ftl.