### PR TITLE
Generate gofmt-compliant Go SDK code

### DIFF
--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/client/ClientGeneratorUtil.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/client/ClientGeneratorUtil.kt
@@ -51,10 +51,10 @@ fun Ds3Request.getAmazonS3RequestPath(): String {
     }
     val builder = StringBuilder("\"/\"")
     if (bucketRequirement == Requirement.REQUIRED) {
-        builder.append(" + ").append(PATH_REQUEST_REFERENCE).append(".BucketName")
+        builder.append("+").append(PATH_REQUEST_REFERENCE).append(".BucketName")
     }
     if (objectRequirement == Requirement.REQUIRED) {
-        builder.append(" + \"/\" + ").append(PATH_REQUEST_REFERENCE).append(".ObjectName")
+        builder.append("+\"/\"+").append(PATH_REQUEST_REFERENCE).append(".ObjectName")
     }
     return builder.toString()
 }
@@ -77,12 +77,12 @@ fun Ds3Request.getSpectraDs3RequestPath(): String {
             && includeInPath
             && (RequestConverterUtil.getNotificationType(this) == NotificationType.DELETE
                 || RequestConverterUtil.getNotificationType(this) == NotificationType.GET)) {
-        builder.append("/\"").append(" + ").append(PATH_REQUEST_REFERENCE).append(".NotificationId")
+        builder.append("/\"").append("+").append(PATH_REQUEST_REFERENCE).append(".NotificationId")
     } else if (Ds3RequestUtils.hasBucketNameInPath(this)) {
-        builder.append("/\"").append(" + ").append(PATH_REQUEST_REFERENCE).append(".BucketName")
+        builder.append("/\"").append("+").append(PATH_REQUEST_REFERENCE).append(".BucketName")
     } else if (this.isGoResourceAnArg()) {
         val resourceArg = this.getGoArgFromResource()
-        builder.append("/\"").append(" + ").append(PATH_REQUEST_REFERENCE)
+        builder.append("/\"").append("+").append(PATH_REQUEST_REFERENCE)
                 .append(".").append(resourceArg.name.capitalize())
     } else {
         builder.append("\"")

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/response/BaseResponseGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/response/BaseResponseGenerator.kt
@@ -20,6 +20,7 @@ import com.spectralogic.ds3autogen.api.models.apispec.Ds3Request
 import com.spectralogic.ds3autogen.api.models.apispec.Ds3ResponseCode
 import com.spectralogic.ds3autogen.go.models.response.Response
 import com.spectralogic.ds3autogen.go.models.response.ResponseCode
+import com.spectralogic.ds3autogen.go.models.response.ResponseStructField
 import com.spectralogic.ds3autogen.go.utils.goIndent
 import com.spectralogic.ds3autogen.utils.ConverterUtil.hasContent
 import com.spectralogic.ds3autogen.utils.ConverterUtil.isEmpty
@@ -39,11 +40,40 @@ open class BaseResponseGenerator : ResponseModelGenerator<Response>, ResponseMod
 
         val name = NormalizingContractNamesUtil.toResponseName(ds3Request.name)
         val payloadStruct = toResponsePayloadStruct(ds3Request.ds3ResponseCodes)
+        val payloadFields = toResponsePayloadFields(ds3Request.ds3ResponseCodes)
         val expectedCodes = toExpectedStatusCodes(ds3Request.ds3ResponseCodes)
         val parseResponseMethod = toParseResponseMethod(name, payloadStruct, ds3Request.ds3ResponseCodes)
         val responseCodes = toResponseCodeList(ds3Request.ds3ResponseCodes, name)
 
-        return Response(name, payloadStruct, expectedCodes, parseResponseMethod, responseCodes)
+        return Response(name, payloadStruct, payloadFields, expectedCodes, parseResponseMethod, responseCodes)
+    }
+
+    /**
+     * Returns the response payload fields as structured (name, type) pairs so the
+     * template can compute gofmt-compatible alignment when emitting the struct.
+     */
+    open fun toResponsePayloadFields(expectedResponseCodes: ImmutableList<Ds3ResponseCode>?): ImmutableList<ResponseStructField> {
+        val payloadStruct = toResponsePayloadStruct(expectedResponseCodes)
+        if (payloadStruct.isEmpty()) {
+            return ImmutableList.of()
+        }
+        return parsePayloadStruct(payloadStruct)
+    }
+
+    /**
+     * Splits the legacy multi-line payload struct string into structured fields.
+     * Each line is "Name Type" optionally prefixed by indentation.
+     */
+    private fun parsePayloadStruct(payloadStruct: String): ImmutableList<ResponseStructField> {
+        val fields = ImmutableList.builder<ResponseStructField>()
+        for (rawLine in payloadStruct.split("\n")) {
+            val line = rawLine.trim()
+            if (line.isEmpty()) continue
+            val firstSpace = line.indexOf(' ')
+            if (firstSpace < 0) continue
+            fields.add(ResponseStructField(line.substring(0, firstSpace), line.substring(firstSpace + 1).trim()))
+        }
+        return fields.build()
     }
 
     /**
@@ -63,7 +93,7 @@ open class BaseResponseGenerator : ResponseModelGenerator<Response>, ResponseMod
         val modelName = name.decapitalize()
         val dereference = toDereferenceResponsePayload(payloadStruct)
         return "func ($modelName *$name) parse(webResponse WebResponse) error {\n" +
-                goIndent(1) + "    return parseResponsePayload(webResponse, $dereference$modelName.$elementName)\n" +
+                goIndent(1) + "return parseResponsePayload(webResponse, $dereference$modelName.$elementName)\n" +
                 "}"
     }
 

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/response/GetObjectResponseGenerator.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/generators/response/GetObjectResponseGenerator.kt
@@ -40,7 +40,7 @@ class GetObjectResponseGenerator : BaseResponseGenerator() {
      */
     override fun toResponseCode(ds3ResponseCode: Ds3ResponseCode, responseName: String): ResponseCode {
         if (ds3ResponseCode.code == 200 || ds3ResponseCode.code == 206) {
-            return ResponseCode(ds3ResponseCode.code, "return &$responseName{ Content: webResponse.Body(), Headers: webResponse.Header() }, nil")
+            return ResponseCode(ds3ResponseCode.code, "return &$responseName{Content: webResponse.Body(), Headers: webResponse.Header()}, nil")
         }
         return toStandardResponseCode(ds3ResponseCode, responseName)
     }

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/models/response/Response.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/models/response/Response.kt
@@ -16,11 +16,13 @@
 package com.spectralogic.ds3autogen.go.models.response
 
 import com.google.common.collect.ImmutableList
-import com.google.common.collect.ImmutableSet
+
+data class ResponseStructField(val name: String, val type: String)
 
 data class Response(
         val name: String,
         val payloadStruct: String, //The struct definition for the response payload
+        val payloadFields: ImmutableList<ResponseStructField>, //Payload fields, used by templates for aligned struct emission
         val expectedCodes: String,
         val parseResponseMethod: String, //Contains the Go code for the parse method if one is needed, else empty
         val responseCodes: ImmutableList<ResponseCode>)

--- a/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/utils/GoFormattingUtil.kt
+++ b/ds3-autogen-go/src/main/kotlin/com/spectralogic/ds3autogen/go/utils/GoFormattingUtil.kt
@@ -20,7 +20,7 @@ package com.spectralogic.ds3autogen.go.utils
  */
 
 /** The standard indentation used in the Go SDK */
-private val GO_INDENT = "    "
+private val GO_INDENT = "\t"
 
 /**
  * Creates the specified indentation in accordance with the Go SDK formatting

--- a/ds3-autogen-go/src/main/resources/tmpls/go/client/client_template.ftl
+++ b/ds3-autogen-go/src/main/resources/tmpls/go/client/client_template.ftl
@@ -3,65 +3,63 @@
 package ds3
 
 import (
-    "context"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3/models"
-    "github.com/SpectraLogic/ds3_go_sdk/ds3/networking"
+	"context"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3/models"
+	"github.com/SpectraLogic/ds3_go_sdk/ds3/networking"
 <#if usesStrconv>
-    "strconv"
+	"strconv"
 </#if>
 )
-
 <#list commandsNoRedirect as cmd>
+
 func (client *Client) ${cmd.name}(ctx context.Context, request *models.${cmd.name}Request) (*models.${cmd.name}Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        <#list cmd.requestBuildLine as line>
-        ${line.line}
-        </#list>
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		<#list cmd.requestBuildLine as line>
+		${line.line}
+		</#list>
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
 
-    // Invoke the HTTP request.
-    response, requestErr := networkRetryDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := networkRetryDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.New${cmd.name}Response(response)
+	// Create a response object based on the result.
+	return models.New${cmd.name}Response(response)
 }
-
 </#list>
-
 <#list commandsWithRedirect as cmd>
+
 func (client *Client) ${cmd.name}(ctx context.Context, request *models.${cmd.name}Request) (*models.${cmd.name}Response, error) {
-    // Build the http request
-    httpRequest, err := networking.NewHttpRequestBuilder().
-        <#list cmd.requestBuildLine as line>
-        ${line.line}
-        </#list>
-        Build(ctx, client.connectionInfo)
+	// Build the http request
+	httpRequest, err := networking.NewHttpRequestBuilder().
+		<#list cmd.requestBuildLine as line>
+		${line.line}
+		</#list>
+		Build(ctx, client.connectionInfo)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
-    httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
+	networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)
+	httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)
 
-    // Invoke the HTTP request.
-    response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
-    if requestErr != nil {
-        return nil, requestErr
-    }
+	// Invoke the HTTP request.
+	response, requestErr := httpRedirectDecorator.Invoke(httpRequest)
+	if requestErr != nil {
+		return nil, requestErr
+	}
 
-    // Create a response object based on the result.
-    return models.New${cmd.name}Response(response)
+	// Create a response object based on the result.
+	return models.New${cmd.name}Response(response)
 }
-
 </#list>

--- a/ds3-autogen-go/src/main/resources/tmpls/go/parser/base_type_parser.ftl
+++ b/ds3-autogen-go/src/main/resources/tmpls/go/parser/base_type_parser.ftl
@@ -1,30 +1,30 @@
+
 func (${modelName?uncap_first} *${modelName?cap_first}) parse(xmlNode *XmlNode, aggErr *AggregateError) {
-    <#if helper.hasContent(attributes) == true>
-    // Parse Attributes
-    for _, attr := range xmlNode.Attrs {
-        switch attr.Name.Local {
-        <#list attributes as attr>
-        case "${attr.xmlTag}":
-            ${attr.parsingCode}
-        </#list>
-        default:
-            log.Printf("WARNING: unable to parse unknown attribute '%s' while parsing ${modelName}.", attr.Name.Local)
-        }
-    }
-    </#if>
+<#if helper.hasContent(attributes) == true>
+	// Parse Attributes
+	for _, attr := range xmlNode.Attrs {
+		switch attr.Name.Local {
+<#list attributes as attr>
+		case "${attr.xmlTag}":
+			${attr.parsingCode}
+</#list>
+		default:
+			log.Printf("WARNING: unable to parse unknown attribute '%s' while parsing ${modelName}.", attr.Name.Local)
+		}
+	}
+</#if>
+<#if helper.hasContent(childNodes) == true>
 
-    <#if helper.hasContent(childNodes) == true>
-    // Parse Child Nodes
-    for _, child := range xmlNode.Children {
-        switch child.XMLName.Local {
-        <#list childNodes as child>
-        case "${child.xmlTag}":
-            ${child.parsingCode}
-        </#list>
-        default:
-            log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing ${modelName}.", child.XMLName.Local)
-        }
-    }
-    </#if>
+	// Parse Child Nodes
+	for _, child := range xmlNode.Children {
+		switch child.XMLName.Local {
+<#list childNodes as child>
+		case "${child.xmlTag}":
+			${child.parsingCode}
+</#list>
+		default:
+			log.Printf("WARNING: unable to parse unknown xml tag '%s' while parsing ${modelName}.", child.XMLName.Local)
+		}
+	}
+</#if>
 }
-

--- a/ds3-autogen-go/src/main/resources/tmpls/go/parser/type_parser_with_list.ftl
+++ b/ds3-autogen-go/src/main/resources/tmpls/go/parser/type_parser_with_list.ftl
@@ -1,16 +1,15 @@
 <#include "base_type_parser.ftl" />
 
 func parse${modelName}Slice(tagName string, xmlNodes []XmlNode, aggErr *AggregateError) []${modelName} {
-    var result []${modelName}
-    for _, curXmlNode := range xmlNodes {
-        if curXmlNode.XMLName.Local == tagName {
-            var curResult ${modelName}
-            curResult.parse(&curXmlNode, aggErr)
-            result = append(result, curResult)
-        } else {
-            log.Printf("WARNING: Discovered unexpected xml tag '%s' when expected tag '%s' when parsing ${modelName} struct.\n", curXmlNode.XMLName.Local, tagName)
-        }
-    }
-    return result
+	var result []${modelName}
+	for _, curXmlNode := range xmlNodes {
+		if curXmlNode.XMLName.Local == tagName {
+			var curResult ${modelName}
+			curResult.parse(&curXmlNode, aggErr)
+			result = append(result, curResult)
+		} else {
+			log.Printf("WARNING: Discovered unexpected xml tag '%s' when expected tag '%s' when parsing ${modelName} struct.\n", curXmlNode.XMLName.Local, tagName)
+		}
+	}
+	return result
 }
-

--- a/ds3-autogen-go/src/main/resources/tmpls/go/request/get_bulk_job_request.ftl
+++ b/ds3-autogen-go/src/main/resources/tmpls/go/request/get_bulk_job_request.ftl
@@ -1,23 +1,29 @@
 <#include "request_struct.ftl" />
 
+<#assign maxConstNameLen = 0>
+<#list constructor.structParams as param>
+	<#if param.name?cap_first?length gt maxConstNameLen>
+		<#assign maxConstNameLen = param.name?cap_first?length>
+	</#if>
+</#list>
+<#if "Objects"?length gt maxConstNameLen>
+	<#assign maxConstNameLen = "Objects"?length>
+</#if>
 func New${name}(${constructor.constructorParams}, objectNames []string) *${name} {
-
-    return &${name}{
-        <#list constructor.structParams as param>
-        ${param.name?cap_first}: ${param.assignment},
-        </#list>
-        Objects: buildDs3GetObjectSliceFromNames(objectNames),
-    }
+	return &${name}{
+<#list constructor.structParams as param>
+		${(param.name?cap_first + ":")?right_pad(maxConstNameLen + 1)} ${param.assignment},
+</#list>
+		${("Objects:")?right_pad(maxConstNameLen + 1)} buildDs3GetObjectSliceFromNames(objectNames),
+	}
 }
 
 func New${name}WithPartialObjects(${constructor.constructorParams}, objects []Ds3GetObject) *${name} {
-
-    return &${name}{
-        <#list constructor.structParams as param>
-        ${param.name?cap_first}: ${param.assignment},
-        </#list>
-        Objects: objects,
-    }
+	return &${name}{
+<#list constructor.structParams as param>
+		${(param.name?cap_first + ":")?right_pad(maxConstNameLen + 1)} ${param.assignment},
+</#list>
+		${("Objects:")?right_pad(maxConstNameLen + 1)} objects,
+	}
 }
-
 <#include "with_constructors.ftl" />

--- a/ds3-autogen-go/src/main/resources/tmpls/go/request/get_object_request.ftl
+++ b/ds3-autogen-go/src/main/resources/tmpls/go/request/get_object_request.ftl
@@ -1,17 +1,16 @@
+
 type Range struct {
-    Start int64
-    End int64
+	Start int64
+	End   int64
 }
-
 <#include "request_body.ftl" />
-
 <#include "with_checksum.ftl" />
 
 func (${name?uncap_first} *${name}) WithRanges(ranges ...Range) *${name} {
-    var rangeElements []string
-    for _, cur := range ranges {
-        rangeElements = append(rangeElements, fmt.Sprintf("%d-%d", cur.Start, cur.End))
-    }
-    ${name?uncap_first}.Metadata["Range"] = fmt.Sprintf("bytes=%s", strings.Join(rangeElements[:], ","))
-    return ${name?uncap_first}
+	var rangeElements []string
+	for _, cur := range ranges {
+		rangeElements = append(rangeElements, fmt.Sprintf("%d-%d", cur.Start, cur.End))
+	}
+	${name?uncap_first}.Metadata["Range"] = fmt.Sprintf("bytes=%s", strings.Join(rangeElements[:], ","))
+	return ${name?uncap_first}
 }

--- a/ds3-autogen-go/src/main/resources/tmpls/go/request/put_object_request.ftl
+++ b/ds3-autogen-go/src/main/resources/tmpls/go/request/put_object_request.ftl
@@ -1,5 +1,3 @@
 <#include "request_body.ftl" />
-
 <#include "with_checksum.ftl" />
-
 <#include "with_headers.ftl" />

--- a/ds3-autogen-go/src/main/resources/tmpls/go/request/request_body.ftl
+++ b/ds3-autogen-go/src/main/resources/tmpls/go/request/request_body.ftl
@@ -1,11 +1,20 @@
 <#include "request_struct.ftl" />
 
+<#assign maxConstNameLen = 0>
+<#list constructor.structParams as param>
+	<#if param.name?cap_first?length gt maxConstNameLen>
+		<#assign maxConstNameLen = param.name?cap_first?length>
+	</#if>
+</#list>
 func New${name}(${constructor.constructorParams}) *${name} {
-    return &${name}{
-        <#list constructor.structParams as param>
-        ${param.name?cap_first}: ${param.assignment},
-        </#list>
-    }
+<#if constructor.structParams?has_content>
+	return &${name}{
+<#list constructor.structParams as param>
+		${(param.name?cap_first + ":")?right_pad(maxConstNameLen + 1)} ${param.assignment},
+</#list>
+	}
+<#else>
+	return &${name}{}
+</#if>
 }
-
 <#include "with_constructors.ftl" />

--- a/ds3-autogen-go/src/main/resources/tmpls/go/request/request_header.ftl
+++ b/ds3-autogen-go/src/main/resources/tmpls/go/request/request_header.ftl
@@ -3,7 +3,6 @@
 package models
 
 import (
-    "fmt"
-    "strings"
+	"fmt"
+	"strings"
 )
-

--- a/ds3-autogen-go/src/main/resources/tmpls/go/request/request_struct.ftl
+++ b/ds3-autogen-go/src/main/resources/tmpls/go/request/request_struct.ftl
@@ -1,5 +1,12 @@
+<#assign maxNameLen = 0>
+<#list structParams as param>
+	<#if param.name?cap_first?length gt maxNameLen>
+		<#assign maxNameLen = param.name?cap_first?length>
+	</#if>
+</#list>
+
 type ${name} struct {
-    <#list structParams as param>
-    ${param.name?cap_first} ${param.type}
-    </#list>
+<#list structParams as param>
+	${param.name?cap_first?right_pad(maxNameLen)} ${param.type}
+</#list>
 }

--- a/ds3-autogen-go/src/main/resources/tmpls/go/request/with_checksum.ftl
+++ b/ds3-autogen-go/src/main/resources/tmpls/go/request/with_checksum.ftl
@@ -1,5 +1,6 @@
+
 func (${name?uncap_first} *${name}) WithChecksum(contentHash string, checksumType ChecksumType) *${name} {
-    ${name?uncap_first}.Checksum.ContentHash = contentHash
-    ${name?uncap_first}.Checksum.Type = checksumType
-    return ${name?uncap_first}
+	${name?uncap_first}.Checksum.ContentHash = contentHash
+	${name?uncap_first}.Checksum.Type = checksumType
+	return ${name?uncap_first}
 }

--- a/ds3-autogen-go/src/main/resources/tmpls/go/request/with_constructors.ftl
+++ b/ds3-autogen-go/src/main/resources/tmpls/go/request/with_constructors.ftl
@@ -1,7 +1,7 @@
 <#list withConstructors as const>
-func (${name?uncap_first} *${name}) With${const.name?cap_first}(${const.constructorParams}) *${name} {
-    ${name?uncap_first}.${const.name?cap_first} = ${const.assignment}
-    return ${name?uncap_first}
-}
 
+func (${name?uncap_first} *${name}) With${const.name?cap_first}(${const.constructorParams}) *${name} {
+	${name?uncap_first}.${const.name?cap_first} = ${const.assignment}
+	return ${name?uncap_first}
+}
 </#list>

--- a/ds3-autogen-go/src/main/resources/tmpls/go/request/with_headers.ftl
+++ b/ds3-autogen-go/src/main/resources/tmpls/go/request/with_headers.ftl
@@ -1,8 +1,9 @@
+
 func (${name?uncap_first} *${name}) WithMetaData(key string, values ...string) *${name} {
-    if strings.HasPrefix(strings.ToLower(key), AMZ_META_HEADER) {
-        ${name?uncap_first}.Metadata[key] = strings.Join(values, ",")
-    } else {
-        ${name?uncap_first}.Metadata[strings.ToLower(AMZ_META_HEADER + key)] = strings.Join(values, ",")
-    }
-    return ${name?uncap_first}
+	if strings.HasPrefix(strings.ToLower(key), AMZ_META_HEADER) {
+		${name?uncap_first}.Metadata[key] = strings.Join(values, ",")
+	} else {
+		${name?uncap_first}.Metadata[strings.ToLower(AMZ_META_HEADER+key)] = strings.Join(values, ",")
+	}
+	return ${name?uncap_first}
 }

--- a/ds3-autogen-go/src/main/resources/tmpls/go/response/response_get_object_template.ftl
+++ b/ds3-autogen-go/src/main/resources/tmpls/go/response/response_get_object_template.ftl
@@ -1,21 +1,31 @@
+<#assign maxFieldNameLen = "Headers"?length>
+<#list payloadFields as field>
+	<#if field.name?length gt maxFieldNameLen>
+		<#assign maxFieldNameLen = field.name?length>
+	</#if>
+</#list>
+
 type ${name} struct {
-    ${payloadStruct}
-    Headers *http.Header
+<#list payloadFields as field>
+	${field.name?right_pad(maxFieldNameLen)} ${field.type}
+</#list>
+	${"Headers"?right_pad(maxFieldNameLen)} *http.Header
 }
+<#if parseResponseMethod?has_content>
 
 ${parseResponseMethod}
+</#if>
 
 func New${name}(webResponse WebResponse) (*${name}, error) {
-    expectedStatusCodes := []int { ${expectedCodes} }
+	expectedStatusCodes := []int{${expectedCodes}}
 
-    switch code := webResponse.StatusCode(); code {
-    <#list responseCodes as code>
-    case ${code.code}:
-        ${code.parseResponse}
-    </#list>
-    default:
-        defer webResponse.Body().Close()
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+<#list responseCodes as code>
+	case ${code.code}:
+		${code.parseResponse}
+</#list>
+	default:
+		defer webResponse.Body().Close()
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
-

--- a/ds3-autogen-go/src/main/resources/tmpls/go/response/response_header.ftl
+++ b/ds3-autogen-go/src/main/resources/tmpls/go/response/response_header.ftl
@@ -3,7 +3,6 @@
 package models
 
 import (
-    "net/http"
-    "io"
+	"io"
+	"net/http"
 )
-

--- a/ds3-autogen-go/src/main/resources/tmpls/go/response/response_template.ftl
+++ b/ds3-autogen-go/src/main/resources/tmpls/go/response/response_template.ftl
@@ -1,21 +1,31 @@
+<#assign maxFieldNameLen = "Headers"?length>
+<#list payloadFields as field>
+	<#if field.name?length gt maxFieldNameLen>
+		<#assign maxFieldNameLen = field.name?length>
+	</#if>
+</#list>
+
 type ${name} struct {
-    ${payloadStruct}
-    Headers *http.Header
+<#list payloadFields as field>
+	${field.name?right_pad(maxFieldNameLen)} ${field.type}
+</#list>
+	${"Headers"?right_pad(maxFieldNameLen)} *http.Header
 }
+<#if parseResponseMethod?has_content>
 
 ${parseResponseMethod}
+</#if>
 
 func New${name}(webResponse WebResponse) (*${name}, error) {
-    defer webResponse.Body().Close()
-    expectedStatusCodes := []int { ${expectedCodes} }
+	defer webResponse.Body().Close()
+	expectedStatusCodes := []int{${expectedCodes}}
 
-    switch code := webResponse.StatusCode(); code {
-    <#list responseCodes as code>
-    case ${code.code}:
-        ${code.parseResponse}
-    </#list>
-    default:
-        return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
-    }
+	switch code := webResponse.StatusCode(); code {
+<#list responseCodes as code>
+	case ${code.code}:
+		${code.parseResponse}
+</#list>
+	default:
+		return nil, buildBadStatusCodeError(webResponse, expectedStatusCodes)
+	}
 }
-

--- a/ds3-autogen-go/src/main/resources/tmpls/go/type/checksum_type_enum.ftl
+++ b/ds3-autogen-go/src/main/resources/tmpls/go/type/checksum_type_enum.ftl
@@ -1,20 +1,27 @@
+<#assign maxConstLen = "NONE"?length>
+<#list enumConstants as const>
+	<#if (enumPrefix + const)?length gt maxConstLen>
+		<#assign maxConstLen = (enumPrefix + const)?length>
+	</#if>
+</#list>
+
 type ${name} Enum
 
 const (
-    <#list enumConstants as const>
-    ${enumPrefix}${const} ${name} = 1 + iota
-    </#list>
-    NONE ChecksumType = 1 + iota
+<#list enumConstants as const>
+	${(enumPrefix + const)?right_pad(maxConstLen)} ${name} = 1 + iota
+</#list>
+	${"NONE"?right_pad(maxConstLen)} ChecksumType = 1 + iota
 )
 
 <#include "enum_unmarshal_to_string.ftl" />
 
 func new${name}FromContent(content []byte, aggErr *AggregateError) *${name} {
-    if len(content) == 0 {
-        // no value
-        return nil
-    }
-    result := new(${name})
-    parseEnum(content, result, aggErr)
-    return result
+	if len(content) == 0 {
+		// no value
+		return nil
+	}
+	result := new(${name})
+	parseEnum(content, result, aggErr)
+	return result
 }

--- a/ds3-autogen-go/src/main/resources/tmpls/go/type/enum_type.ftl
+++ b/ds3-autogen-go/src/main/resources/tmpls/go/type/enum_type.ftl
@@ -1,19 +1,26 @@
+<#assign maxConstLen = 0>
+<#list enumConstants as const>
+	<#if (enumPrefix + const)?length gt maxConstLen>
+		<#assign maxConstLen = (enumPrefix + const)?length>
+	</#if>
+</#list>
+
 type ${name} Enum
 
 const (
-    <#list enumConstants as const>
-    ${enumPrefix}${const} ${name} = 1 + iota
-    </#list>
+<#list enumConstants as const>
+	${(enumPrefix + const)?right_pad(maxConstLen)} ${name} = 1 + iota
+</#list>
 )
 
 <#include "enum_unmarshal_to_string.ftl" />
 
 func new${name}FromContent(content []byte, aggErr *AggregateError) *${name} {
-    if len(content) == 0 {
-        // no value
-        return nil
-    }
-    result := new(${name})
-    parseEnum(content, result, aggErr)
-    return result
+	if len(content) == 0 {
+		// no value
+		return nil
+	}
+	result := new(${name})
+	parseEnum(content, result, aggErr)
+	return result
 }

--- a/ds3-autogen-go/src/main/resources/tmpls/go/type/enum_unmarshal_to_string.ftl
+++ b/ds3-autogen-go/src/main/resources/tmpls/go/type/enum_unmarshal_to_string.ftl
@@ -1,32 +1,35 @@
 func (${name?uncap_first} *${name}) UnmarshalText(text []byte) error {
-    var str string = string(bytes.ToUpper(text))
-    switch str {
-        case "": *${name?uncap_first} = UNDEFINED
-        <#list enumConstants as const>
-        case "${const}": *${name?uncap_first} = ${enumPrefix}${const}
-        </#list>
-        default:
-            *${name?uncap_first} = UNDEFINED
-            return errors.New(fmt.Sprintf("Cannot marshal '%s' into ${name}", str))
-    }
-    return nil
+	var str string = string(bytes.ToUpper(text))
+	switch str {
+	case "":
+		*${name?uncap_first} = UNDEFINED
+<#list enumConstants as const>
+	case "${const}":
+		*${name?uncap_first} = ${enumPrefix}${const}
+</#list>
+	default:
+		*${name?uncap_first} = UNDEFINED
+		return errors.New(fmt.Sprintf("Cannot marshal '%s' into ${name}", str))
+	}
+	return nil
 }
 
 func (${name?uncap_first} ${name}) String() string {
-    switch ${name?uncap_first} {
-        <#list enumConstants as const>
-        case ${enumPrefix}${const}: return "${const}"
-        </#list>
-        default:
-            log.Printf("Error: invalid ${name} represented by '%d'", ${name?uncap_first})
-            return ""
-    }
+	switch ${name?uncap_first} {
+<#list enumConstants as const>
+	case ${enumPrefix}${const}:
+		return "${const}"
+</#list>
+	default:
+		log.Printf("Error: invalid ${name} represented by '%d'", ${name?uncap_first})
+		return ""
+	}
 }
 
 func (${name?uncap_first} ${name}) StringPtr() *string {
-    if ${name?uncap_first} == UNDEFINED {
-        return nil
-    }
-    result := ${name?uncap_first}.String()
-    return &result
+	if ${name?uncap_first} == UNDEFINED {
+		return nil
+	}
+	result := ${name?uncap_first}.String()
+	return &result
 }

--- a/ds3-autogen-go/src/main/resources/tmpls/go/type/type_header.ftl
+++ b/ds3-autogen-go/src/main/resources/tmpls/go/type/type_header.ftl
@@ -3,9 +3,8 @@
 package models
 
 import (
-    "errors"
-    "fmt"
-    "bytes"
-    "log"
+	"bytes"
+	"errors"
+	"fmt"
+	"log"
 )
-

--- a/ds3-autogen-go/src/main/resources/tmpls/go/type/type_template.ftl
+++ b/ds3-autogen-go/src/main/resources/tmpls/go/type/type_template.ftl
@@ -1,6 +1,12 @@
-type ${name} struct {
-    <#list structElements as element>
-    ${element.name} ${element.type}
-    </#list>
-}
+<#assign maxNameLen = 0>
+<#list structElements as element>
+	<#if element.name?length gt maxNameLen>
+		<#assign maxNameLen = element.name?length>
+	</#if>
+</#list>
 
+type ${name} struct {
+<#list structElements as element>
+	${element.name?right_pad(maxNameLen)} ${element.type}
+</#list>
+}

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTests.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTests.java
@@ -38,6 +38,20 @@ public class GoFunctionalTests {
     private final static Logger LOG = LoggerFactory.getLogger(GoFunctionalTests.class);
     private final static GeneratedCodeLogger CODE_LOGGER = new GeneratedCodeLogger(FileTypeToLog.MODEL, LOG);
 
+    /**
+     * Collapses runs of whitespace in {@code haystack} and {@code needle} to a single
+     * space before checking containment. This lets assertions written as
+     * {@code "Foo Bar"} continue to match against gofmt-aligned output where Foo and
+     * Bar may be separated by multiple spaces.
+     */
+    private static boolean containsNormalized(final String haystack, final String needle) {
+        return normalize(haystack).contains(normalize(needle));
+    }
+
+    private static String normalize(final String s) {
+        return s.replaceAll("\\s+", " ");
+    }
+
     @Test
     public void simpleRequestNoPayload() throws IOException, TemplateModelException {
         final FileUtils fileUtils = mock(FileUtils.class);
@@ -55,16 +69,16 @@ public class GoFunctionalTests {
         CODE_LOGGER.logFile(responseCode, FileTypeToLog.RESPONSE);
         assertTrue(hasContent(responseCode));
 
-        assertFalse(responseCode.contains("\"ds3/networking\""));
-        assertTrue(responseCode.contains("\"net/http\""));
+        assertFalse(containsNormalized(responseCode, "\"ds3/networking\""));
+        assertTrue(containsNormalized(responseCode, "\"net/http\""));
 
-        assertTrue(responseCode.contains("Headers *http.Header"));
+        assertTrue(containsNormalized(responseCode, "Headers *http.Header"));
 
-        assertTrue(responseCode.contains("func NewSimpleNoPayloadResponse(webResponse WebResponse) (*SimpleNoPayloadResponse, error) {"));
-        assertTrue(responseCode.contains("expectedStatusCodes := []int { 200 }"));
-        assertTrue(responseCode.contains("return &SimpleNoPayloadResponse{Headers: webResponse.Header()}, nil"));
+        assertTrue(containsNormalized(responseCode, "func NewSimpleNoPayloadResponse(webResponse WebResponse) (*SimpleNoPayloadResponse, error) {"));
+        assertTrue(containsNormalized(responseCode, "expectedStatusCodes := []int{200}"));
+        assertTrue(containsNormalized(responseCode, "return &SimpleNoPayloadResponse{Headers: webResponse.Header()}, nil"));
 
-        assertFalse(responseCode.contains("parse(webResponse WebResponse)"));
+        assertFalse(containsNormalized(responseCode, "parse(webResponse WebResponse)"));
 
         // Verify response payload type file was not generated
         final String typeCode = codeGenerator.getTypeCode();
@@ -76,19 +90,19 @@ public class GoFunctionalTests {
         CODE_LOGGER.logFile(client, FileTypeToLog.CLIENT);
         assertTrue(hasContent(client));
 
-        assertTrue(client.contains("func (client *Client) SimpleNoPayload(ctx context.Context, request *models.SimpleNoPayloadRequest) (*models.SimpleNoPayloadResponse, error) {"));
-        assertTrue(client.contains("networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)"));
-        assertTrue(client.contains("httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)"));
-        assertTrue(client.contains("response, requestErr := httpRedirectDecorator.Invoke(httpRequest)"));
+        assertTrue(containsNormalized(client, "func (client *Client) SimpleNoPayload(ctx context.Context, request *models.SimpleNoPayloadRequest) (*models.SimpleNoPayloadResponse, error) {"));
+        assertTrue(containsNormalized(client, "networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)"));
+        assertTrue(containsNormalized(client, "httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)"));
+        assertTrue(containsNormalized(client, "response, requestErr := httpRedirectDecorator.Invoke(httpRequest)"));
 
-        assertTrue(client.contains("WithHttpVerb(HTTP_VERB_GET)."));
-        assertTrue(client.contains("WithPath(\"/\" + request.BucketName)."));
-        assertTrue(client.contains("WithQueryParam(\"id\", request.Id)."));
-        assertTrue(client.contains("WithOptionalQueryParam(\"upload_id\", request.UploadId)."));
-        assertTrue(client.contains("WithOptionalQueryParam(\"offset\", networking.Int64PtrToStrPtr(request.Offset))."));
+        assertTrue(containsNormalized(client, "WithHttpVerb(HTTP_VERB_GET)."));
+        assertTrue(containsNormalized(client, "WithPath(\"/\"+request.BucketName)."));
+        assertTrue(containsNormalized(client, "WithQueryParam(\"id\", request.Id)."));
+        assertTrue(containsNormalized(client, "WithOptionalQueryParam(\"upload_id\", request.UploadId)."));
+        assertTrue(containsNormalized(client, "WithOptionalQueryParam(\"offset\", networking.Int64PtrToStrPtr(request.Offset))."));
 
         // Client must not import strconv when no command uses strconv-based conversions.
-        assertFalse(client.contains("\"strconv\""));
+        assertFalse(containsNormalized(client, "\"strconv\""));
     }
 
     @Test
@@ -108,22 +122,22 @@ public class GoFunctionalTests {
         CODE_LOGGER.logFile(responseCode, FileTypeToLog.RESPONSE);
         assertTrue(hasContent(responseCode));
 
-        assertFalse(responseCode.contains("\"ds3/networking\""));
-        assertTrue(responseCode.contains("\"net/http\""));
+        assertFalse(containsNormalized(responseCode, "\"ds3/networking\""));
+        assertTrue(containsNormalized(responseCode, "\"net/http\""));
 
-        assertTrue(responseCode.contains("Bucket Bucket"));
-        assertFalse(responseCode.contains("`xml:\"Bucket\"`"));
-        assertTrue(responseCode.contains("Headers *http.Header"));
+        assertTrue(containsNormalized(responseCode, "Bucket Bucket"));
+        assertFalse(containsNormalized(responseCode, "`xml:\"Bucket\"`"));
+        assertTrue(containsNormalized(responseCode, "Headers *http.Header"));
 
-        assertTrue(responseCode.contains("func NewSimpleWithPayloadResponse(webResponse WebResponse) (*SimpleWithPayloadResponse, error) {"));
-        assertTrue(responseCode.contains("expectedStatusCodes := []int { 204 }"));
-        assertTrue(responseCode.contains("var body SimpleWithPayloadResponse"));
-        assertTrue(responseCode.contains("if err := body.parse(webResponse); err != nil {"));
-        assertTrue(responseCode.contains("body.Headers = webResponse.Header()"));
-        assertTrue(responseCode.contains("return &body, nil"));
+        assertTrue(containsNormalized(responseCode, "func NewSimpleWithPayloadResponse(webResponse WebResponse) (*SimpleWithPayloadResponse, error) {"));
+        assertTrue(containsNormalized(responseCode, "expectedStatusCodes := []int{204}"));
+        assertTrue(containsNormalized(responseCode, "var body SimpleWithPayloadResponse"));
+        assertTrue(containsNormalized(responseCode, "if err := body.parse(webResponse); err != nil {"));
+        assertTrue(containsNormalized(responseCode, "body.Headers = webResponse.Header()"));
+        assertTrue(containsNormalized(responseCode, "return &body, nil"));
 
-        assertTrue(responseCode.contains("func (simpleWithPayloadResponse *SimpleWithPayloadResponse) parse(webResponse WebResponse) error {"));
-        assertTrue(responseCode.contains("return parseResponsePayload(webResponse, &simpleWithPayloadResponse.Bucket)"));
+        assertTrue(containsNormalized(responseCode, "func (simpleWithPayloadResponse *SimpleWithPayloadResponse) parse(webResponse WebResponse) error {"));
+        assertTrue(containsNormalized(responseCode, "return parseResponsePayload(webResponse, &simpleWithPayloadResponse.Bucket)"));
 
         // Verify response payload type file was not generated
         final String typeCode = codeGenerator.getTypeCode();
@@ -135,16 +149,16 @@ public class GoFunctionalTests {
         CODE_LOGGER.logFile(client, FileTypeToLog.CLIENT);
         assertTrue(hasContent(client));
 
-        assertTrue(client.contains("func (client *Client) SimpleWithPayload(ctx context.Context, request *models.SimpleWithPayloadRequest) (*models.SimpleWithPayloadResponse, error) {"));
-        assertTrue(client.contains("networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)"));
-        assertTrue(client.contains("response, requestErr := networkRetryDecorator.Invoke(httpRequest)"));
+        assertTrue(containsNormalized(client, "func (client *Client) SimpleWithPayload(ctx context.Context, request *models.SimpleWithPayloadRequest) (*models.SimpleWithPayloadResponse, error) {"));
+        assertTrue(containsNormalized(client, "networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)"));
+        assertTrue(containsNormalized(client, "response, requestErr := networkRetryDecorator.Invoke(httpRequest)"));
 
-        assertTrue(client.contains("WithHttpVerb(HTTP_VERB_DELETE)."));
-        assertTrue(client.contains("WithPath(\"/\" + request.BucketName + \"/\" + request.ObjectName)."));
-        assertTrue(client.contains("WithQueryParam(\"void_param\", \"\")."));
-        assertTrue(client.contains("WithQueryParam(\"place_holder\", request.PlaceHolder.String())."));
-        assertTrue(client.contains("WithOptionalQueryParam(\"optional_place_holder\", networking.IntPtrToStrPtr(request.OptionalPlaceHolder))."));
-        assertTrue(client.contains("WithQueryParam(\"operation\", \"start_bulk_get\")."));
+        assertTrue(containsNormalized(client, "WithHttpVerb(HTTP_VERB_DELETE)."));
+        assertTrue(containsNormalized(client, "WithPath(\"/\"+request.BucketName+\"/\"+request.ObjectName)."));
+        assertTrue(containsNormalized(client, "WithQueryParam(\"void_param\", \"\")."));
+        assertTrue(containsNormalized(client, "WithQueryParam(\"place_holder\", request.PlaceHolder.String())."));
+        assertTrue(containsNormalized(client, "WithOptionalQueryParam(\"optional_place_holder\", networking.IntPtrToStrPtr(request.OptionalPlaceHolder))."));
+        assertTrue(containsNormalized(client, "WithQueryParam(\"operation\", \"start_bulk_get\")."));
     }
 
     @Test
@@ -159,24 +173,24 @@ public class GoFunctionalTests {
         CODE_LOGGER.logFile(requestCode, FileTypeToLog.REQUEST);
         assertTrue(hasContent(requestCode));
 
-        assertFalse(requestCode.contains("\"strconv\""));
-        assertTrue(requestCode.contains("func NewDeleteBucketAclSpectraS3Request(bucketAcl string) *DeleteBucketAclSpectraS3Request {"));
+        assertFalse(containsNormalized(requestCode, "\"strconv\""));
+        assertTrue(containsNormalized(requestCode, "func NewDeleteBucketAclSpectraS3Request(bucketAcl string) *DeleteBucketAclSpectraS3Request {"));
 
         // Verify Response file was generated
         final String responseCode = codeGenerator.getResponseCode();
         CODE_LOGGER.logFile(responseCode, FileTypeToLog.RESPONSE);
         assertTrue(hasContent(responseCode));
 
-        assertFalse(responseCode.contains("\"ds3/networking\""));
-        assertTrue(responseCode.contains("\"net/http\""));
+        assertFalse(containsNormalized(responseCode, "\"ds3/networking\""));
+        assertTrue(containsNormalized(responseCode, "\"net/http\""));
 
-        assertTrue(responseCode.contains("Headers *http.Header"));
+        assertTrue(containsNormalized(responseCode, "Headers *http.Header"));
 
-        assertTrue(responseCode.contains("func NewDeleteBucketAclSpectraS3Response(webResponse WebResponse) (*DeleteBucketAclSpectraS3Response, error) {"));
-        assertTrue(responseCode.contains("expectedStatusCodes := []int { 204 }"));
-        assertTrue(responseCode.contains("return &DeleteBucketAclSpectraS3Response{Headers: webResponse.Header()}, nil"));
+        assertTrue(containsNormalized(responseCode, "func NewDeleteBucketAclSpectraS3Response(webResponse WebResponse) (*DeleteBucketAclSpectraS3Response, error) {"));
+        assertTrue(containsNormalized(responseCode, "expectedStatusCodes := []int{204}"));
+        assertTrue(containsNormalized(responseCode, "return &DeleteBucketAclSpectraS3Response{Headers: webResponse.Header()}, nil"));
 
-        assertFalse(responseCode.contains("parse(webResponse WebResponse)"));
+        assertFalse(containsNormalized(responseCode, "parse(webResponse WebResponse)"));
 
         // Verify response payload type file was not generated
         final String typeCode = codeGenerator.getTypeCode();
@@ -188,12 +202,12 @@ public class GoFunctionalTests {
         CODE_LOGGER.logFile(client, FileTypeToLog.CLIENT);
         assertTrue(hasContent(client));
 
-        assertTrue(client.contains("func (client *Client) DeleteBucketAclSpectraS3(ctx context.Context, request *models.DeleteBucketAclSpectraS3Request) (*models.DeleteBucketAclSpectraS3Response, error) {"));
-        assertTrue(client.contains("networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)"));
-        assertTrue(client.contains("response, requestErr := networkRetryDecorator.Invoke(httpRequest)"));
+        assertTrue(containsNormalized(client, "func (client *Client) DeleteBucketAclSpectraS3(ctx context.Context, request *models.DeleteBucketAclSpectraS3Request) (*models.DeleteBucketAclSpectraS3Response, error) {"));
+        assertTrue(containsNormalized(client, "networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)"));
+        assertTrue(containsNormalized(client, "response, requestErr := networkRetryDecorator.Invoke(httpRequest)"));
 
-        assertTrue(client.contains("WithHttpVerb(HTTP_VERB_DELETE)"));
-        assertTrue(client.contains("WithPath(\"/_rest_/bucket_acl/\" + request.BucketAcl)."));
+        assertTrue(containsNormalized(client, "WithHttpVerb(HTTP_VERB_DELETE)"));
+        assertTrue(containsNormalized(client, "WithPath(\"/_rest_/bucket_acl/\"+request.BucketAcl)."));
     }
 
     @Test
@@ -209,39 +223,39 @@ public class GoFunctionalTests {
         CODE_LOGGER.logFile(requestCode, FileTypeToLog.REQUEST);
         assertTrue(hasContent(requestCode));
 
-        assertTrue(requestCode.contains("BucketName string"));
-        assertTrue(requestCode.contains("Objects []Ds3GetObject"));
-        assertTrue(requestCode.contains("StorageDomain *string"));
+        assertTrue(containsNormalized(requestCode, "BucketName string"));
+        assertTrue(containsNormalized(requestCode, "Objects []Ds3GetObject"));
+        assertTrue(containsNormalized(requestCode, "StorageDomain *string"));
 
-        assertTrue(requestCode.contains("func NewVerifyPhysicalPlacementForObjectsSpectraS3Request(bucketName string, objectNames []string) *VerifyPhysicalPlacementForObjectsSpectraS3Request {"));
-        assertTrue(requestCode.contains("BucketName: bucketName,"));
-        assertTrue(requestCode.contains("Objects: buildDs3GetObjectSliceFromNames(objectNames),"));
+        assertTrue(containsNormalized(requestCode, "func NewVerifyPhysicalPlacementForObjectsSpectraS3Request(bucketName string, objectNames []string) *VerifyPhysicalPlacementForObjectsSpectraS3Request {"));
+        assertTrue(containsNormalized(requestCode, "BucketName: bucketName,"));
+        assertTrue(containsNormalized(requestCode, "Objects: buildDs3GetObjectSliceFromNames(objectNames),"));
 
-        assertTrue(requestCode.contains("func NewVerifyPhysicalPlacementForObjectsSpectraS3RequestWithPartialObjects(bucketName string, objects []Ds3GetObject) *VerifyPhysicalPlacementForObjectsSpectraS3Request {"));
-        assertTrue(requestCode.contains("BucketName: bucketName,"));
-        assertTrue(requestCode.contains("Objects: objects,"));
+        assertTrue(containsNormalized(requestCode, "func NewVerifyPhysicalPlacementForObjectsSpectraS3RequestWithPartialObjects(bucketName string, objects []Ds3GetObject) *VerifyPhysicalPlacementForObjectsSpectraS3Request {"));
+        assertTrue(containsNormalized(requestCode, "BucketName: bucketName,"));
+        assertTrue(containsNormalized(requestCode, "Objects: objects,"));
 
         // Verify Response file was generated
         final String responseCode = codeGenerator.getResponseCode();
         CODE_LOGGER.logFile(responseCode, FileTypeToLog.RESPONSE);
         assertTrue(hasContent(responseCode));
 
-        assertFalse(responseCode.contains("\"ds3/networking\""));
-        assertTrue(responseCode.contains("\"net/http\""));
+        assertFalse(containsNormalized(responseCode, "\"ds3/networking\""));
+        assertTrue(containsNormalized(responseCode, "\"net/http\""));
 
-        assertTrue(responseCode.contains("PhysicalPlacement PhysicalPlacement"));
-        assertFalse(responseCode.contains("`xml:\"PhysicalPlacement\"`"));
-        assertTrue(responseCode.contains("Headers *http.Header"));
+        assertTrue(containsNormalized(responseCode, "PhysicalPlacement PhysicalPlacement"));
+        assertFalse(containsNormalized(responseCode, "`xml:\"PhysicalPlacement\"`"));
+        assertTrue(containsNormalized(responseCode, "Headers *http.Header"));
 
-        assertTrue(responseCode.contains("func NewVerifyPhysicalPlacementForObjectsSpectraS3Response(webResponse WebResponse) (*VerifyPhysicalPlacementForObjectsSpectraS3Response, error) {"));
-        assertTrue(responseCode.contains("expectedStatusCodes := []int { 200 }"));
-        assertTrue(responseCode.contains("var body VerifyPhysicalPlacementForObjectsSpectraS3Response"));
-        assertTrue(responseCode.contains("if err := body.parse(webResponse); err != nil {"));
-        assertTrue(responseCode.contains("body.Headers = webResponse.Header()"));
-        assertTrue(responseCode.contains("return &body, nil"));
+        assertTrue(containsNormalized(responseCode, "func NewVerifyPhysicalPlacementForObjectsSpectraS3Response(webResponse WebResponse) (*VerifyPhysicalPlacementForObjectsSpectraS3Response, error) {"));
+        assertTrue(containsNormalized(responseCode, "expectedStatusCodes := []int{200}"));
+        assertTrue(containsNormalized(responseCode, "var body VerifyPhysicalPlacementForObjectsSpectraS3Response"));
+        assertTrue(containsNormalized(responseCode, "if err := body.parse(webResponse); err != nil {"));
+        assertTrue(containsNormalized(responseCode, "body.Headers = webResponse.Header()"));
+        assertTrue(containsNormalized(responseCode, "return &body, nil"));
 
-        assertTrue(responseCode.contains("func (verifyPhysicalPlacementForObjectsSpectraS3Response *VerifyPhysicalPlacementForObjectsSpectraS3Response) parse(webResponse WebResponse) error {"));
-        assertTrue(responseCode.contains("return parseResponsePayload(webResponse, &verifyPhysicalPlacementForObjectsSpectraS3Response.PhysicalPlacement)"));
+        assertTrue(containsNormalized(responseCode, "func (verifyPhysicalPlacementForObjectsSpectraS3Response *VerifyPhysicalPlacementForObjectsSpectraS3Response) parse(webResponse WebResponse) error {"));
+        assertTrue(containsNormalized(responseCode, "return parseResponsePayload(webResponse, &verifyPhysicalPlacementForObjectsSpectraS3Response.PhysicalPlacement)"));
 
         // Verify response payload type file was not generated
         final String typeCode = codeGenerator.getTypeCode();
@@ -252,16 +266,16 @@ public class GoFunctionalTests {
         final String client = codeGenerator.getClientCode(HttpVerb.GET);
         CODE_LOGGER.logFile(client, FileTypeToLog.CLIENT);
         assertTrue(hasContent(client));
-        assertTrue(client.contains("func (client *Client) VerifyPhysicalPlacementForObjectsSpectraS3(ctx context.Context, request *models.VerifyPhysicalPlacementForObjectsSpectraS3Request) (*models.VerifyPhysicalPlacementForObjectsSpectraS3Response, error) {"));
-        assertTrue(client.contains("networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)"));
-        assertTrue(client.contains("httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)"));
-        assertTrue(client.contains("response, requestErr := httpRedirectDecorator.Invoke(httpRequest)"));
+        assertTrue(containsNormalized(client, "func (client *Client) VerifyPhysicalPlacementForObjectsSpectraS3(ctx context.Context, request *models.VerifyPhysicalPlacementForObjectsSpectraS3Request) (*models.VerifyPhysicalPlacementForObjectsSpectraS3Response, error) {"));
+        assertTrue(containsNormalized(client, "networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)"));
+        assertTrue(containsNormalized(client, "httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)"));
+        assertTrue(containsNormalized(client, "response, requestErr := httpRedirectDecorator.Invoke(httpRequest)"));
 
-        assertTrue(client.contains("WithHttpVerb(HTTP_VERB_GET)."));
-        assertTrue(client.contains("WithPath(\"/_rest_/bucket/\" + request.BucketName)."));
-        assertTrue(client.contains("WithOptionalQueryParam(\"storage_domain\", request.StorageDomain)."));
-        assertTrue(client.contains("WithQueryParam(\"operation\", \"verify_physical_placement\")."));
-        assertTrue(client.contains("WithReadCloser(buildDs3GetObjectListStream(request.Objects))."));
+        assertTrue(containsNormalized(client, "WithHttpVerb(HTTP_VERB_GET)."));
+        assertTrue(containsNormalized(client, "WithPath(\"/_rest_/bucket/\"+request.BucketName)."));
+        assertTrue(containsNormalized(client, "WithOptionalQueryParam(\"storage_domain\", request.StorageDomain)."));
+        assertTrue(containsNormalized(client, "WithQueryParam(\"operation\", \"verify_physical_placement\")."));
+        assertTrue(containsNormalized(client, "WithReadCloser(buildDs3GetObjectListStream(request.Objects))."));
     }
 
     @Test
@@ -276,33 +290,33 @@ public class GoFunctionalTests {
         final String requestCode = codeGenerator.getRequestCode();
         CODE_LOGGER.logFile(requestCode, FileTypeToLog.REQUEST);
         assertTrue(hasContent(requestCode));
-        assertFalse(requestCode.contains("\"strconv\""));
-        assertTrue(requestCode.contains("RequestPayload string"));
-        assertTrue(requestCode.contains("RequestPayload: requestPayload,"));
+        assertFalse(containsNormalized(requestCode, "\"strconv\""));
+        assertTrue(containsNormalized(requestCode, "RequestPayload string"));
+        assertTrue(containsNormalized(requestCode, "RequestPayload: requestPayload,"));
 
         // Verify Response file was generated
         final String responseCode = codeGenerator.getResponseCode();
         CODE_LOGGER.logFile(responseCode, FileTypeToLog.RESPONSE);
         assertTrue(hasContent(responseCode));
 
-        assertFalse(responseCode.contains("\"ds3/networking\""));
-        assertTrue(responseCode.contains("\"net/http\""));
+        assertFalse(containsNormalized(responseCode, "\"ds3/networking\""));
+        assertTrue(containsNormalized(responseCode, "\"net/http\""));
 
-        assertTrue(responseCode.contains("MasterObjectList *MasterObjectList"));
-        assertFalse(responseCode.contains("`xml:\"MasterObjectList\"`"));
-        assertTrue(responseCode.contains("Headers *http.Header"));
+        assertTrue(containsNormalized(responseCode, "MasterObjectList *MasterObjectList"));
+        assertFalse(containsNormalized(responseCode, "`xml:\"MasterObjectList\"`"));
+        assertTrue(containsNormalized(responseCode, "Headers *http.Header"));
 
-        assertTrue(responseCode.contains("func NewReplicatePutJobSpectraS3Response(webResponse WebResponse) (*ReplicatePutJobSpectraS3Response, error) {"));
-        assertTrue(responseCode.contains("expectedStatusCodes := []int { 200, 204 }"));
-        assertTrue(responseCode.contains("var body ReplicatePutJobSpectraS3Response"));
-        assertTrue(responseCode.contains("if err := body.parse(webResponse); err != nil {"));
-        assertTrue(responseCode.contains("body.Headers = webResponse.Header()"));
-        assertTrue(responseCode.contains("return &body, nil"));
+        assertTrue(containsNormalized(responseCode, "func NewReplicatePutJobSpectraS3Response(webResponse WebResponse) (*ReplicatePutJobSpectraS3Response, error) {"));
+        assertTrue(containsNormalized(responseCode, "expectedStatusCodes := []int{200, 204}"));
+        assertTrue(containsNormalized(responseCode, "var body ReplicatePutJobSpectraS3Response"));
+        assertTrue(containsNormalized(responseCode, "if err := body.parse(webResponse); err != nil {"));
+        assertTrue(containsNormalized(responseCode, "body.Headers = webResponse.Header()"));
+        assertTrue(containsNormalized(responseCode, "return &body, nil"));
 
-        assertTrue(responseCode.contains("return &ReplicatePutJobSpectraS3Response{Headers: webResponse.Header()}, nil"));
+        assertTrue(containsNormalized(responseCode, "return &ReplicatePutJobSpectraS3Response{Headers: webResponse.Header()}, nil"));
 
-        assertTrue(responseCode.contains("func (replicatePutJobSpectraS3Response *ReplicatePutJobSpectraS3Response) parse(webResponse WebResponse) error {"));
-        assertTrue(responseCode.contains("return parseResponsePayload(webResponse, replicatePutJobSpectraS3Response.MasterObjectList)"));
+        assertTrue(containsNormalized(responseCode, "func (replicatePutJobSpectraS3Response *ReplicatePutJobSpectraS3Response) parse(webResponse WebResponse) error {"));
+        assertTrue(containsNormalized(responseCode, "return parseResponsePayload(webResponse, replicatePutJobSpectraS3Response.MasterObjectList)"));
 
         // Verify response payload type file was not generated
         final String typeCode = codeGenerator.getTypeCode();
@@ -313,16 +327,16 @@ public class GoFunctionalTests {
         final String client = codeGenerator.getClientCode(HttpVerb.PUT);
         CODE_LOGGER.logFile(client, FileTypeToLog.CLIENT);
         assertTrue(hasContent(client));
-        assertTrue(client.contains("func (client *Client) ReplicatePutJobSpectraS3(ctx context.Context, request *models.ReplicatePutJobSpectraS3Request) (*models.ReplicatePutJobSpectraS3Response, error) {"));
-        assertTrue(client.contains("networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)"));
-        assertTrue(client.contains("response, requestErr := networkRetryDecorator.Invoke(httpRequest)"));
+        assertTrue(containsNormalized(client, "func (client *Client) ReplicatePutJobSpectraS3(ctx context.Context, request *models.ReplicatePutJobSpectraS3Request) (*models.ReplicatePutJobSpectraS3Response, error) {"));
+        assertTrue(containsNormalized(client, "networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)"));
+        assertTrue(containsNormalized(client, "response, requestErr := networkRetryDecorator.Invoke(httpRequest)"));
 
-        assertTrue(client.contains("WithHttpVerb(HTTP_VERB_PUT)."));
-        assertTrue(client.contains("WithPath(\"/_rest_/bucket/\" + request.BucketName)."));
-        assertTrue(client.contains("WithQueryParam(\"replicate\", \"\")."));
-        assertTrue(client.contains("WithOptionalQueryParam(\"priority\", networking.InterfaceToStrPtr(request.Priority))."));
-        assertTrue(client.contains("WithQueryParam(\"operation\", \"start_bulk_put\")."));
-        assertTrue(client.contains("WithReadCloser(buildStreamFromString(request.RequestPayload))."));
+        assertTrue(containsNormalized(client, "WithHttpVerb(HTTP_VERB_PUT)."));
+        assertTrue(containsNormalized(client, "WithPath(\"/_rest_/bucket/\"+request.BucketName)."));
+        assertTrue(containsNormalized(client, "WithQueryParam(\"replicate\", \"\")."));
+        assertTrue(containsNormalized(client, "WithOptionalQueryParam(\"priority\", networking.InterfaceToStrPtr(request.Priority))."));
+        assertTrue(containsNormalized(client, "WithQueryParam(\"operation\", \"start_bulk_put\")."));
+        assertTrue(containsNormalized(client, "WithReadCloser(buildStreamFromString(request.RequestPayload))."));
     }
 
     @Test
@@ -337,38 +351,38 @@ public class GoFunctionalTests {
         final String requestCode = codeGenerator.getRequestCode();
         CODE_LOGGER.logFile(requestCode, FileTypeToLog.REQUEST);
         assertTrue(hasContent(requestCode));
-        assertFalse(requestCode.contains("\"strconv\""));
+        assertFalse(containsNormalized(requestCode, "\"strconv\""));
 
-        assertTrue(requestCode.contains("BucketName string"));
-        assertTrue(requestCode.contains("ObjectName string"));
-        assertTrue(requestCode.contains("Parts []Part"));
-        assertTrue(requestCode.contains("UploadId string"));
+        assertTrue(containsNormalized(requestCode, "BucketName string"));
+        assertTrue(containsNormalized(requestCode, "ObjectName string"));
+        assertTrue(containsNormalized(requestCode, "Parts []Part"));
+        assertTrue(containsNormalized(requestCode, "UploadId string"));
 
-        assertTrue(requestCode.contains("BucketName: bucketName,"));
-        assertTrue(requestCode.contains("ObjectName: objectName,"));
-        assertTrue(requestCode.contains("UploadId: uploadId,"));
-        assertTrue(requestCode.contains("Parts: parts,"));
+        assertTrue(containsNormalized(requestCode, "BucketName: bucketName,"));
+        assertTrue(containsNormalized(requestCode, "ObjectName: objectName,"));
+        assertTrue(containsNormalized(requestCode, "UploadId: uploadId,"));
+        assertTrue(containsNormalized(requestCode, "Parts: parts,"));
 
         // Verify Response file was generated
         final String responseCode = codeGenerator.getResponseCode();
         CODE_LOGGER.logFile(responseCode, FileTypeToLog.RESPONSE);
         assertTrue(hasContent(responseCode));
-        assertFalse(responseCode.contains("\"ds3/networking\""));
-        assertTrue(responseCode.contains("\"net/http\""));
+        assertFalse(containsNormalized(responseCode, "\"ds3/networking\""));
+        assertTrue(containsNormalized(responseCode, "\"net/http\""));
 
-        assertTrue(responseCode.contains("CompleteMultipartUploadResult CompleteMultipartUploadResult"));
-        assertTrue(responseCode.contains("Headers *http.Header"));
+        assertTrue(containsNormalized(responseCode, "CompleteMultipartUploadResult CompleteMultipartUploadResult"));
+        assertTrue(containsNormalized(responseCode, "Headers *http.Header"));
 
-        assertFalse(responseCode.contains("`xml:\"CompleteMultipartUploadResult\"`"));
-        assertTrue(responseCode.contains("func NewCompleteMultiPartUploadResponse(webResponse WebResponse) (*CompleteMultiPartUploadResponse, error) {"));
-        assertTrue(responseCode.contains("expectedStatusCodes := []int { 200 }"));
-        assertTrue(responseCode.contains("var body CompleteMultiPartUploadResponse"));
-        assertTrue(responseCode.contains("if err := body.parse(webResponse); err != nil {"));
-        assertTrue(responseCode.contains("body.Headers = webResponse.Header()"));
-        assertTrue(responseCode.contains("return &body, nil"));
+        assertFalse(containsNormalized(responseCode, "`xml:\"CompleteMultipartUploadResult\"`"));
+        assertTrue(containsNormalized(responseCode, "func NewCompleteMultiPartUploadResponse(webResponse WebResponse) (*CompleteMultiPartUploadResponse, error) {"));
+        assertTrue(containsNormalized(responseCode, "expectedStatusCodes := []int{200}"));
+        assertTrue(containsNormalized(responseCode, "var body CompleteMultiPartUploadResponse"));
+        assertTrue(containsNormalized(responseCode, "if err := body.parse(webResponse); err != nil {"));
+        assertTrue(containsNormalized(responseCode, "body.Headers = webResponse.Header()"));
+        assertTrue(containsNormalized(responseCode, "return &body, nil"));
 
-        assertTrue(responseCode.contains("func (completeMultiPartUploadResponse *CompleteMultiPartUploadResponse) parse(webResponse WebResponse) error {"));
-        assertTrue(responseCode.contains("return parseResponsePayload(webResponse, &completeMultiPartUploadResponse.CompleteMultipartUploadResult)"));
+        assertTrue(containsNormalized(responseCode, "func (completeMultiPartUploadResponse *CompleteMultiPartUploadResponse) parse(webResponse WebResponse) error {"));
+        assertTrue(containsNormalized(responseCode, "return parseResponsePayload(webResponse, &completeMultiPartUploadResponse.CompleteMultipartUploadResult)"));
 
         // Verify response payload type file was not generated
         final String typeCode = codeGenerator.getTypeCode();
@@ -379,14 +393,14 @@ public class GoFunctionalTests {
         final String client = codeGenerator.getClientCode(HttpVerb.POST);
         CODE_LOGGER.logFile(client, FileTypeToLog.CLIENT);
         assertTrue(hasContent(client));
-        assertTrue(client.contains("func (client *Client) CompleteMultiPartUpload(ctx context.Context, request *models.CompleteMultiPartUploadRequest) (*models.CompleteMultiPartUploadResponse, error) {"));
-        assertTrue(client.contains("networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)"));
-        assertTrue(client.contains("response, requestErr := networkRetryDecorator.Invoke(httpRequest)"));
+        assertTrue(containsNormalized(client, "func (client *Client) CompleteMultiPartUpload(ctx context.Context, request *models.CompleteMultiPartUploadRequest) (*models.CompleteMultiPartUploadResponse, error) {"));
+        assertTrue(containsNormalized(client, "networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)"));
+        assertTrue(containsNormalized(client, "response, requestErr := networkRetryDecorator.Invoke(httpRequest)"));
 
-        assertTrue(client.contains("WithHttpVerb(HTTP_VERB_POST)."));
-        assertTrue(client.contains("WithPath(\"/\" + request.BucketName + \"/\" + request.ObjectName)."));
-        assertTrue(client.contains("WithQueryParam(\"upload_id\", request.UploadId)."));
-        assertTrue(client.contains("WithReadCloser(buildPartsListStream(request.Parts))."));
+        assertTrue(containsNormalized(client, "WithHttpVerb(HTTP_VERB_POST)."));
+        assertTrue(containsNormalized(client, "WithPath(\"/\"+request.BucketName+\"/\"+request.ObjectName)."));
+        assertTrue(containsNormalized(client, "WithQueryParam(\"upload_id\", request.UploadId)."));
+        assertTrue(containsNormalized(client, "WithReadCloser(buildPartsListStream(request.Parts))."));
     }
 
     @Test
@@ -401,39 +415,39 @@ public class GoFunctionalTests {
         final String requestCode = codeGenerator.getRequestCode();
         CODE_LOGGER.logFile(requestCode, FileTypeToLog.REQUEST);
         assertTrue(hasContent(requestCode));
-        assertFalse(requestCode.contains("\"strconv\""));
+        assertFalse(containsNormalized(requestCode, "\"strconv\""));
 
-        assertTrue(requestCode.contains("BucketName string"));
-        assertTrue(requestCode.contains("ObjectNames []string"));
-        assertTrue(requestCode.contains("RollBack bool"));
+        assertTrue(containsNormalized(requestCode, "BucketName string"));
+        assertTrue(containsNormalized(requestCode, "ObjectNames []string"));
+        assertTrue(containsNormalized(requestCode, "RollBack bool"));
 
-        assertTrue(requestCode.contains("BucketName: bucketName,"));
-        assertTrue(requestCode.contains("ObjectNames: objectNames,"));
+        assertTrue(containsNormalized(requestCode, "BucketName: bucketName,"));
+        assertTrue(containsNormalized(requestCode, "ObjectNames: objectNames,"));
 
-        assertTrue(requestCode.contains("func (deleteObjectsRequest *DeleteObjectsRequest) WithRollBack() *DeleteObjectsRequest {"));
-        assertTrue(requestCode.contains("deleteObjectsRequest.RollBack = true"));
+        assertTrue(containsNormalized(requestCode, "func (deleteObjectsRequest *DeleteObjectsRequest) WithRollBack() *DeleteObjectsRequest {"));
+        assertTrue(containsNormalized(requestCode, "deleteObjectsRequest.RollBack = true"));
 
         // Verify Response file was generated
         final String responseCode = codeGenerator.getResponseCode();
         CODE_LOGGER.logFile(responseCode, FileTypeToLog.RESPONSE);
         assertTrue(hasContent(responseCode));
 
-        assertFalse(responseCode.contains("\"ds3/networking\""));
-        assertTrue(responseCode.contains("\"net/http\""));
+        assertFalse(containsNormalized(responseCode, "\"ds3/networking\""));
+        assertTrue(containsNormalized(responseCode, "\"net/http\""));
 
-        assertTrue(responseCode.contains("DeleteResult DeleteResult"));
-        assertTrue(responseCode.contains("Headers *http.Header"));
-        assertFalse(responseCode.contains("`xml:\"DeleteResult\"`"));
+        assertTrue(containsNormalized(responseCode, "DeleteResult DeleteResult"));
+        assertTrue(containsNormalized(responseCode, "Headers *http.Header"));
+        assertFalse(containsNormalized(responseCode, "`xml:\"DeleteResult\"`"));
 
-        assertTrue(responseCode.contains("func NewDeleteObjectsResponse(webResponse WebResponse) (*DeleteObjectsResponse, error) {"));
-        assertTrue(responseCode.contains("expectedStatusCodes := []int { 200 }"));
-        assertTrue(responseCode.contains("var body DeleteObjectsResponse"));
-        assertTrue(responseCode.contains("if err := body.parse(webResponse); err != nil {"));
-        assertTrue(responseCode.contains("body.Headers = webResponse.Header()"));
-        assertTrue(responseCode.contains("return &body, nil"));
+        assertTrue(containsNormalized(responseCode, "func NewDeleteObjectsResponse(webResponse WebResponse) (*DeleteObjectsResponse, error) {"));
+        assertTrue(containsNormalized(responseCode, "expectedStatusCodes := []int{200}"));
+        assertTrue(containsNormalized(responseCode, "var body DeleteObjectsResponse"));
+        assertTrue(containsNormalized(responseCode, "if err := body.parse(webResponse); err != nil {"));
+        assertTrue(containsNormalized(responseCode, "body.Headers = webResponse.Header()"));
+        assertTrue(containsNormalized(responseCode, "return &body, nil"));
 
-        assertTrue(responseCode.contains("func (deleteObjectsResponse *DeleteObjectsResponse) parse(webResponse WebResponse) error {"));
-        assertTrue(responseCode.contains("return parseResponsePayload(webResponse, &deleteObjectsResponse.DeleteResult)"));
+        assertTrue(containsNormalized(responseCode, "func (deleteObjectsResponse *DeleteObjectsResponse) parse(webResponse WebResponse) error {"));
+        assertTrue(containsNormalized(responseCode, "return parseResponsePayload(webResponse, &deleteObjectsResponse.DeleteResult)"));
 
         // Verify response payload type file was not generated
         final String typeCode = codeGenerator.getTypeCode();
@@ -444,15 +458,15 @@ public class GoFunctionalTests {
         final String client = codeGenerator.getClientCode(HttpVerb.POST);
         CODE_LOGGER.logFile(client, FileTypeToLog.CLIENT);
         assertTrue(hasContent(client));
-        assertTrue(client.contains("func (client *Client) DeleteObjects(ctx context.Context, request *models.DeleteObjectsRequest) (*models.DeleteObjectsResponse, error) {"));
-        assertTrue(client.contains("networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)"));
-        assertTrue(client.contains("response, requestErr := networkRetryDecorator.Invoke(httpRequest)"));
+        assertTrue(containsNormalized(client, "func (client *Client) DeleteObjects(ctx context.Context, request *models.DeleteObjectsRequest) (*models.DeleteObjectsResponse, error) {"));
+        assertTrue(containsNormalized(client, "networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)"));
+        assertTrue(containsNormalized(client, "response, requestErr := networkRetryDecorator.Invoke(httpRequest)"));
 
-        assertTrue(client.contains("WithHttpVerb(HTTP_VERB_POST)."));
-        assertTrue(client.contains("WithPath(\"/\" + request.BucketName)."));
-        assertTrue(client.contains("WithQueryParam(\"delete\", \"\")."));
-        assertTrue(client.contains("WithOptionalVoidQueryParam(\"roll_back\", request.RollBack)."));
-        assertTrue(client.contains("WithReadCloser(buildDeleteObjectsPayload(request.ObjectNames))."));
+        assertTrue(containsNormalized(client, "WithHttpVerb(HTTP_VERB_POST)."));
+        assertTrue(containsNormalized(client, "WithPath(\"/\"+request.BucketName)."));
+        assertTrue(containsNormalized(client, "WithQueryParam(\"delete\", \"\")."));
+        assertTrue(containsNormalized(client, "WithOptionalVoidQueryParam(\"roll_back\", request.RollBack)."));
+        assertTrue(containsNormalized(client, "WithReadCloser(buildDeleteObjectsPayload(request.ObjectNames))."));
     }
 
     @Test
@@ -467,27 +481,27 @@ public class GoFunctionalTests {
         final String requestCode = codeGenerator.getRequestCode();
         CODE_LOGGER.logFile(requestCode, FileTypeToLog.REQUEST);
         assertTrue(hasContent(requestCode));
-        assertFalse(requestCode.contains("\"strconv\""));
+        assertFalse(containsNormalized(requestCode, "\"strconv\""));
 
-        assertTrue(requestCode.contains("JobId string"));
-        assertTrue(requestCode.contains("JobId: jobId,"));
+        assertTrue(containsNormalized(requestCode, "JobId string"));
+        assertTrue(containsNormalized(requestCode, "JobId: jobId,"));
 
         // Verify Response file was generated
         final String responseCode = codeGenerator.getResponseCode();
         CODE_LOGGER.logFile(responseCode, FileTypeToLog.RESPONSE);
         assertTrue(hasContent(responseCode));
 
-        assertFalse(responseCode.contains("\"ds3/networking\""));
-        assertTrue(responseCode.contains("\"net/http\""));
+        assertFalse(containsNormalized(responseCode, "\"ds3/networking\""));
+        assertTrue(containsNormalized(responseCode, "\"net/http\""));
 
-        assertTrue(responseCode.contains("Content string"));
-        assertTrue(responseCode.contains("Headers *http.Header"));
+        assertTrue(containsNormalized(responseCode, "Content string"));
+        assertTrue(containsNormalized(responseCode, "Headers *http.Header"));
 
-        assertTrue(responseCode.contains("func NewGetJobToReplicateSpectraS3Response(webResponse WebResponse) (*GetJobToReplicateSpectraS3Response, error) {"));
-        assertTrue(responseCode.contains("expectedStatusCodes := []int { 200 }"));
-        assertTrue(responseCode.contains("return &GetJobToReplicateSpectraS3Response{Content: content, Headers: webResponse.Header()}, nil"));
+        assertTrue(containsNormalized(responseCode, "func NewGetJobToReplicateSpectraS3Response(webResponse WebResponse) (*GetJobToReplicateSpectraS3Response, error) {"));
+        assertTrue(containsNormalized(responseCode, "expectedStatusCodes := []int{200}"));
+        assertTrue(containsNormalized(responseCode, "return &GetJobToReplicateSpectraS3Response{Content: content, Headers: webResponse.Header()}, nil"));
 
-        assertFalse(responseCode.contains("parse(webResponse WebResponse)"));
+        assertFalse(containsNormalized(responseCode, "parse(webResponse WebResponse)"));
 
         // Verify response payload type file was not generated
         final String typeCode = codeGenerator.getTypeCode();
@@ -498,14 +512,14 @@ public class GoFunctionalTests {
         final String client = codeGenerator.getClientCode(HttpVerb.GET);
         CODE_LOGGER.logFile(client, FileTypeToLog.CLIENT);
         assertTrue(hasContent(client));
-        assertTrue(client.contains("func (client *Client) GetJobToReplicateSpectraS3(ctx context.Context, request *models.GetJobToReplicateSpectraS3Request) (*models.GetJobToReplicateSpectraS3Response, error) {"));
-        assertTrue(client.contains("networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)"));
-        assertTrue(client.contains("httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)"));
-        assertTrue(client.contains("response, requestErr := httpRedirectDecorator.Invoke(httpRequest)"));
+        assertTrue(containsNormalized(client, "func (client *Client) GetJobToReplicateSpectraS3(ctx context.Context, request *models.GetJobToReplicateSpectraS3Request) (*models.GetJobToReplicateSpectraS3Response, error) {"));
+        assertTrue(containsNormalized(client, "networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)"));
+        assertTrue(containsNormalized(client, "httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)"));
+        assertTrue(containsNormalized(client, "response, requestErr := httpRedirectDecorator.Invoke(httpRequest)"));
 
-        assertTrue(client.contains("WithHttpVerb(HTTP_VERB_GET)."));
-        assertTrue(client.contains("WithPath(\"/_rest_/job/\" + request.JobId)"));
-        assertTrue(client.contains("WithQueryParam(\"replicate\", \"\")."));
+        assertTrue(containsNormalized(client, "WithHttpVerb(HTTP_VERB_GET)."));
+        assertTrue(containsNormalized(client, "WithPath(\"/_rest_/job/\"+request.JobId)"));
+        assertTrue(containsNormalized(client, "WithQueryParam(\"replicate\", \"\")."));
     }
 
     @Test
@@ -521,60 +535,60 @@ public class GoFunctionalTests {
         assertTrue(hasContent(requestCode));
 
         // test request imports
-        assertTrue(requestCode.contains("\"fmt\""));
-        assertTrue(requestCode.contains("\"strings\""));
-        assertFalse(requestCode.contains("\"ds3/networking\""));
+        assertTrue(containsNormalized(requestCode, "\"fmt\""));
+        assertTrue(containsNormalized(requestCode, "\"strings\""));
+        assertFalse(containsNormalized(requestCode, "\"ds3/networking\""));
 
         // test request struct
-        assertTrue(requestCode.contains("BucketName string"));
-        assertTrue(requestCode.contains("ObjectName string"));
-        assertTrue(requestCode.contains("Checksum Checksum"));
-        assertTrue(requestCode.contains("Job *string"));
-        assertTrue(requestCode.contains("Offset *int64"));
-        assertTrue(requestCode.contains("Metadata map[string]string"));
+        assertTrue(containsNormalized(requestCode, "BucketName string"));
+        assertTrue(containsNormalized(requestCode, "ObjectName string"));
+        assertTrue(containsNormalized(requestCode, "Checksum Checksum"));
+        assertTrue(containsNormalized(requestCode, "Job *string"));
+        assertTrue(containsNormalized(requestCode, "Offset *int64"));
+        assertTrue(containsNormalized(requestCode, "Metadata map[string]string"));
 
-        assertTrue(requestCode.contains("type Range struct {"));
+        assertTrue(containsNormalized(requestCode, "type Range struct {"));
 
         // test constructor and with-constructors
-        assertTrue(requestCode.contains("func NewGetObjectRequest(bucketName string, objectName string) *GetObjectRequest {"));
-        assertTrue(requestCode.contains("BucketName: bucketName,"));
-        assertTrue(requestCode.contains("ObjectName: objectName,"));
-        assertTrue(requestCode.contains("Checksum: NewNoneChecksum(),"));
-        assertTrue(requestCode.contains("Metadata: make(map[string]string)"));
+        assertTrue(containsNormalized(requestCode, "func NewGetObjectRequest(bucketName string, objectName string) *GetObjectRequest {"));
+        assertTrue(containsNormalized(requestCode, "BucketName: bucketName,"));
+        assertTrue(containsNormalized(requestCode, "ObjectName: objectName,"));
+        assertTrue(containsNormalized(requestCode, "Checksum: NewNoneChecksum(),"));
+        assertTrue(containsNormalized(requestCode, "Metadata: make(map[string]string)"));
 
-        assertTrue(requestCode.contains("func (getObjectRequest *GetObjectRequest) WithRanges(ranges ...Range) *GetObjectRequest {"));
-        assertTrue(requestCode.contains("getObjectRequest.Metadata[\"Range\"] = fmt.Sprintf(\"bytes=%s\", strings.Join(rangeElements[:], \",\"))"));
-        assertFalse(requestCode.contains("func (getObjectRequest *GetObjectRequest) WithRange(start, end int) *GetObjectRequest {"));
-        assertFalse(requestCode.contains("getObjectRequest.Metadata[\"Range\"] = fmt.Sprintf(\"bytes=%d-%d\", start, end)"));
+        assertTrue(containsNormalized(requestCode, "func (getObjectRequest *GetObjectRequest) WithRanges(ranges ...Range) *GetObjectRequest {"));
+        assertTrue(containsNormalized(requestCode, "getObjectRequest.Metadata[\"Range\"] = fmt.Sprintf(\"bytes=%s\", strings.Join(rangeElements[:], \",\"))"));
+        assertFalse(containsNormalized(requestCode, "func (getObjectRequest *GetObjectRequest) WithRange(start, end int) *GetObjectRequest {"));
+        assertFalse(containsNormalized(requestCode, "getObjectRequest.Metadata[\"Range\"] = fmt.Sprintf(\"bytes=%d-%d\", start, end)"));
 
-        assertTrue(requestCode.contains("func (getObjectRequest *GetObjectRequest) WithChecksum(contentHash string, checksumType ChecksumType) *GetObjectRequest {"));
-        assertTrue(requestCode.contains("getObjectRequest.Checksum.ContentHash = contentHash"));
-        assertTrue(requestCode.contains("getObjectRequest.Checksum.Type = checksumType"));
+        assertTrue(containsNormalized(requestCode, "func (getObjectRequest *GetObjectRequest) WithChecksum(contentHash string, checksumType ChecksumType) *GetObjectRequest {"));
+        assertTrue(containsNormalized(requestCode, "getObjectRequest.Checksum.ContentHash = contentHash"));
+        assertTrue(containsNormalized(requestCode, "getObjectRequest.Checksum.Type = checksumType"));
 
-        assertTrue(requestCode.contains("func (getObjectRequest *GetObjectRequest) WithJob(job string) *GetObjectRequest {"));
-        assertTrue(requestCode.contains("getObjectRequest.Job = &job"));
+        assertTrue(containsNormalized(requestCode, "func (getObjectRequest *GetObjectRequest) WithJob(job string) *GetObjectRequest {"));
+        assertTrue(containsNormalized(requestCode, "getObjectRequest.Job = &job"));
 
-        assertTrue(requestCode.contains("func (getObjectRequest *GetObjectRequest) WithOffset(offset int64) *GetObjectRequest {"));
-        assertTrue(requestCode.contains("getObjectRequest.Offset = &offset"));
+        assertTrue(containsNormalized(requestCode, "func (getObjectRequest *GetObjectRequest) WithOffset(offset int64) *GetObjectRequest {"));
+        assertTrue(containsNormalized(requestCode, "getObjectRequest.Offset = &offset"));
 
         // Verify Response file was generated
         final String responseCode = codeGenerator.getResponseCode();
         CODE_LOGGER.logFile(responseCode, FileTypeToLog.RESPONSE);
         assertTrue(hasContent(responseCode));
 
-        assertTrue(responseCode.contains("\"io\""));
-        assertFalse(responseCode.contains("\"ds3/networking\""));
-        assertTrue(responseCode.contains("\"net/http\""));
+        assertTrue(containsNormalized(responseCode, "\"io\""));
+        assertFalse(containsNormalized(responseCode, "\"ds3/networking\""));
+        assertTrue(containsNormalized(responseCode, "\"net/http\""));
 
-        assertTrue(responseCode.contains("Content io.ReadCloser"));
-        assertTrue(responseCode.contains("Headers *http.Header"));
+        assertTrue(containsNormalized(responseCode, "Content io.ReadCloser"));
+        assertTrue(containsNormalized(responseCode, "Headers *http.Header"));
 
-        assertTrue(responseCode.contains("func NewGetObjectResponse(webResponse WebResponse) (*GetObjectResponse, error) {"));
-        assertTrue(responseCode.contains("expectedStatusCodes := []int { 200, 206 }"));
-        assertTrue(responseCode.contains("return &GetObjectResponse{ Content: webResponse.Body(), Headers: webResponse.Header() }, nil"));
+        assertTrue(containsNormalized(responseCode, "func NewGetObjectResponse(webResponse WebResponse) (*GetObjectResponse, error) {"));
+        assertTrue(containsNormalized(responseCode, "expectedStatusCodes := []int{200, 206}"));
+        assertTrue(containsNormalized(responseCode, "return &GetObjectResponse{Content: webResponse.Body(), Headers: webResponse.Header()}, nil"));
         assertFalse(responseCode.contains("return &GetObjectResponse{Headers: webResponse.Header()}, nil"));
 
-        assertFalse(responseCode.contains("parse(webResponse WebResponse)"));
+        assertFalse(containsNormalized(responseCode, "parse(webResponse WebResponse)"));
 
         // Verify response payload type file was not generated
         final String typeCode = codeGenerator.getTypeCode();
@@ -585,16 +599,16 @@ public class GoFunctionalTests {
         final String client = codeGenerator.getClientCode(HttpVerb.GET);
         CODE_LOGGER.logFile(client, FileTypeToLog.CLIENT);
         assertTrue(hasContent(client));
-        assertTrue(client.contains("func (client *Client) GetObject(ctx context.Context, request *models.GetObjectRequest) (*models.GetObjectResponse, error) {"));
-        assertTrue(client.contains("networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)"));
-        assertTrue(client.contains("response, requestErr := networkRetryDecorator.Invoke(httpRequest)"));
+        assertTrue(containsNormalized(client, "func (client *Client) GetObject(ctx context.Context, request *models.GetObjectRequest) (*models.GetObjectResponse, error) {"));
+        assertTrue(containsNormalized(client, "networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)"));
+        assertTrue(containsNormalized(client, "response, requestErr := networkRetryDecorator.Invoke(httpRequest)"));
 
-        assertTrue(client.contains("WithHttpVerb(HTTP_VERB_GET)."));
-        assertTrue(client.contains("WithPath(\"/\" + request.BucketName + \"/\" + request.ObjectName)."));
-        assertTrue(client.contains("WithOptionalQueryParam(\"job\", request.Job)."));
-        assertTrue(client.contains("WithOptionalQueryParam(\"offset\", networking.Int64PtrToStrPtr(request.Offset))."));
-        assertTrue(client.contains("WithChecksum(request.Checksum)."));
-        assertTrue(client.contains("WithHeaders(request.Metadata)."));
+        assertTrue(containsNormalized(client, "WithHttpVerb(HTTP_VERB_GET)."));
+        assertTrue(containsNormalized(client, "WithPath(\"/\"+request.BucketName+\"/\"+request.ObjectName)."));
+        assertTrue(containsNormalized(client, "WithOptionalQueryParam(\"job\", request.Job)."));
+        assertTrue(containsNormalized(client, "WithOptionalQueryParam(\"offset\", networking.Int64PtrToStrPtr(request.Offset))."));
+        assertTrue(containsNormalized(client, "WithChecksum(request.Checksum)."));
+        assertTrue(containsNormalized(client, "WithHeaders(request.Metadata)."));
     }
 
     @Test
@@ -611,47 +625,47 @@ public class GoFunctionalTests {
         assertTrue(hasContent(requestCode));
 
         // test request struct
-        assertTrue(requestCode.contains("DataPolicyId *string"));
-        assertTrue(requestCode.contains("DataReplicationRuleType DataReplicationRuleType"));
-        assertTrue(requestCode.contains("PageLength *int"));
-        assertTrue(requestCode.contains("PageOffset *int"));
-        assertTrue(requestCode.contains("PageStartMarker *string"));
-        assertTrue(requestCode.contains("ReplicateDeletes *bool"));
-        assertTrue(requestCode.contains("State DataPlacementRuleState"));
-        assertTrue(requestCode.contains("TargetId *string"));
-        assertTrue(requestCode.contains("LastPage bool"));
+        assertTrue(containsNormalized(requestCode, "DataPolicyId *string"));
+        assertTrue(containsNormalized(requestCode, "DataReplicationRuleType DataReplicationRuleType"));
+        assertTrue(containsNormalized(requestCode, "PageLength *int"));
+        assertTrue(containsNormalized(requestCode, "PageOffset *int"));
+        assertTrue(containsNormalized(requestCode, "PageStartMarker *string"));
+        assertTrue(containsNormalized(requestCode, "ReplicateDeletes *bool"));
+        assertTrue(containsNormalized(requestCode, "State DataPlacementRuleState"));
+        assertTrue(containsNormalized(requestCode, "TargetId *string"));
+        assertTrue(containsNormalized(requestCode, "LastPage bool"));
 
         // test constructor and with-constructors
-        assertTrue(requestCode.contains("func (getAzureDataReplicationRulesSpectraS3Request *GetAzureDataReplicationRulesSpectraS3Request) WithDataPolicyId(dataPolicyId string) *GetAzureDataReplicationRulesSpectraS3Request {"));
-        assertTrue(requestCode.contains("func (getAzureDataReplicationRulesSpectraS3Request *GetAzureDataReplicationRulesSpectraS3Request) WithPageLength(pageLength int) *GetAzureDataReplicationRulesSpectraS3Request {"));
-        assertTrue(requestCode.contains("func (getAzureDataReplicationRulesSpectraS3Request *GetAzureDataReplicationRulesSpectraS3Request) WithPageOffset(pageOffset int) *GetAzureDataReplicationRulesSpectraS3Request {"));
-        assertTrue(requestCode.contains("func (getAzureDataReplicationRulesSpectraS3Request *GetAzureDataReplicationRulesSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetAzureDataReplicationRulesSpectraS3Request {"));
-        assertTrue(requestCode.contains("func (getAzureDataReplicationRulesSpectraS3Request *GetAzureDataReplicationRulesSpectraS3Request) WithReplicateDeletes(replicateDeletes bool) *GetAzureDataReplicationRulesSpectraS3Request {"));
-        assertTrue(requestCode.contains("func (getAzureDataReplicationRulesSpectraS3Request *GetAzureDataReplicationRulesSpectraS3Request) WithState(state DataPlacementRuleState) *GetAzureDataReplicationRulesSpectraS3Request {"));
-        assertTrue(requestCode.contains("func (getAzureDataReplicationRulesSpectraS3Request *GetAzureDataReplicationRulesSpectraS3Request) WithTargetId(targetId string) *GetAzureDataReplicationRulesSpectraS3Request {"));
-        assertTrue(requestCode.contains("func (getAzureDataReplicationRulesSpectraS3Request *GetAzureDataReplicationRulesSpectraS3Request) WithDataReplicationRuleType(dataReplicationRuleType DataReplicationRuleType) *GetAzureDataReplicationRulesSpectraS3Request {"));
-        assertTrue(requestCode.contains("func (getAzureDataReplicationRulesSpectraS3Request *GetAzureDataReplicationRulesSpectraS3Request) WithLastPage() *GetAzureDataReplicationRulesSpectraS3Request {"));
+        assertTrue(containsNormalized(requestCode, "func (getAzureDataReplicationRulesSpectraS3Request *GetAzureDataReplicationRulesSpectraS3Request) WithDataPolicyId(dataPolicyId string) *GetAzureDataReplicationRulesSpectraS3Request {"));
+        assertTrue(containsNormalized(requestCode, "func (getAzureDataReplicationRulesSpectraS3Request *GetAzureDataReplicationRulesSpectraS3Request) WithPageLength(pageLength int) *GetAzureDataReplicationRulesSpectraS3Request {"));
+        assertTrue(containsNormalized(requestCode, "func (getAzureDataReplicationRulesSpectraS3Request *GetAzureDataReplicationRulesSpectraS3Request) WithPageOffset(pageOffset int) *GetAzureDataReplicationRulesSpectraS3Request {"));
+        assertTrue(containsNormalized(requestCode, "func (getAzureDataReplicationRulesSpectraS3Request *GetAzureDataReplicationRulesSpectraS3Request) WithPageStartMarker(pageStartMarker string) *GetAzureDataReplicationRulesSpectraS3Request {"));
+        assertTrue(containsNormalized(requestCode, "func (getAzureDataReplicationRulesSpectraS3Request *GetAzureDataReplicationRulesSpectraS3Request) WithReplicateDeletes(replicateDeletes bool) *GetAzureDataReplicationRulesSpectraS3Request {"));
+        assertTrue(containsNormalized(requestCode, "func (getAzureDataReplicationRulesSpectraS3Request *GetAzureDataReplicationRulesSpectraS3Request) WithState(state DataPlacementRuleState) *GetAzureDataReplicationRulesSpectraS3Request {"));
+        assertTrue(containsNormalized(requestCode, "func (getAzureDataReplicationRulesSpectraS3Request *GetAzureDataReplicationRulesSpectraS3Request) WithTargetId(targetId string) *GetAzureDataReplicationRulesSpectraS3Request {"));
+        assertTrue(containsNormalized(requestCode, "func (getAzureDataReplicationRulesSpectraS3Request *GetAzureDataReplicationRulesSpectraS3Request) WithDataReplicationRuleType(dataReplicationRuleType DataReplicationRuleType) *GetAzureDataReplicationRulesSpectraS3Request {"));
+        assertTrue(containsNormalized(requestCode, "func (getAzureDataReplicationRulesSpectraS3Request *GetAzureDataReplicationRulesSpectraS3Request) WithLastPage() *GetAzureDataReplicationRulesSpectraS3Request {"));
 
         // Verify Response file was generated
         final String responseCode = codeGenerator.getResponseCode();
         CODE_LOGGER.logFile(responseCode, FileTypeToLog.RESPONSE);
         assertTrue(hasContent(responseCode));
 
-        assertFalse(responseCode.contains("\"ds3/networking\""));
-        assertTrue(responseCode.contains("\"net/http\""));
+        assertFalse(containsNormalized(responseCode, "\"ds3/networking\""));
+        assertTrue(containsNormalized(responseCode, "\"net/http\""));
 
-        assertTrue(responseCode.contains("AzureDataReplicationRuleList AzureDataReplicationRuleList"));
-        assertFalse(responseCode.contains("`xml:\"AzureDataReplicationRuleList\"`"));
-        assertTrue(responseCode.contains("Headers *http.Header"));
+        assertTrue(containsNormalized(responseCode, "AzureDataReplicationRuleList AzureDataReplicationRuleList"));
+        assertFalse(containsNormalized(responseCode, "`xml:\"AzureDataReplicationRuleList\"`"));
+        assertTrue(containsNormalized(responseCode, "Headers *http.Header"));
 
-        assertTrue(responseCode.contains("func NewGetAzureDataReplicationRulesSpectraS3Response(webResponse WebResponse) (*GetAzureDataReplicationRulesSpectraS3Response, error) {"));
-        assertTrue(responseCode.contains("expectedStatusCodes := []int { 200 }"));
-        assertTrue(responseCode.contains("if err := body.parse(webResponse); err != nil {"));
-        assertTrue(responseCode.contains("body.Headers = webResponse.Header()"));
-        assertTrue(responseCode.contains("return &body, nil"));
+        assertTrue(containsNormalized(responseCode, "func NewGetAzureDataReplicationRulesSpectraS3Response(webResponse WebResponse) (*GetAzureDataReplicationRulesSpectraS3Response, error) {"));
+        assertTrue(containsNormalized(responseCode, "expectedStatusCodes := []int{200}"));
+        assertTrue(containsNormalized(responseCode, "if err := body.parse(webResponse); err != nil {"));
+        assertTrue(containsNormalized(responseCode, "body.Headers = webResponse.Header()"));
+        assertTrue(containsNormalized(responseCode, "return &body, nil"));
 
-        assertTrue(responseCode.contains("func (getAzureDataReplicationRulesSpectraS3Response *GetAzureDataReplicationRulesSpectraS3Response) parse(webResponse WebResponse) error {"));
-        assertTrue(responseCode.contains("return parseResponsePayload(webResponse, &getAzureDataReplicationRulesSpectraS3Response.AzureDataReplicationRuleList)"));
+        assertTrue(containsNormalized(responseCode, "func (getAzureDataReplicationRulesSpectraS3Response *GetAzureDataReplicationRulesSpectraS3Response) parse(webResponse WebResponse) error {"));
+        assertTrue(containsNormalized(responseCode, "return parseResponsePayload(webResponse, &getAzureDataReplicationRulesSpectraS3Response.AzureDataReplicationRuleList)"));
 
         // Verify response payload type file was not generated
         final String typeCode = codeGenerator.getTypeCode();
@@ -663,22 +677,22 @@ public class GoFunctionalTests {
         CODE_LOGGER.logFile(client, FileTypeToLog.CLIENT);
         assertTrue(hasContent(client));
 
-        assertTrue(client.contains("func (client *Client) GetAzureDataReplicationRulesSpectraS3(ctx context.Context, request *models.GetAzureDataReplicationRulesSpectraS3Request) (*models.GetAzureDataReplicationRulesSpectraS3Response, error) {"));
-        assertTrue(client.contains("networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)"));
-        assertTrue(client.contains("httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)"));
-        assertTrue(client.contains("response, requestErr := httpRedirectDecorator.Invoke(httpRequest)"));
+        assertTrue(containsNormalized(client, "func (client *Client) GetAzureDataReplicationRulesSpectraS3(ctx context.Context, request *models.GetAzureDataReplicationRulesSpectraS3Request) (*models.GetAzureDataReplicationRulesSpectraS3Response, error) {"));
+        assertTrue(containsNormalized(client, "networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)"));
+        assertTrue(containsNormalized(client, "httpRedirectDecorator := networking.NewHttpTempRedirectDecorator(networkRetryDecorator, client.clientPolicy.maxRedirect)"));
+        assertTrue(containsNormalized(client, "response, requestErr := httpRedirectDecorator.Invoke(httpRequest)"));
 
-        assertTrue(client.contains("WithHttpVerb(HTTP_VERB_GET)."));
-        assertTrue(client.contains("WithPath(\"/_rest_/azure_data_replication_rule\")."));
-        assertTrue(client.contains("WithOptionalQueryParam(\"data_policy_id\", request.DataPolicyId)."));
-        assertTrue(client.contains("WithOptionalVoidQueryParam(\"last_page\", request.LastPage)."));
-        assertTrue(client.contains("WithOptionalQueryParam(\"page_length\", networking.IntPtrToStrPtr(request.PageLength))."));
-        assertTrue(client.contains("WithOptionalQueryParam(\"page_offset\", networking.IntPtrToStrPtr(request.PageOffset))."));
-        assertTrue(client.contains("WithOptionalQueryParam(\"page_start_marker\", request.PageStartMarker)."));
-        assertTrue(client.contains("WithOptionalQueryParam(\"replicate_deletes\", networking.BoolPtrToStrPtr(request.ReplicateDeletes))."));
-        assertTrue(client.contains("WithOptionalQueryParam(\"state\", networking.InterfaceToStrPtr(request.State))."));
-        assertTrue(client.contains("WithOptionalQueryParam(\"target_id\", request.TargetId)."));
-        assertTrue(client.contains("WithOptionalQueryParam(\"type\", networking.InterfaceToStrPtr(request.DataReplicationRuleType))."));
+        assertTrue(containsNormalized(client, "WithHttpVerb(HTTP_VERB_GET)."));
+        assertTrue(containsNormalized(client, "WithPath(\"/_rest_/azure_data_replication_rule\")."));
+        assertTrue(containsNormalized(client, "WithOptionalQueryParam(\"data_policy_id\", request.DataPolicyId)."));
+        assertTrue(containsNormalized(client, "WithOptionalVoidQueryParam(\"last_page\", request.LastPage)."));
+        assertTrue(containsNormalized(client, "WithOptionalQueryParam(\"page_length\", networking.IntPtrToStrPtr(request.PageLength))."));
+        assertTrue(containsNormalized(client, "WithOptionalQueryParam(\"page_offset\", networking.IntPtrToStrPtr(request.PageOffset))."));
+        assertTrue(containsNormalized(client, "WithOptionalQueryParam(\"page_start_marker\", request.PageStartMarker)."));
+        assertTrue(containsNormalized(client, "WithOptionalQueryParam(\"replicate_deletes\", networking.BoolPtrToStrPtr(request.ReplicateDeletes))."));
+        assertTrue(containsNormalized(client, "WithOptionalQueryParam(\"state\", networking.InterfaceToStrPtr(request.State))."));
+        assertTrue(containsNormalized(client, "WithOptionalQueryParam(\"target_id\", request.TargetId)."));
+        assertTrue(containsNormalized(client, "WithOptionalQueryParam(\"type\", networking.InterfaceToStrPtr(request.DataReplicationRuleType))."));
     }
 
     @Test
@@ -695,42 +709,42 @@ public class GoFunctionalTests {
         assertTrue(hasContent(requestCode));
 
         // test request struct
-        assertTrue(requestCode.contains("DataPolicyId string"));
-        assertTrue(requestCode.contains("DataReplicationRuleType DataReplicationRuleType"));
-        assertTrue(requestCode.contains("MaxBlobPartSizeInBytes *int64"));
-        assertTrue(requestCode.contains("ReplicateDeletes *bool"));
-        assertTrue(requestCode.contains("TargetId string"));
+        assertTrue(containsNormalized(requestCode, "DataPolicyId string"));
+        assertTrue(containsNormalized(requestCode, "DataReplicationRuleType DataReplicationRuleType"));
+        assertTrue(containsNormalized(requestCode, "MaxBlobPartSizeInBytes *int64"));
+        assertTrue(containsNormalized(requestCode, "ReplicateDeletes *bool"));
+        assertTrue(containsNormalized(requestCode, "TargetId string"));
 
         // test constructor and
-        assertTrue(requestCode.contains("func NewPutAzureDataReplicationRuleSpectraS3Request(dataPolicyId string, dataReplicationRuleType DataReplicationRuleType, targetId string) *PutAzureDataReplicationRuleSpectraS3Request {"));
-        assertTrue(requestCode.contains("DataPolicyId: dataPolicyId,"));
-        assertTrue(requestCode.contains("TargetId: targetId,"));
-        assertTrue(requestCode.contains("DataReplicationRuleType: dataReplicationRuleType,"));
+        assertTrue(containsNormalized(requestCode, "func NewPutAzureDataReplicationRuleSpectraS3Request(dataPolicyId string, dataReplicationRuleType DataReplicationRuleType, targetId string) *PutAzureDataReplicationRuleSpectraS3Request {"));
+        assertTrue(containsNormalized(requestCode, "DataPolicyId: dataPolicyId,"));
+        assertTrue(containsNormalized(requestCode, "TargetId: targetId,"));
+        assertTrue(containsNormalized(requestCode, "DataReplicationRuleType: dataReplicationRuleType,"));
 
         // test with-constructors
-        assertTrue(requestCode.contains("func (putAzureDataReplicationRuleSpectraS3Request *PutAzureDataReplicationRuleSpectraS3Request) WithMaxBlobPartSizeInBytes(maxBlobPartSizeInBytes int64) *PutAzureDataReplicationRuleSpectraS3Request {"));
-        assertTrue(requestCode.contains("func (putAzureDataReplicationRuleSpectraS3Request *PutAzureDataReplicationRuleSpectraS3Request) WithReplicateDeletes(replicateDeletes bool) *PutAzureDataReplicationRuleSpectraS3Request {"));
+        assertTrue(containsNormalized(requestCode, "func (putAzureDataReplicationRuleSpectraS3Request *PutAzureDataReplicationRuleSpectraS3Request) WithMaxBlobPartSizeInBytes(maxBlobPartSizeInBytes int64) *PutAzureDataReplicationRuleSpectraS3Request {"));
+        assertTrue(containsNormalized(requestCode, "func (putAzureDataReplicationRuleSpectraS3Request *PutAzureDataReplicationRuleSpectraS3Request) WithReplicateDeletes(replicateDeletes bool) *PutAzureDataReplicationRuleSpectraS3Request {"));
 
         // Verify Response file was generated
         final String responseCode = codeGenerator.getResponseCode();
         CODE_LOGGER.logFile(responseCode, FileTypeToLog.RESPONSE);
         assertTrue(hasContent(responseCode));
 
-        assertFalse(responseCode.contains("\"ds3/networking\""));
-        assertTrue(responseCode.contains("\"net/http\""));
+        assertFalse(containsNormalized(responseCode, "\"ds3/networking\""));
+        assertTrue(containsNormalized(responseCode, "\"net/http\""));
 
-        assertTrue(responseCode.contains("AzureDataReplicationRule AzureDataReplicationRule"));
-        assertFalse(responseCode.contains("`xml:\"AzureDataReplicationRule\"`"));
-        assertTrue(responseCode.contains("Headers *http.Header"));
+        assertTrue(containsNormalized(responseCode, "AzureDataReplicationRule AzureDataReplicationRule"));
+        assertFalse(containsNormalized(responseCode, "`xml:\"AzureDataReplicationRule\"`"));
+        assertTrue(containsNormalized(responseCode, "Headers *http.Header"));
 
-        assertTrue(responseCode.contains("func NewPutAzureDataReplicationRuleSpectraS3Response(webResponse WebResponse) (*PutAzureDataReplicationRuleSpectraS3Response, error) {"));
-        assertTrue(responseCode.contains("expectedStatusCodes := []int { 201 }"));
-        assertTrue(responseCode.contains("if err := body.parse(webResponse); err != nil {"));
-        assertTrue(responseCode.contains("body.Headers = webResponse.Header()"));
-        assertTrue(responseCode.contains("return &body, nil"));
+        assertTrue(containsNormalized(responseCode, "func NewPutAzureDataReplicationRuleSpectraS3Response(webResponse WebResponse) (*PutAzureDataReplicationRuleSpectraS3Response, error) {"));
+        assertTrue(containsNormalized(responseCode, "expectedStatusCodes := []int{201}"));
+        assertTrue(containsNormalized(responseCode, "if err := body.parse(webResponse); err != nil {"));
+        assertTrue(containsNormalized(responseCode, "body.Headers = webResponse.Header()"));
+        assertTrue(containsNormalized(responseCode, "return &body, nil"));
 
-        assertTrue(responseCode.contains("func (putAzureDataReplicationRuleSpectraS3Response *PutAzureDataReplicationRuleSpectraS3Response) parse(webResponse WebResponse) error {"));
-        assertTrue(responseCode.contains("return parseResponsePayload(webResponse, &putAzureDataReplicationRuleSpectraS3Response.AzureDataReplicationRule)"));
+        assertTrue(containsNormalized(responseCode, "func (putAzureDataReplicationRuleSpectraS3Response *PutAzureDataReplicationRuleSpectraS3Response) parse(webResponse WebResponse) error {"));
+        assertTrue(containsNormalized(responseCode, "return parseResponsePayload(webResponse, &putAzureDataReplicationRuleSpectraS3Response.AzureDataReplicationRule)"));
 
         // Verify response payload type file was not generated
         final String typeCode = codeGenerator.getTypeCode();
@@ -742,17 +756,17 @@ public class GoFunctionalTests {
         CODE_LOGGER.logFile(client, FileTypeToLog.CLIENT);
         assertTrue(hasContent(client));
 
-        assertTrue(client.contains("func (client *Client) PutAzureDataReplicationRuleSpectraS3(ctx context.Context, request *models.PutAzureDataReplicationRuleSpectraS3Request) (*models.PutAzureDataReplicationRuleSpectraS3Response, error) {"));
-        assertTrue(client.contains("networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)"));
-        assertTrue(client.contains("response, requestErr := networkRetryDecorator.Invoke(httpRequest)"));
+        assertTrue(containsNormalized(client, "func (client *Client) PutAzureDataReplicationRuleSpectraS3(ctx context.Context, request *models.PutAzureDataReplicationRuleSpectraS3Request) (*models.PutAzureDataReplicationRuleSpectraS3Response, error) {"));
+        assertTrue(containsNormalized(client, "networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)"));
+        assertTrue(containsNormalized(client, "response, requestErr := networkRetryDecorator.Invoke(httpRequest)"));
 
-        assertTrue(client.contains("WithHttpVerb(HTTP_VERB_POST)."));
-        assertTrue(client.contains("WithPath(\"/_rest_/azure_data_replication_rule\")."));
-        assertTrue(client.contains("WithQueryParam(\"data_policy_id\", request.DataPolicyId)."));
-        assertTrue(client.contains("WithQueryParam(\"target_id\", request.TargetId)."));
-        assertTrue(client.contains("WithQueryParam(\"type\", request.DataReplicationRuleType.String())."));
-        assertTrue(client.contains("WithOptionalQueryParam(\"max_blob_part_size_in_bytes\", networking.Int64PtrToStrPtr(request.MaxBlobPartSizeInBytes))."));
-        assertTrue(client.contains("WithOptionalQueryParam(\"replicate_deletes\", networking.BoolPtrToStrPtr(request.ReplicateDeletes))."));
+        assertTrue(containsNormalized(client, "WithHttpVerb(HTTP_VERB_POST)."));
+        assertTrue(containsNormalized(client, "WithPath(\"/_rest_/azure_data_replication_rule\")."));
+        assertTrue(containsNormalized(client, "WithQueryParam(\"data_policy_id\", request.DataPolicyId)."));
+        assertTrue(containsNormalized(client, "WithQueryParam(\"target_id\", request.TargetId)."));
+        assertTrue(containsNormalized(client, "WithQueryParam(\"type\", request.DataReplicationRuleType.String())."));
+        assertTrue(containsNormalized(client, "WithOptionalQueryParam(\"max_blob_part_size_in_bytes\", networking.Int64PtrToStrPtr(request.MaxBlobPartSizeInBytes))."));
+        assertTrue(containsNormalized(client, "WithOptionalQueryParam(\"replicate_deletes\", networking.BoolPtrToStrPtr(request.ReplicateDeletes))."));
     }
 
     @Test
@@ -769,27 +783,27 @@ public class GoFunctionalTests {
         assertTrue(hasContent(requestCode));
 
         // test request struct
-        assertTrue(requestCode.contains("NotificationId string"));
+        assertTrue(containsNormalized(requestCode, "NotificationId string"));
 
         // test constructor
-        assertTrue(requestCode.contains("func NewDeleteJobCreatedNotificationRegistrationSpectraS3Request(notificationId string) *DeleteJobCreatedNotificationRegistrationSpectraS3Request {"));
-        assertTrue(requestCode.contains("NotificationId: notificationId,"));
+        assertTrue(containsNormalized(requestCode, "func NewDeleteJobCreatedNotificationRegistrationSpectraS3Request(notificationId string) *DeleteJobCreatedNotificationRegistrationSpectraS3Request {"));
+        assertTrue(containsNormalized(requestCode, "NotificationId: notificationId,"));
 
         // Verify Response file was generated
         final String responseCode = codeGenerator.getResponseCode();
         CODE_LOGGER.logFile(responseCode, FileTypeToLog.RESPONSE);
         assertTrue(hasContent(responseCode));
 
-        assertFalse(responseCode.contains("\"ds3/networking\""));
-        assertTrue(responseCode.contains("\"net/http\""));
+        assertFalse(containsNormalized(responseCode, "\"ds3/networking\""));
+        assertTrue(containsNormalized(responseCode, "\"net/http\""));
 
-        assertTrue(responseCode.contains("Headers *http.Header"));
+        assertTrue(containsNormalized(responseCode, "Headers *http.Header"));
 
-        assertTrue(responseCode.contains("func NewDeleteJobCreatedNotificationRegistrationSpectraS3Response(webResponse WebResponse) (*DeleteJobCreatedNotificationRegistrationSpectraS3Response, error) {"));
-        assertTrue(responseCode.contains("expectedStatusCodes := []int { 204 }"));
-        assertTrue(responseCode.contains("return &DeleteJobCreatedNotificationRegistrationSpectraS3Response{Headers: webResponse.Header()}, nil"));
+        assertTrue(containsNormalized(responseCode, "func NewDeleteJobCreatedNotificationRegistrationSpectraS3Response(webResponse WebResponse) (*DeleteJobCreatedNotificationRegistrationSpectraS3Response, error) {"));
+        assertTrue(containsNormalized(responseCode, "expectedStatusCodes := []int{204}"));
+        assertTrue(containsNormalized(responseCode, "return &DeleteJobCreatedNotificationRegistrationSpectraS3Response{Headers: webResponse.Header()}, nil"));
 
-        assertFalse(responseCode.contains("parse(webResponse WebResponse)"));
+        assertFalse(containsNormalized(responseCode, "parse(webResponse WebResponse)"));
 
         // Verify response payload type file was not generated
         final String typeCode = codeGenerator.getTypeCode();
@@ -801,12 +815,12 @@ public class GoFunctionalTests {
         CODE_LOGGER.logFile(client, FileTypeToLog.CLIENT);
         assertTrue(hasContent(client));
 
-        assertTrue(client.contains("func (client *Client) DeleteJobCreatedNotificationRegistrationSpectraS3(ctx context.Context, request *models.DeleteJobCreatedNotificationRegistrationSpectraS3Request) (*models.DeleteJobCreatedNotificationRegistrationSpectraS3Response, error) {"));
-        assertTrue(client.contains("networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)"));
-        assertTrue(client.contains("response, requestErr := networkRetryDecorator.Invoke(httpRequest)"));
+        assertTrue(containsNormalized(client, "func (client *Client) DeleteJobCreatedNotificationRegistrationSpectraS3(ctx context.Context, request *models.DeleteJobCreatedNotificationRegistrationSpectraS3Request) (*models.DeleteJobCreatedNotificationRegistrationSpectraS3Response, error) {"));
+        assertTrue(containsNormalized(client, "networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)"));
+        assertTrue(containsNormalized(client, "response, requestErr := networkRetryDecorator.Invoke(httpRequest)"));
 
-        assertTrue(client.contains("WithHttpVerb(HTTP_VERB_DELETE)."));
-        assertTrue(client.contains("WithPath(\"/_rest_/job_created_notification_registration/\" + request.NotificationId)."));
+        assertTrue(containsNormalized(client, "WithHttpVerb(HTTP_VERB_DELETE)."));
+        assertTrue(containsNormalized(client, "WithPath(\"/_rest_/job_created_notification_registration/\"+request.NotificationId)."));
     }
 
     @Test
@@ -823,38 +837,38 @@ public class GoFunctionalTests {
         assertTrue(hasContent(requestCode));
 
         // test request imports
-        assertFalse(requestCode.contains("\"ds3/networking\""));
+        assertFalse(containsNormalized(requestCode, "\"ds3/networking\""));
 
         // test request struct
-        assertTrue(requestCode.contains("BucketName string"));
-        assertTrue(requestCode.contains("ObjectName string"));
-        assertTrue(requestCode.contains("Content ReaderWithSizeDecorator"));
-        assertTrue(requestCode.contains("PartNumber int"));
-        assertTrue(requestCode.contains("UploadId string"));
+        assertTrue(containsNormalized(requestCode, "BucketName string"));
+        assertTrue(containsNormalized(requestCode, "ObjectName string"));
+        assertTrue(containsNormalized(requestCode, "Content ReaderWithSizeDecorator"));
+        assertTrue(containsNormalized(requestCode, "PartNumber int"));
+        assertTrue(containsNormalized(requestCode, "UploadId string"));
 
         // test constructor
-        assertTrue(requestCode.contains("func NewPutMultiPartUploadPartRequest(bucketName string, objectName string, content ReaderWithSizeDecorator, partNumber int, uploadId string) *PutMultiPartUploadPartRequest {"));
-        assertTrue(requestCode.contains("BucketName: bucketName,"));
-        assertTrue(requestCode.contains("ObjectName: objectName,"));
-        assertTrue(requestCode.contains("PartNumber: partNumber,"));
-        assertTrue(requestCode.contains("UploadId: uploadId,"));
-        assertTrue(requestCode.contains("Content: content,"));
+        assertTrue(containsNormalized(requestCode, "func NewPutMultiPartUploadPartRequest(bucketName string, objectName string, content ReaderWithSizeDecorator, partNumber int, uploadId string) *PutMultiPartUploadPartRequest {"));
+        assertTrue(containsNormalized(requestCode, "BucketName: bucketName,"));
+        assertTrue(containsNormalized(requestCode, "ObjectName: objectName,"));
+        assertTrue(containsNormalized(requestCode, "PartNumber: partNumber,"));
+        assertTrue(containsNormalized(requestCode, "UploadId: uploadId,"));
+        assertTrue(containsNormalized(requestCode, "Content: content,"));
 
         // Verify Response file was generated
         final String responseCode = codeGenerator.getResponseCode();
         CODE_LOGGER.logFile(responseCode, FileTypeToLog.RESPONSE);
         assertTrue(hasContent(responseCode));
 
-        assertFalse(responseCode.contains("\"ds3/networking\""));
-        assertTrue(responseCode.contains("\"net/http\""));
+        assertFalse(containsNormalized(responseCode, "\"ds3/networking\""));
+        assertTrue(containsNormalized(responseCode, "\"net/http\""));
 
-        assertTrue(responseCode.contains("Headers *http.Header"));
+        assertTrue(containsNormalized(responseCode, "Headers *http.Header"));
 
-        assertTrue(responseCode.contains("func NewPutMultiPartUploadPartResponse(webResponse WebResponse) (*PutMultiPartUploadPartResponse, error) {"));
-        assertTrue(responseCode.contains("expectedStatusCodes := []int { 200 }"));
-        assertTrue(responseCode.contains("return &PutMultiPartUploadPartResponse{Headers: webResponse.Header()}, nil"));
+        assertTrue(containsNormalized(responseCode, "func NewPutMultiPartUploadPartResponse(webResponse WebResponse) (*PutMultiPartUploadPartResponse, error) {"));
+        assertTrue(containsNormalized(responseCode, "expectedStatusCodes := []int{200}"));
+        assertTrue(containsNormalized(responseCode, "return &PutMultiPartUploadPartResponse{Headers: webResponse.Header()}, nil"));
 
-        assertFalse(responseCode.contains("parse(webResponse WebResponse)"));
+        assertFalse(containsNormalized(responseCode, "parse(webResponse WebResponse)"));
 
         // Verify response payload type file was not generated
         final String typeCode = codeGenerator.getTypeCode();
@@ -866,18 +880,18 @@ public class GoFunctionalTests {
         CODE_LOGGER.logFile(client, FileTypeToLog.CLIENT);
         assertTrue(hasContent(client));
 
-        assertTrue(client.contains("func (client *Client) PutMultiPartUploadPart(ctx context.Context, request *models.PutMultiPartUploadPartRequest) (*models.PutMultiPartUploadPartResponse, error) {"));
-        assertTrue(client.contains("networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)"));
-        assertTrue(client.contains("response, requestErr := networkRetryDecorator.Invoke(httpRequest)"));
+        assertTrue(containsNormalized(client, "func (client *Client) PutMultiPartUploadPart(ctx context.Context, request *models.PutMultiPartUploadPartRequest) (*models.PutMultiPartUploadPartResponse, error) {"));
+        assertTrue(containsNormalized(client, "networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)"));
+        assertTrue(containsNormalized(client, "response, requestErr := networkRetryDecorator.Invoke(httpRequest)"));
 
-        assertTrue(client.contains("WithHttpVerb(HTTP_VERB_PUT)."));
-        assertTrue(client.contains("WithPath(\"/\" + request.BucketName + \"/\" + request.ObjectName)."));
-        assertTrue(client.contains("WithQueryParam(\"part_number\", strconv.Itoa(request.PartNumber))."));
-        assertTrue(client.contains("WithQueryParam(\"upload_id\", request.UploadId)."));
-        assertTrue(client.contains("WithReader(request.Content)."));
+        assertTrue(containsNormalized(client, "WithHttpVerb(HTTP_VERB_PUT)."));
+        assertTrue(containsNormalized(client, "WithPath(\"/\"+request.BucketName+\"/\"+request.ObjectName)."));
+        assertTrue(containsNormalized(client, "WithQueryParam(\"part_number\", strconv.Itoa(request.PartNumber))."));
+        assertTrue(containsNormalized(client, "WithQueryParam(\"upload_id\", request.UploadId)."));
+        assertTrue(containsNormalized(client, "WithReader(request.Content)."));
 
         // Client must import strconv when any command uses strconv-based conversions.
-        assertTrue(client.contains("\"strconv\""));
+        assertTrue(containsNormalized(client, "\"strconv\""));
     }
 
     @Test
@@ -894,58 +908,58 @@ public class GoFunctionalTests {
         assertTrue(hasContent(requestCode));
 
         // test request imports
-        assertFalse(requestCode.contains("\"ds3/networking\""));
-        assertTrue(requestCode.contains("strings"));
+        assertFalse(containsNormalized(requestCode, "\"ds3/networking\""));
+        assertTrue(containsNormalized(requestCode, "strings"));
 
         // test request struct
-        assertTrue(requestCode.contains("BucketName string"));
-        assertTrue(requestCode.contains("ObjectName string"));
-        assertTrue(requestCode.contains("Job *string"));
-        assertTrue(requestCode.contains("Offset *int64"));
-        assertTrue(requestCode.contains("Content ReaderWithSizeDecorator"));
-        assertTrue(requestCode.contains("Checksum Checksum"));
-        assertTrue(requestCode.contains("Metadata map[string]string"));
+        assertTrue(containsNormalized(requestCode, "BucketName string"));
+        assertTrue(containsNormalized(requestCode, "ObjectName string"));
+        assertTrue(containsNormalized(requestCode, "Job *string"));
+        assertTrue(containsNormalized(requestCode, "Offset *int64"));
+        assertTrue(containsNormalized(requestCode, "Content ReaderWithSizeDecorator"));
+        assertTrue(containsNormalized(requestCode, "Checksum Checksum"));
+        assertTrue(containsNormalized(requestCode, "Metadata map[string]string"));
 
         // test constructor
-        assertTrue(requestCode.contains("func NewPutObjectRequest(bucketName string, objectName string, content ReaderWithSizeDecorator) *PutObjectRequest {"));
-        assertTrue(requestCode.contains("BucketName: bucketName,"));
-        assertTrue(requestCode.contains("ObjectName: objectName,"));
-        assertTrue(requestCode.contains("Content: content,"));
-        assertTrue(requestCode.contains("Checksum: NewNoneChecksum()"));
-        assertTrue(requestCode.contains("Metadata: make(map[string]string),"));
+        assertTrue(containsNormalized(requestCode, "func NewPutObjectRequest(bucketName string, objectName string, content ReaderWithSizeDecorator) *PutObjectRequest {"));
+        assertTrue(containsNormalized(requestCode, "BucketName: bucketName,"));
+        assertTrue(containsNormalized(requestCode, "ObjectName: objectName,"));
+        assertTrue(containsNormalized(requestCode, "Content: content,"));
+        assertTrue(containsNormalized(requestCode, "Checksum: NewNoneChecksum()"));
+        assertTrue(containsNormalized(requestCode, "Metadata: make(map[string]string),"));
 
-        assertTrue(requestCode.contains("func (putObjectRequest *PutObjectRequest) WithJob(job string) *PutObjectRequest {"));
-        assertTrue(requestCode.contains("putObjectRequest.Job = &job"));
-        assertTrue(requestCode.contains("func (putObjectRequest *PutObjectRequest) WithOffset(offset int64) *PutObjectRequest {"));
-        assertTrue(requestCode.contains("putObjectRequest.Offset = &offset"));
+        assertTrue(containsNormalized(requestCode, "func (putObjectRequest *PutObjectRequest) WithJob(job string) *PutObjectRequest {"));
+        assertTrue(containsNormalized(requestCode, "putObjectRequest.Job = &job"));
+        assertTrue(containsNormalized(requestCode, "func (putObjectRequest *PutObjectRequest) WithOffset(offset int64) *PutObjectRequest {"));
+        assertTrue(containsNormalized(requestCode, "putObjectRequest.Offset = &offset"));
 
         // test checksum
-        assertTrue(requestCode.contains("func (putObjectRequest *PutObjectRequest) WithChecksum(contentHash string, checksumType ChecksumType) *PutObjectRequest {"));
-        assertTrue(requestCode.contains("putObjectRequest.Checksum.ContentHash = contentHash"));
-        assertTrue(requestCode.contains("putObjectRequest.Checksum.Type = checksumType"));
+        assertTrue(containsNormalized(requestCode, "func (putObjectRequest *PutObjectRequest) WithChecksum(contentHash string, checksumType ChecksumType) *PutObjectRequest {"));
+        assertTrue(containsNormalized(requestCode, "putObjectRequest.Checksum.ContentHash = contentHash"));
+        assertTrue(containsNormalized(requestCode, "putObjectRequest.Checksum.Type = checksumType"));
 
         // test metadata
-        assertFalse(requestCode.contains("const ( AMZ_META_HEADER = \"x-amz-meta-\" )"));
-        assertTrue(requestCode.contains("func (putObjectRequest *PutObjectRequest) WithMetaData(key string, values ...string) *PutObjectRequest {"));
-        assertTrue(requestCode.contains("if strings.HasPrefix(strings.ToLower(key), AMZ_META_HEADER) {"));
-        assertTrue(requestCode.contains("putObjectRequest.Metadata[key] = strings.Join(values, \",\")"));
-        assertTrue(requestCode.contains("putObjectRequest.Metadata[strings.ToLower(AMZ_META_HEADER + key)] = strings.Join(values, \",\")"));
+        assertFalse(containsNormalized(requestCode, "const ( AMZ_META_HEADER = \"x-amz-meta-\" )"));
+        assertTrue(containsNormalized(requestCode, "func (putObjectRequest *PutObjectRequest) WithMetaData(key string, values ...string) *PutObjectRequest {"));
+        assertTrue(containsNormalized(requestCode, "if strings.HasPrefix(strings.ToLower(key), AMZ_META_HEADER) {"));
+        assertTrue(containsNormalized(requestCode, "putObjectRequest.Metadata[key] = strings.Join(values, \",\")"));
+        assertTrue(containsNormalized(requestCode, "putObjectRequest.Metadata[strings.ToLower(AMZ_META_HEADER+key)] = strings.Join(values, \",\")"));
 
         // Verify Response file was generated
         final String responseCode = codeGenerator.getResponseCode();
         CODE_LOGGER.logFile(responseCode, FileTypeToLog.RESPONSE);
         assertTrue(hasContent(responseCode));
 
-        assertFalse(responseCode.contains("\"ds3/networking\""));
-        assertTrue(responseCode.contains("\"net/http\""));
+        assertFalse(containsNormalized(responseCode, "\"ds3/networking\""));
+        assertTrue(containsNormalized(responseCode, "\"net/http\""));
 
-        assertTrue(responseCode.contains("Headers *http.Header"));
+        assertTrue(containsNormalized(responseCode, "Headers *http.Header"));
 
-        assertTrue(responseCode.contains("func NewPutObjectResponse(webResponse WebResponse) (*PutObjectResponse, error) {"));
-        assertTrue(responseCode.contains("expectedStatusCodes := []int { 200 }"));
-        assertTrue(responseCode.contains("return &PutObjectResponse{Headers: webResponse.Header()}, nil"));
+        assertTrue(containsNormalized(responseCode, "func NewPutObjectResponse(webResponse WebResponse) (*PutObjectResponse, error) {"));
+        assertTrue(containsNormalized(responseCode, "expectedStatusCodes := []int{200}"));
+        assertTrue(containsNormalized(responseCode, "return &PutObjectResponse{Headers: webResponse.Header()}, nil"));
 
-        assertFalse(responseCode.contains("parse(webResponse WebResponse)"));
+        assertFalse(containsNormalized(responseCode, "parse(webResponse WebResponse)"));
 
         // Verify response payload type file was not generated
         final String typeCode = codeGenerator.getTypeCode();
@@ -957,17 +971,17 @@ public class GoFunctionalTests {
         CODE_LOGGER.logFile(client, FileTypeToLog.CLIENT);
         assertTrue(hasContent(client));
 
-        assertTrue(client.contains("func (client *Client) PutObject(ctx context.Context, request *models.PutObjectRequest) (*models.PutObjectResponse, error) {"));
-        assertTrue(client.contains("networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)"));
-        assertTrue(client.contains("response, requestErr := networkRetryDecorator.Invoke(httpRequest)"));
+        assertTrue(containsNormalized(client, "func (client *Client) PutObject(ctx context.Context, request *models.PutObjectRequest) (*models.PutObjectResponse, error) {"));
+        assertTrue(containsNormalized(client, "networkRetryDecorator := networking.NewNetworkRetryDecorator(client.sendNetwork, client.clientPolicy.maxRetries)"));
+        assertTrue(containsNormalized(client, "response, requestErr := networkRetryDecorator.Invoke(httpRequest)"));
 
-        assertTrue(client.contains("WithHttpVerb(HTTP_VERB_PUT)."));
-        assertTrue(client.contains("WithPath(\"/\" + request.BucketName + \"/\" + request.ObjectName)"));
-        assertTrue(client.contains("WithOptionalQueryParam(\"job\", request.Job)."));
-        assertTrue(client.contains("WithOptionalQueryParam(\"offset\", networking.Int64PtrToStrPtr(request.Offset))."));
-        assertTrue(client.contains("WithReader(request.Content)."));
-        assertTrue(client.contains("WithChecksum(request.Checksum)."));
-        assertTrue(client.contains("WithHeaders(request.Metadata)."));
+        assertTrue(containsNormalized(client, "WithHttpVerb(HTTP_VERB_PUT)."));
+        assertTrue(containsNormalized(client, "WithPath(\"/\"+request.BucketName+\"/\"+request.ObjectName)"));
+        assertTrue(containsNormalized(client, "WithOptionalQueryParam(\"job\", request.Job)."));
+        assertTrue(containsNormalized(client, "WithOptionalQueryParam(\"offset\", networking.Int64PtrToStrPtr(request.Offset))."));
+        assertTrue(containsNormalized(client, "WithReader(request.Content)."));
+        assertTrue(containsNormalized(client, "WithChecksum(request.Checksum)."));
+        assertTrue(containsNormalized(client, "WithHeaders(request.Metadata)."));
     }
 
     @Test
@@ -982,15 +996,15 @@ public class GoFunctionalTests {
         CODE_LOGGER.logFile(requestCode, FileTypeToLog.REQUEST);
         assertTrue(hasContent(requestCode));
 
-        assertTrue(requestCode.contains("type ClearSuspectBlobAzureTargetsSpectraS3Request struct {"));
-        assertTrue(requestCode.contains("Ids []string"));
-        assertTrue(requestCode.contains("Force bool"));
+        assertTrue(containsNormalized(requestCode, "type ClearSuspectBlobAzureTargetsSpectraS3Request struct {"));
+        assertTrue(containsNormalized(requestCode, "Ids []string"));
+        assertTrue(containsNormalized(requestCode, "Force bool"));
 
-        assertTrue(requestCode.contains("func NewClearSuspectBlobAzureTargetsSpectraS3Request(ids []string) *ClearSuspectBlobAzureTargetsSpectraS3Request {"));
-        assertTrue(requestCode.contains("Ids: ids,"));
+        assertTrue(containsNormalized(requestCode, "func NewClearSuspectBlobAzureTargetsSpectraS3Request(ids []string) *ClearSuspectBlobAzureTargetsSpectraS3Request {"));
+        assertTrue(containsNormalized(requestCode, "Ids: ids,"));
 
-        assertTrue(requestCode.contains("func (clearSuspectBlobAzureTargetsSpectraS3Request *ClearSuspectBlobAzureTargetsSpectraS3Request) WithForce() *ClearSuspectBlobAzureTargetsSpectraS3Request {"));
-        assertTrue(requestCode.contains("clearSuspectBlobAzureTargetsSpectraS3Request.Force = true"));
+        assertTrue(containsNormalized(requestCode, "func (clearSuspectBlobAzureTargetsSpectraS3Request *ClearSuspectBlobAzureTargetsSpectraS3Request) WithForce() *ClearSuspectBlobAzureTargetsSpectraS3Request {"));
+        assertTrue(containsNormalized(requestCode, "clearSuspectBlobAzureTargetsSpectraS3Request.Force = true"));
 
         // Verify Response file was generated
         final String responseCode = codeGenerator.getResponseCode();
@@ -1007,10 +1021,10 @@ public class GoFunctionalTests {
         CODE_LOGGER.logFile(client, FileTypeToLog.CLIENT);
         assertTrue(hasContent(client));
 
-        assertTrue(client.contains("WithHttpVerb(HTTP_VERB_DELETE)."));
-        assertTrue(client.contains("WithPath(\"/_rest_/suspect_blob_azure_target\")"));
-        assertTrue(client.contains("WithOptionalVoidQueryParam(\"force\", request.Force)."));
-        assertTrue(client.contains("WithReadCloser(buildIdListPayload(request.Ids))."));
+        assertTrue(containsNormalized(client, "WithHttpVerb(HTTP_VERB_DELETE)."));
+        assertTrue(containsNormalized(client, "WithPath(\"/_rest_/suspect_blob_azure_target\")"));
+        assertTrue(containsNormalized(client, "WithOptionalVoidQueryParam(\"force\", request.Force)."));
+        assertTrue(containsNormalized(client, "WithReadCloser(buildIdListPayload(request.Ids))."));
     }
 
     @Test
@@ -1025,66 +1039,66 @@ public class GoFunctionalTests {
         CODE_LOGGER.logFile(requestCode, FileTypeToLog.REQUEST);
         assertTrue(hasContent(requestCode));
 
-        assertTrue(requestCode.contains("BucketName string"));
-        assertTrue(requestCode.contains("Aggregating *bool"));
-        assertTrue(requestCode.contains("ImplicitJobIdResolution *bool"));
-        assertTrue(requestCode.contains("MaxUploadSize *int64"));
-        assertTrue(requestCode.contains("MinimizeSpanningAcrossMedia *bool"));
-        assertTrue(requestCode.contains("Name *string"));
-        assertTrue(requestCode.contains("Priority Priority"));
-        assertTrue(requestCode.contains("VerifyAfterWrite *bool"));
-        assertTrue(requestCode.contains("Objects []Ds3PutObject"));
-        assertTrue(requestCode.contains("IgnoreNamingConflicts bool"));
-        assertTrue(requestCode.contains("Force bool"));
+        assertTrue(containsNormalized(requestCode, "BucketName string"));
+        assertTrue(containsNormalized(requestCode, "Aggregating *bool"));
+        assertTrue(containsNormalized(requestCode, "ImplicitJobIdResolution *bool"));
+        assertTrue(containsNormalized(requestCode, "MaxUploadSize *int64"));
+        assertTrue(containsNormalized(requestCode, "MinimizeSpanningAcrossMedia *bool"));
+        assertTrue(containsNormalized(requestCode, "Name *string"));
+        assertTrue(containsNormalized(requestCode, "Priority Priority"));
+        assertTrue(containsNormalized(requestCode, "VerifyAfterWrite *bool"));
+        assertTrue(containsNormalized(requestCode, "Objects []Ds3PutObject"));
+        assertTrue(containsNormalized(requestCode, "IgnoreNamingConflicts bool"));
+        assertTrue(containsNormalized(requestCode, "Force bool"));
 
-        assertTrue(requestCode.contains("func NewPutBulkJobSpectraS3Request(bucketName string, objects []Ds3PutObject) *PutBulkJobSpectraS3Request {"));
-        assertTrue(requestCode.contains("BucketName: bucketName,"));
-        assertTrue(requestCode.contains("Objects: objects,"));
+        assertTrue(containsNormalized(requestCode, "func NewPutBulkJobSpectraS3Request(bucketName string, objects []Ds3PutObject) *PutBulkJobSpectraS3Request {"));
+        assertTrue(containsNormalized(requestCode, "BucketName: bucketName,"));
+        assertTrue(containsNormalized(requestCode, "Objects: objects,"));
 
-        assertTrue(requestCode.contains("func (putBulkJobSpectraS3Request *PutBulkJobSpectraS3Request) WithAggregating(aggregating bool) *PutBulkJobSpectraS3Request {"));
-        assertTrue(requestCode.contains("putBulkJobSpectraS3Request.Aggregating = &aggregating"));
+        assertTrue(containsNormalized(requestCode, "func (putBulkJobSpectraS3Request *PutBulkJobSpectraS3Request) WithAggregating(aggregating bool) *PutBulkJobSpectraS3Request {"));
+        assertTrue(containsNormalized(requestCode, "putBulkJobSpectraS3Request.Aggregating = &aggregating"));
 
-        assertTrue(requestCode.contains("func (putBulkJobSpectraS3Request *PutBulkJobSpectraS3Request) WithImplicitJobIdResolution(implicitJobIdResolution bool) *PutBulkJobSpectraS3Request {"));
-        assertTrue(requestCode.contains("putBulkJobSpectraS3Request.ImplicitJobIdResolution = &implicitJobIdResolution"));
+        assertTrue(containsNormalized(requestCode, "func (putBulkJobSpectraS3Request *PutBulkJobSpectraS3Request) WithImplicitJobIdResolution(implicitJobIdResolution bool) *PutBulkJobSpectraS3Request {"));
+        assertTrue(containsNormalized(requestCode, "putBulkJobSpectraS3Request.ImplicitJobIdResolution = &implicitJobIdResolution"));
 
-        assertTrue(requestCode.contains("func (putBulkJobSpectraS3Request *PutBulkJobSpectraS3Request) WithMaxUploadSize(maxUploadSize int64) *PutBulkJobSpectraS3Request {"));
-        assertTrue(requestCode.contains("putBulkJobSpectraS3Request.MaxUploadSize = &maxUploadSize"));
+        assertTrue(containsNormalized(requestCode, "func (putBulkJobSpectraS3Request *PutBulkJobSpectraS3Request) WithMaxUploadSize(maxUploadSize int64) *PutBulkJobSpectraS3Request {"));
+        assertTrue(containsNormalized(requestCode, "putBulkJobSpectraS3Request.MaxUploadSize = &maxUploadSize"));
 
-        assertTrue(requestCode.contains("func (putBulkJobSpectraS3Request *PutBulkJobSpectraS3Request) WithMinimizeSpanningAcrossMedia(minimizeSpanningAcrossMedia bool) *PutBulkJobSpectraS3Request {"));
-        assertTrue(requestCode.contains("putBulkJobSpectraS3Request.MinimizeSpanningAcrossMedia = &minimizeSpanningAcrossMedia"));
+        assertTrue(containsNormalized(requestCode, "func (putBulkJobSpectraS3Request *PutBulkJobSpectraS3Request) WithMinimizeSpanningAcrossMedia(minimizeSpanningAcrossMedia bool) *PutBulkJobSpectraS3Request {"));
+        assertTrue(containsNormalized(requestCode, "putBulkJobSpectraS3Request.MinimizeSpanningAcrossMedia = &minimizeSpanningAcrossMedia"));
 
-        assertTrue(requestCode.contains("func (putBulkJobSpectraS3Request *PutBulkJobSpectraS3Request) WithPriority(priority Priority) *PutBulkJobSpectraS3Request {"));
-        assertTrue(requestCode.contains("putBulkJobSpectraS3Request.Priority = priority"));
+        assertTrue(containsNormalized(requestCode, "func (putBulkJobSpectraS3Request *PutBulkJobSpectraS3Request) WithPriority(priority Priority) *PutBulkJobSpectraS3Request {"));
+        assertTrue(containsNormalized(requestCode, "putBulkJobSpectraS3Request.Priority = priority"));
 
-        assertTrue(requestCode.contains("func (putBulkJobSpectraS3Request *PutBulkJobSpectraS3Request) WithVerifyAfterWrite(verifyAfterWrite bool) *PutBulkJobSpectraS3Request {"));
-        assertTrue(requestCode.contains("putBulkJobSpectraS3Request.VerifyAfterWrite = &verifyAfterWrite"));
+        assertTrue(containsNormalized(requestCode, "func (putBulkJobSpectraS3Request *PutBulkJobSpectraS3Request) WithVerifyAfterWrite(verifyAfterWrite bool) *PutBulkJobSpectraS3Request {"));
+        assertTrue(containsNormalized(requestCode, "putBulkJobSpectraS3Request.VerifyAfterWrite = &verifyAfterWrite"));
 
-        assertTrue(requestCode.contains("func (putBulkJobSpectraS3Request *PutBulkJobSpectraS3Request) WithName(name string) *PutBulkJobSpectraS3Request {"));
-        assertTrue(requestCode.contains("putBulkJobSpectraS3Request.Name = &name"));
+        assertTrue(containsNormalized(requestCode, "func (putBulkJobSpectraS3Request *PutBulkJobSpectraS3Request) WithName(name string) *PutBulkJobSpectraS3Request {"));
+        assertTrue(containsNormalized(requestCode, "putBulkJobSpectraS3Request.Name = &name"));
 
-        assertTrue(requestCode.contains("func (putBulkJobSpectraS3Request *PutBulkJobSpectraS3Request) WithForce() *PutBulkJobSpectraS3Request {"));
-        assertTrue(requestCode.contains("putBulkJobSpectraS3Request.Force = true"));
+        assertTrue(containsNormalized(requestCode, "func (putBulkJobSpectraS3Request *PutBulkJobSpectraS3Request) WithForce() *PutBulkJobSpectraS3Request {"));
+        assertTrue(containsNormalized(requestCode, "putBulkJobSpectraS3Request.Force = true"));
 
-        assertTrue(requestCode.contains("func (putBulkJobSpectraS3Request *PutBulkJobSpectraS3Request) WithIgnoreNamingConflicts() *PutBulkJobSpectraS3Request {"));
-        assertTrue(requestCode.contains("putBulkJobSpectraS3Request.IgnoreNamingConflicts = true"));
+        assertTrue(containsNormalized(requestCode, "func (putBulkJobSpectraS3Request *PutBulkJobSpectraS3Request) WithIgnoreNamingConflicts() *PutBulkJobSpectraS3Request {"));
+        assertTrue(containsNormalized(requestCode, "putBulkJobSpectraS3Request.IgnoreNamingConflicts = true"));
 
         // Verify Response file was generated
         final String responseCode = codeGenerator.getResponseCode();
         CODE_LOGGER.logFile(responseCode, FileTypeToLog.RESPONSE);
         assertTrue(hasContent(responseCode));
 
-        assertFalse(responseCode.contains("\"ds3/networking\""));
-        assertTrue(responseCode.contains("\"net/http\""));
+        assertFalse(containsNormalized(responseCode, "\"ds3/networking\""));
+        assertTrue(containsNormalized(responseCode, "\"net/http\""));
 
-        assertTrue(responseCode.contains("MasterObjectList MasterObjectList"));
+        assertTrue(containsNormalized(responseCode, "MasterObjectList MasterObjectList"));
 
-        assertTrue(responseCode.contains("func (putBulkJobSpectraS3Response *PutBulkJobSpectraS3Response) parse(webResponse WebResponse) error {"));
-        assertTrue(responseCode.contains("return parseResponsePayload(webResponse, &putBulkJobSpectraS3Response.MasterObjectList)"));
+        assertTrue(containsNormalized(responseCode, "func (putBulkJobSpectraS3Response *PutBulkJobSpectraS3Response) parse(webResponse WebResponse) error {"));
+        assertTrue(containsNormalized(responseCode, "return parseResponsePayload(webResponse, &putBulkJobSpectraS3Response.MasterObjectList)"));
 
-        assertTrue(responseCode.contains("func NewPutBulkJobSpectraS3Response(webResponse WebResponse) (*PutBulkJobSpectraS3Response, error) {"));
-        assertTrue(responseCode.contains("expectedStatusCodes := []int { 200 }"));
-        assertTrue(responseCode.contains("case 200:"));
-        assertTrue(responseCode.contains("var body PutBulkJobSpectraS3Response"));
+        assertTrue(containsNormalized(responseCode, "func NewPutBulkJobSpectraS3Response(webResponse WebResponse) (*PutBulkJobSpectraS3Response, error) {"));
+        assertTrue(containsNormalized(responseCode, "expectedStatusCodes := []int{200}"));
+        assertTrue(containsNormalized(responseCode, "case 200:"));
+        assertTrue(containsNormalized(responseCode, "var body PutBulkJobSpectraS3Response"));
 
         // Verify response payload type file was generated
         final String typeCode = codeGenerator.getTypeCode();
@@ -1096,19 +1110,19 @@ public class GoFunctionalTests {
         CODE_LOGGER.logFile(client, FileTypeToLog.CLIENT);
         assertTrue(hasContent(client));
 
-        assertTrue(client.contains("WithHttpVerb(HTTP_VERB_PUT)."));
-        assertTrue(client.contains("WithPath(\"/_rest_/bucket/\" + request.BucketName)."));
-        assertTrue(client.contains("WithOptionalQueryParam(\"aggregating\", networking.BoolPtrToStrPtr(request.Aggregating))."));
-        assertTrue(client.contains("WithOptionalVoidQueryParam(\"force\", request.Force)."));
-        assertTrue(client.contains("WithOptionalVoidQueryParam(\"ignore_naming_conflicts\", request.IgnoreNamingConflicts)."));
-        assertTrue(client.contains("WithOptionalQueryParam(\"implicit_job_id_resolution\", networking.BoolPtrToStrPtr(request.ImplicitJobIdResolution))."));
-        assertTrue(client.contains("WithOptionalQueryParam(\"max_upload_size\", networking.Int64PtrToStrPtr(request.MaxUploadSize))."));
-        assertTrue(client.contains("WithOptionalQueryParam(\"minimize_spanning_across_media\", networking.BoolPtrToStrPtr(request.MinimizeSpanningAcrossMedia))."));
-        assertTrue(client.contains("WithOptionalQueryParam(\"name\", request.Name)."));
-        assertTrue(client.contains("WithOptionalQueryParam(\"priority\", networking.InterfaceToStrPtr(request.Priority))."));
-        assertTrue(client.contains("WithOptionalQueryParam(\"verify_after_write\", networking.BoolPtrToStrPtr(request.VerifyAfterWrite))."));
-        assertTrue(client.contains("WithQueryParam(\"operation\", \"start_bulk_put\")."));
-        assertTrue(client.contains("WithReadCloser(buildDs3PutObjectListStream(request.Objects))."));
+        assertTrue(containsNormalized(client, "WithHttpVerb(HTTP_VERB_PUT)."));
+        assertTrue(containsNormalized(client, "WithPath(\"/_rest_/bucket/\"+request.BucketName)."));
+        assertTrue(containsNormalized(client, "WithOptionalQueryParam(\"aggregating\", networking.BoolPtrToStrPtr(request.Aggregating))."));
+        assertTrue(containsNormalized(client, "WithOptionalVoidQueryParam(\"force\", request.Force)."));
+        assertTrue(containsNormalized(client, "WithOptionalVoidQueryParam(\"ignore_naming_conflicts\", request.IgnoreNamingConflicts)."));
+        assertTrue(containsNormalized(client, "WithOptionalQueryParam(\"implicit_job_id_resolution\", networking.BoolPtrToStrPtr(request.ImplicitJobIdResolution))."));
+        assertTrue(containsNormalized(client, "WithOptionalQueryParam(\"max_upload_size\", networking.Int64PtrToStrPtr(request.MaxUploadSize))."));
+        assertTrue(containsNormalized(client, "WithOptionalQueryParam(\"minimize_spanning_across_media\", networking.BoolPtrToStrPtr(request.MinimizeSpanningAcrossMedia))."));
+        assertTrue(containsNormalized(client, "WithOptionalQueryParam(\"name\", request.Name)."));
+        assertTrue(containsNormalized(client, "WithOptionalQueryParam(\"priority\", networking.InterfaceToStrPtr(request.Priority))."));
+        assertTrue(containsNormalized(client, "WithOptionalQueryParam(\"verify_after_write\", networking.BoolPtrToStrPtr(request.VerifyAfterWrite))."));
+        assertTrue(containsNormalized(client, "WithQueryParam(\"operation\", \"start_bulk_put\")."));
+        assertTrue(containsNormalized(client, "WithReadCloser(buildDs3PutObjectListStream(request.Objects))."));
     }
 
     @Test
@@ -1123,55 +1137,55 @@ public class GoFunctionalTests {
         CODE_LOGGER.logFile(requestCode, FileTypeToLog.REQUEST);
         assertTrue(hasContent(requestCode));
 
-        assertFalse(requestCode.contains("import \"ds3\""));
+        assertFalse(containsNormalized(requestCode, "import \"ds3\""));
 
-        assertTrue(requestCode.contains("BucketName string"));
-        assertTrue(requestCode.contains("Aggregating *bool"));
-        assertTrue(requestCode.contains("ChunkClientProcessingOrderGuarantee JobChunkClientProcessingOrderGuarantee"));
-        assertTrue(requestCode.contains("ImplicitJobIdResolution *bool"));
-        assertTrue(requestCode.contains("Name *string"));
-        assertTrue(requestCode.contains("Priority Priority"));
-        assertTrue(requestCode.contains("Objects []Ds3GetObject"));
+        assertTrue(containsNormalized(requestCode, "BucketName string"));
+        assertTrue(containsNormalized(requestCode, "Aggregating *bool"));
+        assertTrue(containsNormalized(requestCode, "ChunkClientProcessingOrderGuarantee JobChunkClientProcessingOrderGuarantee"));
+        assertTrue(containsNormalized(requestCode, "ImplicitJobIdResolution *bool"));
+        assertTrue(containsNormalized(requestCode, "Name *string"));
+        assertTrue(containsNormalized(requestCode, "Priority Priority"));
+        assertTrue(containsNormalized(requestCode, "Objects []Ds3GetObject"));
 
-        assertTrue(requestCode.contains("func NewGetBulkJobSpectraS3Request(bucketName string, objectNames []string) *GetBulkJobSpectraS3Request {"));
-        assertTrue(requestCode.contains("BucketName: bucketName,"));
-        assertTrue(requestCode.contains("Objects: buildDs3GetObjectSliceFromNames(objectNames),"));
+        assertTrue(containsNormalized(requestCode, "func NewGetBulkJobSpectraS3Request(bucketName string, objectNames []string) *GetBulkJobSpectraS3Request {"));
+        assertTrue(containsNormalized(requestCode, "BucketName: bucketName,"));
+        assertTrue(containsNormalized(requestCode, "Objects: buildDs3GetObjectSliceFromNames(objectNames),"));
 
-        assertTrue(requestCode.contains("func NewGetBulkJobSpectraS3RequestWithPartialObjects(bucketName string, objects []Ds3GetObject) *GetBulkJobSpectraS3Request {"));
-        assertTrue(requestCode.contains("Objects: objects,"));
+        assertTrue(containsNormalized(requestCode, "func NewGetBulkJobSpectraS3RequestWithPartialObjects(bucketName string, objects []Ds3GetObject) *GetBulkJobSpectraS3Request {"));
+        assertTrue(containsNormalized(requestCode, "Objects: objects,"));
 
-        assertTrue(requestCode.contains("func (getBulkJobSpectraS3Request *GetBulkJobSpectraS3Request) WithAggregating(aggregating bool) *GetBulkJobSpectraS3Request {"));
-        assertTrue(requestCode.contains("getBulkJobSpectraS3Request.Aggregating = &aggregating"));
+        assertTrue(containsNormalized(requestCode, "func (getBulkJobSpectraS3Request *GetBulkJobSpectraS3Request) WithAggregating(aggregating bool) *GetBulkJobSpectraS3Request {"));
+        assertTrue(containsNormalized(requestCode, "getBulkJobSpectraS3Request.Aggregating = &aggregating"));
 
-        assertTrue(requestCode.contains("func (getBulkJobSpectraS3Request *GetBulkJobSpectraS3Request) WithChunkClientProcessingOrderGuarantee(chunkClientProcessingOrderGuarantee JobChunkClientProcessingOrderGuarantee) *GetBulkJobSpectraS3Request {"));
-        assertTrue(requestCode.contains("getBulkJobSpectraS3Request.ChunkClientProcessingOrderGuarantee = chunkClientProcessingOrderGuarantee"));
+        assertTrue(containsNormalized(requestCode, "func (getBulkJobSpectraS3Request *GetBulkJobSpectraS3Request) WithChunkClientProcessingOrderGuarantee(chunkClientProcessingOrderGuarantee JobChunkClientProcessingOrderGuarantee) *GetBulkJobSpectraS3Request {"));
+        assertTrue(containsNormalized(requestCode, "getBulkJobSpectraS3Request.ChunkClientProcessingOrderGuarantee = chunkClientProcessingOrderGuarantee"));
 
-        assertTrue(requestCode.contains("func (getBulkJobSpectraS3Request *GetBulkJobSpectraS3Request) WithImplicitJobIdResolution(implicitJobIdResolution bool) *GetBulkJobSpectraS3Request {"));
-        assertTrue(requestCode.contains("getBulkJobSpectraS3Request.ImplicitJobIdResolution = &implicitJobIdResolution"));
+        assertTrue(containsNormalized(requestCode, "func (getBulkJobSpectraS3Request *GetBulkJobSpectraS3Request) WithImplicitJobIdResolution(implicitJobIdResolution bool) *GetBulkJobSpectraS3Request {"));
+        assertTrue(containsNormalized(requestCode, "getBulkJobSpectraS3Request.ImplicitJobIdResolution = &implicitJobIdResolution"));
 
-        assertTrue(requestCode.contains("func (getBulkJobSpectraS3Request *GetBulkJobSpectraS3Request) WithPriority(priority Priority) *GetBulkJobSpectraS3Request {"));
-        assertTrue(requestCode.contains("getBulkJobSpectraS3Request.Priority = priority"));
+        assertTrue(containsNormalized(requestCode, "func (getBulkJobSpectraS3Request *GetBulkJobSpectraS3Request) WithPriority(priority Priority) *GetBulkJobSpectraS3Request {"));
+        assertTrue(containsNormalized(requestCode, "getBulkJobSpectraS3Request.Priority = priority"));
 
-        assertTrue(requestCode.contains("func (getBulkJobSpectraS3Request *GetBulkJobSpectraS3Request) WithName(name string) *GetBulkJobSpectraS3Request {"));
-        assertTrue(requestCode.contains("getBulkJobSpectraS3Request.Name = &name"));
+        assertTrue(containsNormalized(requestCode, "func (getBulkJobSpectraS3Request *GetBulkJobSpectraS3Request) WithName(name string) *GetBulkJobSpectraS3Request {"));
+        assertTrue(containsNormalized(requestCode, "getBulkJobSpectraS3Request.Name = &name"));
 
         // Verify Response file was generated
         final String responseCode = codeGenerator.getResponseCode();
         CODE_LOGGER.logFile(responseCode, FileTypeToLog.RESPONSE);
         assertTrue(hasContent(responseCode));
 
-        assertFalse(responseCode.contains("\"ds3/networking\""));
-        assertTrue(responseCode.contains("\"net/http\""));
+        assertFalse(containsNormalized(responseCode, "\"ds3/networking\""));
+        assertTrue(containsNormalized(responseCode, "\"net/http\""));
 
-        assertTrue(responseCode.contains("MasterObjectList MasterObjectList"));
+        assertTrue(containsNormalized(responseCode, "MasterObjectList MasterObjectList"));
 
-        assertTrue(responseCode.contains("func (getBulkJobSpectraS3Response *GetBulkJobSpectraS3Response) parse(webResponse WebResponse) error {"));
-        assertTrue(responseCode.contains("return parseResponsePayload(webResponse, &getBulkJobSpectraS3Response.MasterObjectList)"));
+        assertTrue(containsNormalized(responseCode, "func (getBulkJobSpectraS3Response *GetBulkJobSpectraS3Response) parse(webResponse WebResponse) error {"));
+        assertTrue(containsNormalized(responseCode, "return parseResponsePayload(webResponse, &getBulkJobSpectraS3Response.MasterObjectList)"));
 
-        assertTrue(responseCode.contains("func NewGetBulkJobSpectraS3Response(webResponse WebResponse) (*GetBulkJobSpectraS3Response, error) {"));
-        assertTrue(responseCode.contains("expectedStatusCodes := []int { 200 }"));
-        assertTrue(responseCode.contains("case 200:"));
-        assertTrue(responseCode.contains("var body GetBulkJobSpectraS3Response"));
+        assertTrue(containsNormalized(responseCode, "func NewGetBulkJobSpectraS3Response(webResponse WebResponse) (*GetBulkJobSpectraS3Response, error) {"));
+        assertTrue(containsNormalized(responseCode, "expectedStatusCodes := []int{200}"));
+        assertTrue(containsNormalized(responseCode, "case 200:"));
+        assertTrue(containsNormalized(responseCode, "var body GetBulkJobSpectraS3Response"));
 
         // Verify response payload type file was generated
         final String typeCode = codeGenerator.getTypeCode();
@@ -1183,15 +1197,15 @@ public class GoFunctionalTests {
         CODE_LOGGER.logFile(client, FileTypeToLog.CLIENT);
         assertTrue(hasContent(client));
 
-        assertTrue(client.contains("WithHttpVerb(HTTP_VERB_PUT)."));
-        assertTrue(client.contains("WithPath(\"/_rest_/bucket/\" + request.BucketName)."));
-        assertTrue(client.contains("WithOptionalQueryParam(\"aggregating\", networking.BoolPtrToStrPtr(request.Aggregating))."));
-        assertTrue(client.contains("WithOptionalQueryParam(\"chunk_client_processing_order_guarantee\", networking.InterfaceToStrPtr(request.ChunkClientProcessingOrderGuarantee))."));
-        assertTrue(client.contains("WithOptionalQueryParam(\"implicit_job_id_resolution\", networking.BoolPtrToStrPtr(request.ImplicitJobIdResolution))."));
-        assertTrue(client.contains("WithOptionalQueryParam(\"name\", request.Name)."));
-        assertTrue(client.contains("WithOptionalQueryParam(\"priority\", networking.InterfaceToStrPtr(request.Priority))."));
-        assertTrue(client.contains("WithQueryParam(\"operation\", \"start_bulk_get\")."));
-        assertTrue(client.contains("WithReadCloser(buildDs3GetObjectListStream(request.Objects))."));
+        assertTrue(containsNormalized(client, "WithHttpVerb(HTTP_VERB_PUT)."));
+        assertTrue(containsNormalized(client, "WithPath(\"/_rest_/bucket/\"+request.BucketName)."));
+        assertTrue(containsNormalized(client, "WithOptionalQueryParam(\"aggregating\", networking.BoolPtrToStrPtr(request.Aggregating))."));
+        assertTrue(containsNormalized(client, "WithOptionalQueryParam(\"chunk_client_processing_order_guarantee\", networking.InterfaceToStrPtr(request.ChunkClientProcessingOrderGuarantee))."));
+        assertTrue(containsNormalized(client, "WithOptionalQueryParam(\"implicit_job_id_resolution\", networking.BoolPtrToStrPtr(request.ImplicitJobIdResolution))."));
+        assertTrue(containsNormalized(client, "WithOptionalQueryParam(\"name\", request.Name)."));
+        assertTrue(containsNormalized(client, "WithOptionalQueryParam(\"priority\", networking.InterfaceToStrPtr(request.Priority))."));
+        assertTrue(containsNormalized(client, "WithQueryParam(\"operation\", \"start_bulk_get\")."));
+        assertTrue(containsNormalized(client, "WithReadCloser(buildDs3GetObjectListStream(request.Objects))."));
     }
 
     @Test
@@ -1206,47 +1220,47 @@ public class GoFunctionalTests {
         CODE_LOGGER.logFile(requestCode, FileTypeToLog.REQUEST);
         assertTrue(hasContent(requestCode));
 
-        assertFalse(requestCode.contains("import \"ds3\""));
+        assertFalse(containsNormalized(requestCode, "import \"ds3\""));
 
-        assertTrue(requestCode.contains("BucketName string"));
-        assertTrue(requestCode.contains("Aggregating *bool"));
-        assertTrue(requestCode.contains("Name *string"));
-        assertTrue(requestCode.contains("Priority Priority"));
-        assertTrue(requestCode.contains("Objects []Ds3GetObject"));
+        assertTrue(containsNormalized(requestCode, "BucketName string"));
+        assertTrue(containsNormalized(requestCode, "Aggregating *bool"));
+        assertTrue(containsNormalized(requestCode, "Name *string"));
+        assertTrue(containsNormalized(requestCode, "Priority Priority"));
+        assertTrue(containsNormalized(requestCode, "Objects []Ds3GetObject"));
 
-        assertTrue(requestCode.contains("func NewVerifyBulkJobSpectraS3Request(bucketName string, objectNames []string) *VerifyBulkJobSpectraS3Request {"));
-        assertTrue(requestCode.contains("BucketName: bucketName,"));
-        assertTrue(requestCode.contains("Objects: buildDs3GetObjectSliceFromNames(objectNames),"));
+        assertTrue(containsNormalized(requestCode, "func NewVerifyBulkJobSpectraS3Request(bucketName string, objectNames []string) *VerifyBulkJobSpectraS3Request {"));
+        assertTrue(containsNormalized(requestCode, "BucketName: bucketName,"));
+        assertTrue(containsNormalized(requestCode, "Objects: buildDs3GetObjectSliceFromNames(objectNames),"));
 
-        assertTrue(requestCode.contains("func NewVerifyBulkJobSpectraS3RequestWithPartialObjects(bucketName string, objects []Ds3GetObject) *VerifyBulkJobSpectraS3Request {"));
-        assertTrue(requestCode.contains("Objects: objects,"));
+        assertTrue(containsNormalized(requestCode, "func NewVerifyBulkJobSpectraS3RequestWithPartialObjects(bucketName string, objects []Ds3GetObject) *VerifyBulkJobSpectraS3Request {"));
+        assertTrue(containsNormalized(requestCode, "Objects: objects,"));
 
-        assertTrue(requestCode.contains("func (verifyBulkJobSpectraS3Request *VerifyBulkJobSpectraS3Request) WithAggregating(aggregating bool) *VerifyBulkJobSpectraS3Request {"));
-        assertTrue(requestCode.contains("verifyBulkJobSpectraS3Request.Aggregating = &aggregating"));
+        assertTrue(containsNormalized(requestCode, "func (verifyBulkJobSpectraS3Request *VerifyBulkJobSpectraS3Request) WithAggregating(aggregating bool) *VerifyBulkJobSpectraS3Request {"));
+        assertTrue(containsNormalized(requestCode, "verifyBulkJobSpectraS3Request.Aggregating = &aggregating"));
 
-        assertTrue(requestCode.contains("func (verifyBulkJobSpectraS3Request *VerifyBulkJobSpectraS3Request) WithPriority(priority Priority) *VerifyBulkJobSpectraS3Request {"));
-        assertTrue(requestCode.contains("verifyBulkJobSpectraS3Request.Priority = priority"));
+        assertTrue(containsNormalized(requestCode, "func (verifyBulkJobSpectraS3Request *VerifyBulkJobSpectraS3Request) WithPriority(priority Priority) *VerifyBulkJobSpectraS3Request {"));
+        assertTrue(containsNormalized(requestCode, "verifyBulkJobSpectraS3Request.Priority = priority"));
 
-        assertTrue(requestCode.contains("func (verifyBulkJobSpectraS3Request *VerifyBulkJobSpectraS3Request) WithName(name string) *VerifyBulkJobSpectraS3Request {"));
-        assertTrue(requestCode.contains("verifyBulkJobSpectraS3Request.Name = &name"));
+        assertTrue(containsNormalized(requestCode, "func (verifyBulkJobSpectraS3Request *VerifyBulkJobSpectraS3Request) WithName(name string) *VerifyBulkJobSpectraS3Request {"));
+        assertTrue(containsNormalized(requestCode, "verifyBulkJobSpectraS3Request.Name = &name"));
 
         // Verify Response file was generated
         final String responseCode = codeGenerator.getResponseCode();
         CODE_LOGGER.logFile(responseCode, FileTypeToLog.RESPONSE);
         assertTrue(hasContent(responseCode));
 
-        assertFalse(responseCode.contains("\"ds3/networking\""));
-        assertTrue(responseCode.contains("\"net/http\""));
+        assertFalse(containsNormalized(responseCode, "\"ds3/networking\""));
+        assertTrue(containsNormalized(responseCode, "\"net/http\""));
 
-        assertTrue(responseCode.contains("MasterObjectList MasterObjectList"));
+        assertTrue(containsNormalized(responseCode, "MasterObjectList MasterObjectList"));
 
-        assertTrue(responseCode.contains("func (verifyBulkJobSpectraS3Response *VerifyBulkJobSpectraS3Response) parse(webResponse WebResponse) error {"));
-        assertTrue(responseCode.contains("return parseResponsePayload(webResponse, &verifyBulkJobSpectraS3Response.MasterObjectList)"));
+        assertTrue(containsNormalized(responseCode, "func (verifyBulkJobSpectraS3Response *VerifyBulkJobSpectraS3Response) parse(webResponse WebResponse) error {"));
+        assertTrue(containsNormalized(responseCode, "return parseResponsePayload(webResponse, &verifyBulkJobSpectraS3Response.MasterObjectList)"));
 
-        assertTrue(responseCode.contains("func NewVerifyBulkJobSpectraS3Response(webResponse WebResponse) (*VerifyBulkJobSpectraS3Response, error) {"));
-        assertTrue(responseCode.contains("expectedStatusCodes := []int { 200 }"));
-        assertTrue(responseCode.contains("case 200:"));
-        assertTrue(responseCode.contains("var body VerifyBulkJobSpectraS3Response"));
+        assertTrue(containsNormalized(responseCode, "func NewVerifyBulkJobSpectraS3Response(webResponse WebResponse) (*VerifyBulkJobSpectraS3Response, error) {"));
+        assertTrue(containsNormalized(responseCode, "expectedStatusCodes := []int{200}"));
+        assertTrue(containsNormalized(responseCode, "case 200:"));
+        assertTrue(containsNormalized(responseCode, "var body VerifyBulkJobSpectraS3Response"));
 
         // Verify response payload type file was generated
         final String typeCode = codeGenerator.getTypeCode();
@@ -1258,13 +1272,13 @@ public class GoFunctionalTests {
         CODE_LOGGER.logFile(client, FileTypeToLog.CLIENT);
         assertTrue(hasContent(client));
 
-        assertTrue(client.contains("WithHttpVerb(HTTP_VERB_PUT)."));
-        assertTrue(client.contains("WithPath(\"/_rest_/bucket/\" + request.BucketName)."));
-        assertTrue(client.contains("WithOptionalQueryParam(\"aggregating\", networking.BoolPtrToStrPtr(request.Aggregating))."));
-        assertTrue(client.contains("WithOptionalQueryParam(\"name\", request.Name)."));
-        assertTrue(client.contains("WithOptionalQueryParam(\"priority\", networking.InterfaceToStrPtr(request.Priority))."));
-        assertTrue(client.contains("WithQueryParam(\"operation\", \"start_bulk_verify\")."));
-        assertTrue(client.contains("WithReadCloser(buildDs3GetObjectListStream(request.Objects))."));
+        assertTrue(containsNormalized(client, "WithHttpVerb(HTTP_VERB_PUT)."));
+        assertTrue(containsNormalized(client, "WithPath(\"/_rest_/bucket/\"+request.BucketName)."));
+        assertTrue(containsNormalized(client, "WithOptionalQueryParam(\"aggregating\", networking.BoolPtrToStrPtr(request.Aggregating))."));
+        assertTrue(containsNormalized(client, "WithOptionalQueryParam(\"name\", request.Name)."));
+        assertTrue(containsNormalized(client, "WithOptionalQueryParam(\"priority\", networking.InterfaceToStrPtr(request.Priority))."));
+        assertTrue(containsNormalized(client, "WithQueryParam(\"operation\", \"start_bulk_verify\")."));
+        assertTrue(containsNormalized(client, "WithReadCloser(buildDs3GetObjectListStream(request.Objects))."));
     }
 
     @Test
@@ -1279,23 +1293,23 @@ public class GoFunctionalTests {
         CODE_LOGGER.logFile(requestCode, FileTypeToLog.REQUEST);
         assertTrue(hasContent(requestCode));
 
-        assertTrue(requestCode.contains("type PutBucketSpectraS3Request struct {"));
-        assertTrue(requestCode.contains("DataPolicyId *string"));
-        assertTrue(requestCode.contains("Id *string"));
-        assertTrue(requestCode.contains("Name string"));
-        assertTrue(requestCode.contains("UserId *string"));
+        assertTrue(containsNormalized(requestCode, "type PutBucketSpectraS3Request struct {"));
+        assertTrue(containsNormalized(requestCode, "DataPolicyId *string"));
+        assertTrue(containsNormalized(requestCode, "Id *string"));
+        assertTrue(containsNormalized(requestCode, "Name string"));
+        assertTrue(containsNormalized(requestCode, "UserId *string"));
 
-        assertTrue(requestCode.contains("func NewPutBucketSpectraS3Request(name string) *PutBucketSpectraS3Request {"));
-        assertTrue(requestCode.contains("Name: name,"));
+        assertTrue(containsNormalized(requestCode, "func NewPutBucketSpectraS3Request(name string) *PutBucketSpectraS3Request {"));
+        assertTrue(containsNormalized(requestCode, "Name: name,"));
 
-        assertTrue(requestCode.contains("func (putBucketSpectraS3Request *PutBucketSpectraS3Request) WithDataPolicyId(dataPolicyId string) *PutBucketSpectraS3Request {"));
-        assertTrue(requestCode.contains("putBucketSpectraS3Request.DataPolicyId = &dataPolicyId"));
+        assertTrue(containsNormalized(requestCode, "func (putBucketSpectraS3Request *PutBucketSpectraS3Request) WithDataPolicyId(dataPolicyId string) *PutBucketSpectraS3Request {"));
+        assertTrue(containsNormalized(requestCode, "putBucketSpectraS3Request.DataPolicyId = &dataPolicyId"));
 
-        assertTrue(requestCode.contains("func (putBucketSpectraS3Request *PutBucketSpectraS3Request) WithId(id string) *PutBucketSpectraS3Request {"));
-        assertTrue(requestCode.contains("putBucketSpectraS3Request.Id = &id"));
+        assertTrue(containsNormalized(requestCode, "func (putBucketSpectraS3Request *PutBucketSpectraS3Request) WithId(id string) *PutBucketSpectraS3Request {"));
+        assertTrue(containsNormalized(requestCode, "putBucketSpectraS3Request.Id = &id"));
 
-        assertTrue(requestCode.contains("func (putBucketSpectraS3Request *PutBucketSpectraS3Request) WithUserId(userId string) *PutBucketSpectraS3Request {"));
-        assertTrue(requestCode.contains("putBucketSpectraS3Request.UserId = &userId"));
+        assertTrue(containsNormalized(requestCode, "func (putBucketSpectraS3Request *PutBucketSpectraS3Request) WithUserId(userId string) *PutBucketSpectraS3Request {"));
+        assertTrue(containsNormalized(requestCode, "putBucketSpectraS3Request.UserId = &userId"));
     }
 
     @Test
@@ -1310,28 +1324,28 @@ public class GoFunctionalTests {
         CODE_LOGGER.logFile(requestCode, FileTypeToLog.REQUEST);
         assertTrue(hasContent(requestCode));
 
-        assertTrue(requestCode.contains("type HeadObjectRequest struct {"));
-        assertTrue(requestCode.contains("BucketName string"));
-        assertTrue(requestCode.contains("ObjectName string"));
+        assertTrue(containsNormalized(requestCode, "type HeadObjectRequest struct {"));
+        assertTrue(containsNormalized(requestCode, "BucketName string"));
+        assertTrue(containsNormalized(requestCode, "ObjectName string"));
 
-        assertTrue(requestCode.contains("func NewHeadObjectRequest(bucketName string, objectName string) *HeadObjectRequest {"));
-        assertTrue(requestCode.contains("BucketName: bucketName,"));
-        assertTrue(requestCode.contains("ObjectName: objectName,"));
+        assertTrue(containsNormalized(requestCode, "func NewHeadObjectRequest(bucketName string, objectName string) *HeadObjectRequest {"));
+        assertTrue(containsNormalized(requestCode, "BucketName: bucketName,"));
+        assertTrue(containsNormalized(requestCode, "ObjectName: objectName,"));
 
         // Verify Response file was generated
         final String responseCode = codeGenerator.getResponseCode();
         CODE_LOGGER.logFile(responseCode, FileTypeToLog.RESPONSE);
         assertTrue(hasContent(responseCode));
 
-        assertTrue(responseCode.contains("type HeadObjectResponse struct {"));
-        assertTrue(responseCode.contains("BlobChecksumType ChecksumType"));
-        assertTrue(responseCode.contains("BlobChecksums map[int64]string"));
-        assertTrue(responseCode.contains("Headers *http.Header"));
+        assertTrue(containsNormalized(responseCode, "type HeadObjectResponse struct {"));
+        assertTrue(containsNormalized(responseCode, "BlobChecksumType ChecksumType"));
+        assertTrue(containsNormalized(responseCode, "BlobChecksums map[int64]string"));
+        assertTrue(containsNormalized(responseCode, "Headers *http.Header"));
 
-        assertTrue(responseCode.contains("func NewHeadObjectResponse(webResponse WebResponse) (*HeadObjectResponse, error) {"));
-        assertTrue(responseCode.contains("expectedStatusCodes := []int { 200 }"));
-        assertTrue(responseCode.contains("checksumType, err := getBlobChecksumType(webResponse.Header())"));
-        assertTrue(responseCode.contains("checksumMap, err := getBlobChecksumMap(webResponse.Header())"));
-        assertTrue(responseCode.contains("return &HeadObjectResponse{BlobChecksumType: checksumType, BlobChecksums: checksumMap, Headers: webResponse.Header()}, nil"));
+        assertTrue(containsNormalized(responseCode, "func NewHeadObjectResponse(webResponse WebResponse) (*HeadObjectResponse, error) {"));
+        assertTrue(containsNormalized(responseCode, "expectedStatusCodes := []int{200}"));
+        assertTrue(containsNormalized(responseCode, "checksumType, err := getBlobChecksumType(webResponse.Header())"));
+        assertTrue(containsNormalized(responseCode, "checksumMap, err := getBlobChecksumMap(webResponse.Header())"));
+        assertTrue(containsNormalized(responseCode, "return &HeadObjectResponse{BlobChecksumType: checksumType, BlobChecksums: checksumMap, Headers: webResponse.Header()}, nil"));
     }
 }

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTypeTests.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/GoFunctionalTypeTests.java
@@ -37,6 +37,15 @@ public class GoFunctionalTypeTests {
     private final static Logger LOG = LoggerFactory.getLogger(GoFunctionalTests.class);
     private final static GeneratedCodeLogger CODE_LOGGER = new GeneratedCodeLogger(FileTypeToLog.MODEL, LOG);
 
+    private static boolean containsNormalized(final String haystack, final String needle) {
+        return normalize(haystack).contains(normalize(needle));
+    }
+
+    private static String normalize(final String s) {
+        return s.replaceAll("\\s+", " ");
+    }
+
+
     @Test
     public void simpleEnumGeneration() throws IOException, TemplateModelException {
         final FileUtils fileUtils = mock(FileUtils.class);
@@ -50,29 +59,29 @@ public class GoFunctionalTypeTests {
         assertTrue(hasContent(typeCode));
 
         // Test const definitions
-        assertTrue(typeCode.contains("DATABASE_PHYSICAL_SPACE_STATE_CRITICAL DatabasePhysicalSpaceState = 1 + iota"));
-        assertTrue(typeCode.contains("DATABASE_PHYSICAL_SPACE_STATE_LOW DatabasePhysicalSpaceState = 1 + iota"));
-        assertTrue(typeCode.contains("DATABASE_PHYSICAL_SPACE_STATE_NEAR_LOW DatabasePhysicalSpaceState = 1 + iota"));
-        assertTrue(typeCode.contains("DATABASE_PHYSICAL_SPACE_STATE_NORMAL DatabasePhysicalSpaceState = 1 + iota"));
+        assertTrue(containsNormalized(typeCode, "DATABASE_PHYSICAL_SPACE_STATE_CRITICAL DatabasePhysicalSpaceState = 1 + iota"));
+        assertTrue(containsNormalized(typeCode, "DATABASE_PHYSICAL_SPACE_STATE_LOW DatabasePhysicalSpaceState = 1 + iota"));
+        assertTrue(containsNormalized(typeCode, "DATABASE_PHYSICAL_SPACE_STATE_NEAR_LOW DatabasePhysicalSpaceState = 1 + iota"));
+        assertTrue(containsNormalized(typeCode, "DATABASE_PHYSICAL_SPACE_STATE_NORMAL DatabasePhysicalSpaceState = 1 + iota"));
 
         // Test un-marshaling
-        assertTrue(typeCode.contains("case \"\": *databasePhysicalSpaceState = UNDEFINED"));
-        assertTrue(typeCode.contains("case \"CRITICAL\": *databasePhysicalSpaceState = DATABASE_PHYSICAL_SPACE_STATE_CRITICAL"));
-        assertTrue(typeCode.contains("case \"LOW\": *databasePhysicalSpaceState = DATABASE_PHYSICAL_SPACE_STATE_LOW"));
-        assertTrue(typeCode.contains("case \"NEAR_LOW\": *databasePhysicalSpaceState = DATABASE_PHYSICAL_SPACE_STATE_NEAR_LOW"));
-        assertTrue(typeCode.contains("case \"NORMAL\": *databasePhysicalSpaceState = DATABASE_PHYSICAL_SPACE_STATE_NORMAL"));
+        assertTrue(containsNormalized(typeCode, "case \"\": *databasePhysicalSpaceState = UNDEFINED"));
+        assertTrue(containsNormalized(typeCode, "case \"CRITICAL\": *databasePhysicalSpaceState = DATABASE_PHYSICAL_SPACE_STATE_CRITICAL"));
+        assertTrue(containsNormalized(typeCode, "case \"LOW\": *databasePhysicalSpaceState = DATABASE_PHYSICAL_SPACE_STATE_LOW"));
+        assertTrue(containsNormalized(typeCode, "case \"NEAR_LOW\": *databasePhysicalSpaceState = DATABASE_PHYSICAL_SPACE_STATE_NEAR_LOW"));
+        assertTrue(containsNormalized(typeCode, "case \"NORMAL\": *databasePhysicalSpaceState = DATABASE_PHYSICAL_SPACE_STATE_NORMAL"));
 
         // Test conversion to string
-        assertTrue(typeCode.contains("case DATABASE_PHYSICAL_SPACE_STATE_CRITICAL: return \"CRITICAL\""));
-        assertTrue(typeCode.contains("case DATABASE_PHYSICAL_SPACE_STATE_LOW: return \"LOW\""));
-        assertTrue(typeCode.contains("case DATABASE_PHYSICAL_SPACE_STATE_NEAR_LOW: return \"NEAR_LOW\""));
-        assertTrue(typeCode.contains("case DATABASE_PHYSICAL_SPACE_STATE_NORMAL: return \"NORMAL\""));
+        assertTrue(containsNormalized(typeCode, "case DATABASE_PHYSICAL_SPACE_STATE_CRITICAL: return \"CRITICAL\""));
+        assertTrue(containsNormalized(typeCode, "case DATABASE_PHYSICAL_SPACE_STATE_LOW: return \"LOW\""));
+        assertTrue(containsNormalized(typeCode, "case DATABASE_PHYSICAL_SPACE_STATE_NEAR_LOW: return \"NEAR_LOW\""));
+        assertTrue(containsNormalized(typeCode, "case DATABASE_PHYSICAL_SPACE_STATE_NORMAL: return \"NORMAL\""));
 
         // Verify conversion to string pointer
-        assertTrue(typeCode.contains("func (databasePhysicalSpaceState DatabasePhysicalSpaceState) StringPtr() *string {"));
+        assertTrue(containsNormalized(typeCode, "func (databasePhysicalSpaceState DatabasePhysicalSpaceState) StringPtr() *string {"));
 
         // Verify type parser code was not generated for enum type
-        assertFalse(typeCode.contains("parse("));
+        assertFalse(containsNormalized(typeCode, "parse("));
     }
 
     @Test
@@ -88,33 +97,33 @@ public class GoFunctionalTypeTests {
         assertTrue(hasContent(typeCode));
 
         // Test const definitions
-        assertTrue(typeCode.contains("CHECKSUM_TYPE_CRC_32 ChecksumType = 1 + iota"));
-        assertTrue(typeCode.contains("CHECKSUM_TYPE_CRC_32C ChecksumType = 1 + iota"));
-        assertTrue(typeCode.contains("CHECKSUM_TYPE_MD5 ChecksumType = 1 + iota"));
-        assertTrue(typeCode.contains("CHECKSUM_TYPE_SHA_256 ChecksumType = 1 + iota"));
-        assertTrue(typeCode.contains("CHECKSUM_TYPE_SHA_512 ChecksumType = 1 + iota"));
-        assertTrue(typeCode.contains("NONE ChecksumType = 1 + iota"));
+        assertTrue(containsNormalized(typeCode, "CHECKSUM_TYPE_CRC_32 ChecksumType = 1 + iota"));
+        assertTrue(containsNormalized(typeCode, "CHECKSUM_TYPE_CRC_32C ChecksumType = 1 + iota"));
+        assertTrue(containsNormalized(typeCode, "CHECKSUM_TYPE_MD5 ChecksumType = 1 + iota"));
+        assertTrue(containsNormalized(typeCode, "CHECKSUM_TYPE_SHA_256 ChecksumType = 1 + iota"));
+        assertTrue(containsNormalized(typeCode, "CHECKSUM_TYPE_SHA_512 ChecksumType = 1 + iota"));
+        assertTrue(containsNormalized(typeCode, "NONE ChecksumType = 1 + iota"));
 
         // Test un-marshaling
-        assertTrue(typeCode.contains("case \"\": *checksumType = UNDEFINED"));
-        assertTrue(typeCode.contains("case \"CRC_32\": *checksumType = CHECKSUM_TYPE_CRC_32"));
-        assertTrue(typeCode.contains("case \"CRC_32C\": *checksumType = CHECKSUM_TYPE_CRC_32C"));
-        assertTrue(typeCode.contains("case \"MD5\": *checksumType = CHECKSUM_TYPE_MD5"));
-        assertTrue(typeCode.contains("case \"SHA_256\": *checksumType = CHECKSUM_TYPE_SHA_256"));
-        assertTrue(typeCode.contains("case \"SHA_512\": *checksumType = CHECKSUM_TYPE_SHA_512"));
+        assertTrue(containsNormalized(typeCode, "case \"\": *checksumType = UNDEFINED"));
+        assertTrue(containsNormalized(typeCode, "case \"CRC_32\": *checksumType = CHECKSUM_TYPE_CRC_32"));
+        assertTrue(containsNormalized(typeCode, "case \"CRC_32C\": *checksumType = CHECKSUM_TYPE_CRC_32C"));
+        assertTrue(containsNormalized(typeCode, "case \"MD5\": *checksumType = CHECKSUM_TYPE_MD5"));
+        assertTrue(containsNormalized(typeCode, "case \"SHA_256\": *checksumType = CHECKSUM_TYPE_SHA_256"));
+        assertTrue(containsNormalized(typeCode, "case \"SHA_512\": *checksumType = CHECKSUM_TYPE_SHA_512"));
 
         // Test conversion to string
-        assertTrue(typeCode.contains("case CHECKSUM_TYPE_CRC_32: return \"CRC_32\""));
-        assertTrue(typeCode.contains("case CHECKSUM_TYPE_CRC_32C: return \"CRC_32C\""));
-        assertTrue(typeCode.contains("case CHECKSUM_TYPE_MD5: return \"MD5\""));
-        assertTrue(typeCode.contains("case CHECKSUM_TYPE_SHA_256: return \"SHA_256\""));
-        assertTrue(typeCode.contains("case CHECKSUM_TYPE_SHA_512: return \"SHA_512\""));
+        assertTrue(containsNormalized(typeCode, "case CHECKSUM_TYPE_CRC_32: return \"CRC_32\""));
+        assertTrue(containsNormalized(typeCode, "case CHECKSUM_TYPE_CRC_32C: return \"CRC_32C\""));
+        assertTrue(containsNormalized(typeCode, "case CHECKSUM_TYPE_MD5: return \"MD5\""));
+        assertTrue(containsNormalized(typeCode, "case CHECKSUM_TYPE_SHA_256: return \"SHA_256\""));
+        assertTrue(containsNormalized(typeCode, "case CHECKSUM_TYPE_SHA_512: return \"SHA_512\""));
 
         // Verify conversion to string pointer
-        assertTrue(typeCode.contains("func (checksumType ChecksumType) StringPtr() *string {"));
+        assertTrue(containsNormalized(typeCode, "func (checksumType ChecksumType) StringPtr() *string {"));
 
         // Verify type parser code was not generated for enum type
-        assertFalse(typeCode.contains("parse("));
+        assertFalse(containsNormalized(typeCode, "parse("));
     }
 
     @Test
@@ -129,25 +138,25 @@ public class GoFunctionalTypeTests {
         CODE_LOGGER.logFile(typeCode, FileTypeToLog.MODEL);
         assertTrue(hasContent(typeCode));
 
-        assertTrue(typeCode.contains("CancelOccurred bool"));
-        assertTrue(typeCode.contains("JobId string"));
-        assertTrue(typeCode.contains("NotificationGenerationDate string"));
-        assertTrue(typeCode.contains("ObjectsNotPersisted []BulkObject"));
-        assertTrue(typeCode.contains("ListedElements []TestType"));
+        assertTrue(containsNormalized(typeCode, "CancelOccurred bool"));
+        assertTrue(containsNormalized(typeCode, "JobId string"));
+        assertTrue(containsNormalized(typeCode, "NotificationGenerationDate string"));
+        assertTrue(containsNormalized(typeCode, "ObjectsNotPersisted []BulkObject"));
+        assertTrue(containsNormalized(typeCode, "ListedElements []TestType"));
 
-        assertFalse(typeCode.contains("`xml:\"CancelOccurred\"`"));
-        assertFalse(typeCode.contains("`xml:\"JobId\"`"));
-        assertFalse(typeCode.contains("`xml:\"NotificationGenerationDate\"`"));
-        assertFalse(typeCode.contains("`xml:\"ObjectsNotPersisted>Object\"`"));
-        assertFalse(typeCode.contains("`xml:\"ListedElements\"`"));
+        assertFalse(containsNormalized(typeCode, "`xml:\"CancelOccurred\"`"));
+        assertFalse(containsNormalized(typeCode, "`xml:\"JobId\"`"));
+        assertFalse(containsNormalized(typeCode, "`xml:\"NotificationGenerationDate\"`"));
+        assertFalse(containsNormalized(typeCode, "`xml:\"ObjectsNotPersisted>Object\"`"));
+        assertFalse(containsNormalized(typeCode, "`xml:\"ListedElements\"`"));
 
         // Verify type parser code was generated
-        assertTrue(typeCode.contains("jobCompletedNotificationPayload.CancelOccurred = parseBool(child.Content, aggErr)"));
-        assertTrue(typeCode.contains("jobCompletedNotificationPayload.JobId = parseString(child.Content)"));
-        assertTrue(typeCode.contains("jobCompletedNotificationPayload.NotificationGenerationDate = parseString(child.Content)"));
-        assertTrue(typeCode.contains("jobCompletedNotificationPayload.ObjectsNotPersisted = parseBulkObjectSlice(\"Object\", child.Children, aggErr)"));
-        assertTrue(typeCode.contains("jobCompletedNotificationPayload.ListedElements = append(jobCompletedNotificationPayload.ListedElements, model)"));
-        assertTrue(typeCode.contains("log.Printf(\"WARNING: unable to parse unknown xml tag '%s' while parsing JobCompletedNotificationPayload.\", child.XMLName.Local)"));
+        assertTrue(containsNormalized(typeCode, "jobCompletedNotificationPayload.CancelOccurred = parseBool(child.Content, aggErr)"));
+        assertTrue(containsNormalized(typeCode, "jobCompletedNotificationPayload.JobId = parseString(child.Content)"));
+        assertTrue(containsNormalized(typeCode, "jobCompletedNotificationPayload.NotificationGenerationDate = parseString(child.Content)"));
+        assertTrue(containsNormalized(typeCode, "jobCompletedNotificationPayload.ObjectsNotPersisted = parseBulkObjectSlice(\"Object\", child.Children, aggErr)"));
+        assertTrue(containsNormalized(typeCode, "jobCompletedNotificationPayload.ListedElements = append(jobCompletedNotificationPayload.ListedElements, model)"));
+        assertTrue(containsNormalized(typeCode, "log.Printf(\"WARNING: unable to parse unknown xml tag '%s' while parsing JobCompletedNotificationPayload.\", child.XMLName.Local)"));
     }
 
     @Test
@@ -162,64 +171,64 @@ public class GoFunctionalTypeTests {
         CODE_LOGGER.logFile(typeCode, FileTypeToLog.MODEL);
         assertTrue(hasContent(typeCode));
 
-        assertTrue(typeCode.contains("Aggregating bool"));
-        assertTrue(typeCode.contains("BucketName *string"));
-        assertTrue(typeCode.contains("CachedSizeInBytes int64"));
-        assertTrue(typeCode.contains("ChunkClientProcessingOrderGuarantee JobChunkClientProcessingOrderGuarantee"));
-        assertTrue(typeCode.contains("CompletedSizeInBytes int64"));
-        assertTrue(typeCode.contains("EntirelyInCache bool"));
-        assertTrue(typeCode.contains("JobId string"));
-        assertTrue(typeCode.contains("Naked bool"));
-        assertTrue(typeCode.contains("Name *string"));
-        assertTrue(typeCode.contains("Nodes []JobNode"));
-        assertTrue(typeCode.contains("OriginalSizeInBytes int64"));
-        assertTrue(typeCode.contains("Priority Priority"));
-        assertTrue(typeCode.contains("RequestType JobRequestType"));
-        assertTrue(typeCode.contains("StartDate string"));
-        assertTrue(typeCode.contains("Status JobStatus"));
-        assertTrue(typeCode.contains("UserId string"));
-        assertTrue(typeCode.contains("UserName *string"));
+        assertTrue(containsNormalized(typeCode, "Aggregating bool"));
+        assertTrue(containsNormalized(typeCode, "BucketName *string"));
+        assertTrue(containsNormalized(typeCode, "CachedSizeInBytes int64"));
+        assertTrue(containsNormalized(typeCode, "ChunkClientProcessingOrderGuarantee JobChunkClientProcessingOrderGuarantee"));
+        assertTrue(containsNormalized(typeCode, "CompletedSizeInBytes int64"));
+        assertTrue(containsNormalized(typeCode, "EntirelyInCache bool"));
+        assertTrue(containsNormalized(typeCode, "JobId string"));
+        assertTrue(containsNormalized(typeCode, "Naked bool"));
+        assertTrue(containsNormalized(typeCode, "Name *string"));
+        assertTrue(containsNormalized(typeCode, "Nodes []JobNode"));
+        assertTrue(containsNormalized(typeCode, "OriginalSizeInBytes int64"));
+        assertTrue(containsNormalized(typeCode, "Priority Priority"));
+        assertTrue(containsNormalized(typeCode, "RequestType JobRequestType"));
+        assertTrue(containsNormalized(typeCode, "StartDate string"));
+        assertTrue(containsNormalized(typeCode, "Status JobStatus"));
+        assertTrue(containsNormalized(typeCode, "UserId string"));
+        assertTrue(containsNormalized(typeCode, "UserName *string"));
 
-        assertFalse(typeCode.contains("`xml:\"Aggregating,attr\"`"));
-        assertFalse(typeCode.contains("`xml:\"BucketName,attr\"`"));
-        assertFalse(typeCode.contains("`xml:\"CachedSizeInBytes,attr\"`"));
-        assertFalse(typeCode.contains("`xml:\"ChunkClientProcessingOrderGuarantee,attr\"`"));
-        assertFalse(typeCode.contains("`xml:\"CompletedSizeInBytes,attr\"`"));
-        assertFalse(typeCode.contains("`xml:\"EntirelyInCache,attr\"`"));
-        assertFalse(typeCode.contains("`xml:\"JobId,attr\"`"));
-        assertFalse(typeCode.contains("`xml:\"Naked,attr\"`"));
-        assertFalse(typeCode.contains("`xml:\"Name,attr\"`"));
-        assertFalse(typeCode.contains("`xml:\"Nodes>Node\"`"));
-        assertFalse(typeCode.contains("`xml:\"OriginalSizeInBytes,attr\"`"));
-        assertFalse(typeCode.contains("`xml:\"Priority,attr\"`"));
-        assertFalse(typeCode.contains("`xml:\"RequestType,attr\"`"));
-        assertFalse(typeCode.contains("`xml:\"StartDate,attr\"`"));
-        assertFalse(typeCode.contains("`xml:\"Status,attr\"`"));
-        assertFalse(typeCode.contains("`xml:\"UserId,attr\"`"));
-        assertFalse(typeCode.contains("`xml:\"UserName,attr\"`"));
+        assertFalse(containsNormalized(typeCode, "`xml:\"Aggregating,attr\"`"));
+        assertFalse(containsNormalized(typeCode, "`xml:\"BucketName,attr\"`"));
+        assertFalse(containsNormalized(typeCode, "`xml:\"CachedSizeInBytes,attr\"`"));
+        assertFalse(containsNormalized(typeCode, "`xml:\"ChunkClientProcessingOrderGuarantee,attr\"`"));
+        assertFalse(containsNormalized(typeCode, "`xml:\"CompletedSizeInBytes,attr\"`"));
+        assertFalse(containsNormalized(typeCode, "`xml:\"EntirelyInCache,attr\"`"));
+        assertFalse(containsNormalized(typeCode, "`xml:\"JobId,attr\"`"));
+        assertFalse(containsNormalized(typeCode, "`xml:\"Naked,attr\"`"));
+        assertFalse(containsNormalized(typeCode, "`xml:\"Name,attr\"`"));
+        assertFalse(containsNormalized(typeCode, "`xml:\"Nodes>Node\"`"));
+        assertFalse(containsNormalized(typeCode, "`xml:\"OriginalSizeInBytes,attr\"`"));
+        assertFalse(containsNormalized(typeCode, "`xml:\"Priority,attr\"`"));
+        assertFalse(containsNormalized(typeCode, "`xml:\"RequestType,attr\"`"));
+        assertFalse(containsNormalized(typeCode, "`xml:\"StartDate,attr\"`"));
+        assertFalse(containsNormalized(typeCode, "`xml:\"Status,attr\"`"));
+        assertFalse(containsNormalized(typeCode, "`xml:\"UserId,attr\"`"));
+        assertFalse(containsNormalized(typeCode, "`xml:\"UserName,attr\"`"));
 
 
         // Verify type parser code was generated
-        assertTrue(typeCode.contains("job.Aggregating = parseBoolFromString(attr.Value, aggErr)"));
-        assertTrue(typeCode.contains("job.BucketName = parseNullableStringFromString(attr.Value)"));
-        assertTrue(typeCode.contains("job.CachedSizeInBytes = parseInt64FromString(attr.Value, aggErr)"));
-        assertTrue(typeCode.contains("parseEnumFromString(attr.Value, &job.ChunkClientProcessingOrderGuarantee, aggErr)"));
-        assertTrue(typeCode.contains("job.CompletedSizeInBytes = parseInt64FromString(attr.Value, aggErr)"));
-        assertTrue(typeCode.contains("job.EntirelyInCache = parseBoolFromString(attr.Value, aggErr)"));
-        assertTrue(typeCode.contains("job.JobId = attr.Value"));
-        assertTrue(typeCode.contains("job.Naked = parseBoolFromString(attr.Value, aggErr)"));
-        assertTrue(typeCode.contains("job.Name = parseNullableStringFromString(attr.Value)"));
-        assertTrue(typeCode.contains("job.OriginalSizeInBytes = parseInt64FromString(attr.Value, aggErr)"));
-        assertTrue(typeCode.contains("parseEnumFromString(attr.Value, &job.Priority, aggErr)"));
-        assertTrue(typeCode.contains("parseEnumFromString(attr.Value, &job.RequestType, aggErr)"));
-        assertTrue(typeCode.contains("job.StartDate = attr.Value"));
-        assertTrue(typeCode.contains("parseEnumFromString(attr.Value, &job.Status, aggErr)"));
-        assertTrue(typeCode.contains("job.UserId = attr.Value"));
-        assertTrue(typeCode.contains("job.UserName = parseNullableStringFromString(attr.Value)"));
-        assertTrue(typeCode.contains("log.Printf(\"WARNING: unable to parse unknown attribute '%s' while parsing Job.\", attr.Name.Local)"));
+        assertTrue(containsNormalized(typeCode, "job.Aggregating = parseBoolFromString(attr.Value, aggErr)"));
+        assertTrue(containsNormalized(typeCode, "job.BucketName = parseNullableStringFromString(attr.Value)"));
+        assertTrue(containsNormalized(typeCode, "job.CachedSizeInBytes = parseInt64FromString(attr.Value, aggErr)"));
+        assertTrue(containsNormalized(typeCode, "parseEnumFromString(attr.Value, &job.ChunkClientProcessingOrderGuarantee, aggErr)"));
+        assertTrue(containsNormalized(typeCode, "job.CompletedSizeInBytes = parseInt64FromString(attr.Value, aggErr)"));
+        assertTrue(containsNormalized(typeCode, "job.EntirelyInCache = parseBoolFromString(attr.Value, aggErr)"));
+        assertTrue(containsNormalized(typeCode, "job.JobId = attr.Value"));
+        assertTrue(containsNormalized(typeCode, "job.Naked = parseBoolFromString(attr.Value, aggErr)"));
+        assertTrue(containsNormalized(typeCode, "job.Name = parseNullableStringFromString(attr.Value)"));
+        assertTrue(containsNormalized(typeCode, "job.OriginalSizeInBytes = parseInt64FromString(attr.Value, aggErr)"));
+        assertTrue(containsNormalized(typeCode, "parseEnumFromString(attr.Value, &job.Priority, aggErr)"));
+        assertTrue(containsNormalized(typeCode, "parseEnumFromString(attr.Value, &job.RequestType, aggErr)"));
+        assertTrue(containsNormalized(typeCode, "job.StartDate = attr.Value"));
+        assertTrue(containsNormalized(typeCode, "parseEnumFromString(attr.Value, &job.Status, aggErr)"));
+        assertTrue(containsNormalized(typeCode, "job.UserId = attr.Value"));
+        assertTrue(containsNormalized(typeCode, "job.UserName = parseNullableStringFromString(attr.Value)"));
+        assertTrue(containsNormalized(typeCode, "log.Printf(\"WARNING: unable to parse unknown attribute '%s' while parsing Job.\", attr.Name.Local)"));
 
-        assertTrue(typeCode.contains("job.Nodes = parseJobNodeSlice(\"Node\", child.Children, aggErr)"));
-        assertTrue(typeCode.contains("log.Printf(\"WARNING: unable to parse unknown xml tag '%s' while parsing Job.\", child.XMLName.Local)"));
+        assertTrue(containsNormalized(typeCode, "job.Nodes = parseJobNodeSlice(\"Node\", child.Children, aggErr)"));
+        assertTrue(containsNormalized(typeCode, "log.Printf(\"WARNING: unable to parse unknown xml tag '%s' while parsing Job.\", child.XMLName.Local)"));
     }
 
     @Test
@@ -234,22 +243,22 @@ public class GoFunctionalTypeTests {
         CODE_LOGGER.logFile(typeCode, FileTypeToLog.MODEL);
         assertTrue(hasContent(typeCode));
 
-        assertTrue(typeCode.contains("EndPoint *string"));
-        assertTrue(typeCode.contains("HttpPort *int"));
-        assertTrue(typeCode.contains("HttpsPort *int"));
-        assertTrue(typeCode.contains("Id string"));
+        assertTrue(containsNormalized(typeCode, "EndPoint *string"));
+        assertTrue(containsNormalized(typeCode, "HttpPort *int"));
+        assertTrue(containsNormalized(typeCode, "HttpsPort *int"));
+        assertTrue(containsNormalized(typeCode, "Id string"));
 
-        assertFalse(typeCode.contains("`xml:\"EndPoint,attr\"`"));
-        assertFalse(typeCode.contains("`xml:\"HttpPort,attr\"`"));
-        assertFalse(typeCode.contains("`xml:\"HttpsPort,attr\"`"));
-        assertFalse(typeCode.contains("`xml:\"Id,attr\"`"));
+        assertFalse(containsNormalized(typeCode, "`xml:\"EndPoint,attr\"`"));
+        assertFalse(containsNormalized(typeCode, "`xml:\"HttpPort,attr\"`"));
+        assertFalse(containsNormalized(typeCode, "`xml:\"HttpsPort,attr\"`"));
+        assertFalse(containsNormalized(typeCode, "`xml:\"Id,attr\"`"));
 
         // Verify type parser code was generated
-        assertTrue(typeCode.contains("jobNode.EndPoint = parseNullableStringFromString(attr.Value)"));
-        assertTrue(typeCode.contains("jobNode.HttpPort = parseNullableIntFromString(attr.Value, aggErr)"));
-        assertTrue(typeCode.contains("jobNode.HttpsPort = parseNullableIntFromString(attr.Value, aggErr)"));
-        assertTrue(typeCode.contains("jobNode.Id = attr.Value"));
-        assertTrue(typeCode.contains("log.Printf(\"WARNING: unable to parse unknown attribute '%s' while parsing JobNode.\", attr.Name.Local)"));
+        assertTrue(containsNormalized(typeCode, "jobNode.EndPoint = parseNullableStringFromString(attr.Value)"));
+        assertTrue(containsNormalized(typeCode, "jobNode.HttpPort = parseNullableIntFromString(attr.Value, aggErr)"));
+        assertTrue(containsNormalized(typeCode, "jobNode.HttpsPort = parseNullableIntFromString(attr.Value, aggErr)"));
+        assertTrue(containsNormalized(typeCode, "jobNode.Id = attr.Value"));
+        assertTrue(containsNormalized(typeCode, "log.Printf(\"WARNING: unable to parse unknown attribute '%s' while parsing JobNode.\", attr.Name.Local)"));
     }
 
     @Test
@@ -264,19 +273,19 @@ public class GoFunctionalTypeTests {
         CODE_LOGGER.logFile(typeCode, FileTypeToLog.MODEL);
         assertTrue(hasContent(typeCode));
 
-        assertTrue(typeCode.contains("Jobs []Job"));
+        assertTrue(containsNormalized(typeCode, "Jobs []Job"));
 
-        assertFalse(typeCode.contains("`xml:\"Job\"`"));
+        assertFalse(containsNormalized(typeCode, "`xml:\"Job\"`"));
 
         // Verify type parser code was generated
-        assertFalse(typeCode.contains("case \"Jobs\":"));
-        assertFalse(typeCode.contains("jobList.Jobs = parseJobSlice(\"Job\", child.Children, aggErr)"));
+        assertFalse(containsNormalized(typeCode, "case \"Jobs\":"));
+        assertFalse(containsNormalized(typeCode, "jobList.Jobs = parseJobSlice(\"Job\", child.Children, aggErr)"));
 
-        assertTrue(typeCode.contains("case \"Job\":"));
-        assertTrue(typeCode.contains("var model Job"));
-        assertTrue(typeCode.contains("model.parse(&child, aggErr)"));
-        assertTrue(typeCode.contains("jobList.Jobs = append(jobList.Jobs, model)"));
-        assertTrue(typeCode.contains("log.Printf(\"WARNING: unable to parse unknown xml tag '%s' while parsing JobList.\", child.XMLName.Local)"));
+        assertTrue(containsNormalized(typeCode, "case \"Job\":"));
+        assertTrue(containsNormalized(typeCode, "var model Job"));
+        assertTrue(containsNormalized(typeCode, "model.parse(&child, aggErr)"));
+        assertTrue(containsNormalized(typeCode, "jobList.Jobs = append(jobList.Jobs, model)"));
+        assertTrue(containsNormalized(typeCode, "log.Printf(\"WARNING: unable to parse unknown xml tag '%s' while parsing JobList.\", child.XMLName.Local)"));
     }
 
     @Test
@@ -291,32 +300,32 @@ public class GoFunctionalTypeTests {
         CODE_LOGGER.logFile(typeCode, FileTypeToLog.MODEL);
         assertTrue(hasContent(typeCode));
 
-        assertTrue(typeCode.contains("CommonPrefixes []string"));
-        assertTrue(typeCode.contains("CreationDate *string"));
-        assertTrue(typeCode.contains("Delimiter *string"));
-        assertTrue(typeCode.contains("Marker *string"));
-        assertTrue(typeCode.contains("MaxKeys int"));
-        assertTrue(typeCode.contains("Name *string"));
-        assertTrue(typeCode.contains("NextMarker *string"));
-        assertTrue(typeCode.contains("Objects []Contents"));
-        assertTrue(typeCode.contains("Prefix *string"));
-        assertTrue(typeCode.contains("Truncated bool"));
+        assertTrue(containsNormalized(typeCode, "CommonPrefixes []string"));
+        assertTrue(containsNormalized(typeCode, "CreationDate *string"));
+        assertTrue(containsNormalized(typeCode, "Delimiter *string"));
+        assertTrue(containsNormalized(typeCode, "Marker *string"));
+        assertTrue(containsNormalized(typeCode, "MaxKeys int"));
+        assertTrue(containsNormalized(typeCode, "Name *string"));
+        assertTrue(containsNormalized(typeCode, "NextMarker *string"));
+        assertTrue(containsNormalized(typeCode, "Objects []Contents"));
+        assertTrue(containsNormalized(typeCode, "Prefix *string"));
+        assertTrue(containsNormalized(typeCode, "Truncated bool"));
 
         // Verify type parser code was generated
-        assertTrue(typeCode.contains("case \"CommonPrefixes\":"));
-        assertTrue(typeCode.contains("var prefixes []string"));
-        assertTrue(typeCode.contains("prefixes = parseStringSlice(\"Prefix\", child.Children, aggErr)"));
-        assertTrue(typeCode.contains("listBucketResult.CommonPrefixes = append(listBucketResult.CommonPrefixes, prefixes...)"));
+        assertTrue(containsNormalized(typeCode, "case \"CommonPrefixes\":"));
+        assertTrue(containsNormalized(typeCode, "var prefixes []string"));
+        assertTrue(containsNormalized(typeCode, "prefixes = parseStringSlice(\"Prefix\", child.Children, aggErr)"));
+        assertTrue(containsNormalized(typeCode, "listBucketResult.CommonPrefixes = append(listBucketResult.CommonPrefixes, prefixes...)"));
 
-        assertTrue(typeCode.contains("listBucketResult.CreationDate = parseNullableString(child.Content)"));
-        assertTrue(typeCode.contains("listBucketResult.Delimiter = parseNullableString(child.Content)"));
-        assertTrue(typeCode.contains("listBucketResult.Marker = parseNullableString(child.Content)"));
-        assertTrue(typeCode.contains("listBucketResult.MaxKeys = parseInt(child.Content, aggErr)"));
-        assertTrue(typeCode.contains("listBucketResult.Name = parseNullableString(child.Content)"));
-        assertTrue(typeCode.contains("listBucketResult.NextMarker = parseNullableString(child.Content)"));
-        assertTrue(typeCode.contains("listBucketResult.Objects = append(listBucketResult.Objects, model)"));
-        assertTrue(typeCode.contains("listBucketResult.Prefix = parseNullableString(child.Content)"));
-        assertTrue(typeCode.contains("listBucketResult.Truncated = parseBool(child.Content, aggErr)"));
-        assertTrue(typeCode.contains("log.Printf(\"WARNING: unable to parse unknown xml tag '%s' while parsing ListBucketResult.\", child.XMLName.Local)"));
+        assertTrue(containsNormalized(typeCode, "listBucketResult.CreationDate = parseNullableString(child.Content)"));
+        assertTrue(containsNormalized(typeCode, "listBucketResult.Delimiter = parseNullableString(child.Content)"));
+        assertTrue(containsNormalized(typeCode, "listBucketResult.Marker = parseNullableString(child.Content)"));
+        assertTrue(containsNormalized(typeCode, "listBucketResult.MaxKeys = parseInt(child.Content, aggErr)"));
+        assertTrue(containsNormalized(typeCode, "listBucketResult.Name = parseNullableString(child.Content)"));
+        assertTrue(containsNormalized(typeCode, "listBucketResult.NextMarker = parseNullableString(child.Content)"));
+        assertTrue(containsNormalized(typeCode, "listBucketResult.Objects = append(listBucketResult.Objects, model)"));
+        assertTrue(containsNormalized(typeCode, "listBucketResult.Prefix = parseNullableString(child.Content)"));
+        assertTrue(containsNormalized(typeCode, "listBucketResult.Truncated = parseBool(child.Content, aggErr)"));
+        assertTrue(containsNormalized(typeCode, "log.Printf(\"WARNING: unable to parse unknown xml tag '%s' while parsing ListBucketResult.\", child.XMLName.Local)"));
     }
 }

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/client/BaseClientGenerator_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/client/BaseClientGenerator_Test.java
@@ -72,7 +72,7 @@ public class BaseClientGenerator_Test {
                 "GetBucketHandler",
                 ImmutableList.of(
                         new HttpVerbBuildLine(HttpVerb.GET),
-                        new PathBuildLine("\"/\" + request.BucketName"),
+                        new PathBuildLine("\"/\"+request.BucketName"),
                         new OptionalQueryParamBuildLine("delimiter", "request.Delimiter"),
                         new OptionalQueryParamBuildLine("marker", "request.Marker"),
                         new OptionalQueryParamBuildLine("max_keys", "networking.IntPtrToStrPtr(request.MaxKeys)"),
@@ -147,14 +147,14 @@ public class BaseClientGenerator_Test {
                         "DeleteBucketHandler",
                         ImmutableList.of(
                                 new HttpVerbBuildLine(HttpVerb.DELETE),
-                                new PathBuildLine("\"/_rest_/bucket/\" + request.BucketName"),
+                                new PathBuildLine("\"/_rest_/bucket/\"+request.BucketName"),
                                 new VoidOptionalQueryParamBuildLine("force", "Force")
                         )),
                 new Command(
                         "CreateGetJobHandler",
                         ImmutableList.of(
                                 new HttpVerbBuildLine(HttpVerb.PUT),
-                                new PathBuildLine("\"/_rest_/bucket/\" + request.BucketName"),
+                                new PathBuildLine("\"/_rest_/bucket/\"+request.BucketName"),
                                 new OptionalQueryParamBuildLine("chunk_client_processing_order_guarantee", "networking.InterfaceToStrPtr(request.ChunkClientProcessingOrderGuarantee)"),
                                 new OptionalQueryParamBuildLine("priority", "networking.InterfaceToStrPtr(request.Priority)"),
                                 new OperationBuildLine(Operation.START_BULK_GET),

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/client/ClientGeneratorUtil_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/client/ClientGeneratorUtil_Test.java
@@ -30,29 +30,29 @@ public class ClientGeneratorUtil_Test {
     public void toRequestPathTest() {
         //Spectra requests
         assertThat(toRequestPath(getRequestDeleteNotification()))
-                .isEqualTo("\"/_rest_/job_created_notification_registration/\" + request.NotificationId");
+                .isEqualTo("\"/_rest_/job_created_notification_registration/\"+request.NotificationId");
         assertThat(toRequestPath(getRequestCreateNotification()))
                 .isEqualTo("\"/_rest_/job_created_notification_registration\"");
         assertThat(toRequestPath(getRequestGetNotification()))
-                .isEqualTo("\"/_rest_/job_completed_notification_registration/\" + request.NotificationId");
+                .isEqualTo("\"/_rest_/job_completed_notification_registration/\"+request.NotificationId");
         assertThat(toRequestPath(getRequestVerifyPhysicalPlacement())).
-                isEqualTo("\"/_rest_/bucket/\" + request.BucketName");
+                isEqualTo("\"/_rest_/bucket/\"+request.BucketName");
         assertThat(toRequestPath(getRequestBulkGet()))
-                .isEqualTo("\"/_rest_/bucket/\" + request.BucketName");
+                .isEqualTo("\"/_rest_/bucket/\"+request.BucketName");
         assertThat(toRequestPath(getRequestBulkPut()))
-                .isEqualTo("\"/_rest_/bucket/\" + request.BucketName");
+                .isEqualTo("\"/_rest_/bucket/\"+request.BucketName");
         assertThat(toRequestPath(getRequestSpectraS3GetObject()))
-                .isEqualTo("\"/_rest_/object/\" + request.ObjectName");
+                .isEqualTo("\"/_rest_/object/\"+request.ObjectName");
         assertThat(toRequestPath(getRequestGetJob()))
-                .isEqualTo("\"/_rest_/job/\" + request.JobId");
+                .isEqualTo("\"/_rest_/job/\"+request.JobId");
 
         //Amazon requests
         assertThat(toRequestPath(getRequestMultiFileDelete()))
-                .isEqualTo("\"/\" + request.BucketName");
+                .isEqualTo("\"/\"+request.BucketName");
         assertThat(toRequestPath(getRequestCreateObject()))
-                .isEqualTo("\"/\" + request.BucketName + \"/\" + request.ObjectName");
+                .isEqualTo("\"/\"+request.BucketName+\"/\"+request.ObjectName");
         assertThat(toRequestPath(getRequestAmazonS3GetObject()))
-                .isEqualTo("\"/\" + request.BucketName + \"/\" + request.ObjectName");
+                .isEqualTo("\"/\"+request.BucketName+\"/\"+request.ObjectName");
     }
 
     @Test (expected = IllegalArgumentException.class)
@@ -79,11 +79,11 @@ public class ClientGeneratorUtil_Test {
     public void getAmazonS3RequestPathTest() {
         //Amazon requests
         assertThat(getAmazonS3RequestPath(getRequestMultiFileDelete()))
-                .isEqualTo("\"/\" + request.BucketName");
+                .isEqualTo("\"/\"+request.BucketName");
         assertThat(getAmazonS3RequestPath(getRequestCreateObject()))
-                .isEqualTo("\"/\" + request.BucketName + \"/\" + request.ObjectName");
+                .isEqualTo("\"/\"+request.BucketName+\"/\"+request.ObjectName");
         assertThat(getAmazonS3RequestPath(getRequestAmazonS3GetObject()))
-                .isEqualTo("\"/\" + request.BucketName + \"/\" + request.ObjectName");
+                .isEqualTo("\"/\"+request.BucketName+\"/\"+request.ObjectName");
 
         //Spectra requests
         assertThat(getAmazonS3RequestPath(getRequestDeleteNotification())).isEmpty();
@@ -100,21 +100,21 @@ public class ClientGeneratorUtil_Test {
     public void getSpectraDs3RequestPathTest() {
         //Spectra requests
         assertThat(getSpectraDs3RequestPath(getRequestDeleteNotification()))
-                .isEqualTo("\"/_rest_/job_created_notification_registration/\" + request.NotificationId");
+                .isEqualTo("\"/_rest_/job_created_notification_registration/\"+request.NotificationId");
         assertThat(getSpectraDs3RequestPath(getRequestCreateNotification()))
                 .isEqualTo("\"/_rest_/job_created_notification_registration\"");
         assertThat(getSpectraDs3RequestPath(getRequestGetNotification()))
-                .isEqualTo("\"/_rest_/job_completed_notification_registration/\" + request.NotificationId");
+                .isEqualTo("\"/_rest_/job_completed_notification_registration/\"+request.NotificationId");
         assertThat(getSpectraDs3RequestPath(getRequestVerifyPhysicalPlacement()))
-                .isEqualTo("\"/_rest_/bucket/\" + request.BucketName");
+                .isEqualTo("\"/_rest_/bucket/\"+request.BucketName");
         assertThat(getSpectraDs3RequestPath(getRequestBulkGet()))
-                .isEqualTo("\"/_rest_/bucket/\" + request.BucketName");
+                .isEqualTo("\"/_rest_/bucket/\"+request.BucketName");
         assertThat(getSpectraDs3RequestPath(getRequestBulkPut()))
-                .isEqualTo("\"/_rest_/bucket/\" + request.BucketName");
+                .isEqualTo("\"/_rest_/bucket/\"+request.BucketName");
         assertThat(getSpectraDs3RequestPath(getRequestSpectraS3GetObject()))
-                .isEqualTo("\"/_rest_/object/\" + request.ObjectName");
+                .isEqualTo("\"/_rest_/object/\"+request.ObjectName");
         assertThat(getSpectraDs3RequestPath(getRequestGetJob()))
-                .isEqualTo("\"/_rest_/job/\" + request.JobId");
+                .isEqualTo("\"/_rest_/job/\"+request.JobId");
 
         //Amazon requests
         assertThat(getSpectraDs3RequestPath(getRequestMultiFileDelete())).isEmpty();

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/client/command/BaseCommandGenerator_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/client/command/BaseCommandGenerator_Test.java
@@ -37,7 +37,7 @@ public class BaseCommandGenerator_Test {
         assertThat(result)
                 .containsExactlyInAnyOrder(
                         new HttpVerbBuildLine(HttpVerb.PUT),
-                        new PathBuildLine("\"/\" + request.BucketName + \"/\" + request.ObjectName"),
+                        new PathBuildLine("\"/\"+request.BucketName+\"/\"+request.ObjectName"),
                         new OptionalQueryParamBuildLine("job", "request.Job"),
                         new OptionalQueryParamBuildLine("offset", "networking.Int64PtrToStrPtr(request.Offset)")
                 );
@@ -50,7 +50,7 @@ public class BaseCommandGenerator_Test {
         assertThat(result)
                 .containsExactlyInAnyOrder(
                         new HttpVerbBuildLine(HttpVerb.GET),
-                        new PathBuildLine("\"/\" + request.BucketName"),
+                        new PathBuildLine("\"/\"+request.BucketName"),
                         new OptionalQueryParamBuildLine("delimiter", "request.Delimiter"),
                         new OptionalQueryParamBuildLine("marker", "request.Marker"),
                         new OptionalQueryParamBuildLine("max_keys", "networking.IntPtrToStrPtr(request.MaxKeys)"),

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/response/BaseResponseGenerator_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/response/BaseResponseGenerator_Test.java
@@ -167,11 +167,11 @@ public class BaseResponseGenerator_Test {
     @Test
     public void toPayloadResponseCode_Test() {
         final String expectedGoCode = "var body ResponseName\n" +
-                "        if err := body.parse(webResponse); err != nil {\n" +
-                "            return nil, err\n" +
-                "        }\n" +
-                "        body.Headers = webResponse.Header()\n" +
-                "        return &body, nil";
+                "\t\tif err := body.parse(webResponse); err != nil {\n" +
+                "\t\t\treturn nil, err\n" +
+                "\t\t}\n" +
+                "\t\tbody.Headers = webResponse.Header()\n" +
+                "\t\treturn &body, nil";
 
         final ResponseCode result = generator.toPayloadResponseCode(200, "ResponseName");
         assertThat(result.getCode(), is(200));
@@ -190,10 +190,10 @@ public class BaseResponseGenerator_Test {
     @Test
     public void toStringPayloadResponseCode() {
         final String expect = "content, err := getResponseBodyAsString(webResponse)\n" +
-                "        if err != nil {\n" +
-                "            return nil, err\n" +
-                "        }\n" +
-                "        return &ResponseName{Content: content, Headers: webResponse.Header()}, nil";
+                "\t\tif err != nil {\n" +
+                "\t\t\treturn nil, err\n" +
+                "\t\t}\n" +
+                "\t\treturn &ResponseName{Content: content, Headers: webResponse.Header()}, nil";
 
         final ResponseCode result = generator.toStringPayloadResponseCode(200, "ResponseName");
         assertThat(result.getCode(), is(200));
@@ -221,10 +221,10 @@ public class BaseResponseGenerator_Test {
     @Test
     public void toResponseCode_StringPayload_Test() {
         final String expectedGoCode = "content, err := getResponseBodyAsString(webResponse)\n" +
-                "        if err != nil {\n" +
-                "            return nil, err\n" +
-                "        }\n" +
-                "        return &ResponseName{Content: content, Headers: webResponse.Header()}, nil";
+                "\t\tif err != nil {\n" +
+                "\t\t\treturn nil, err\n" +
+                "\t\t}\n" +
+                "\t\treturn &ResponseName{Content: content, Headers: webResponse.Header()}, nil";
 
         final Ds3ResponseCode responseCode = new Ds3ResponseCode(
                 200,
@@ -238,11 +238,11 @@ public class BaseResponseGenerator_Test {
     @Test
     public void toResponseCode_Test() {
         final String expectedGoCode = "var body ResponseName\n" +
-                "        if err := body.parse(webResponse); err != nil {\n" +
-                "            return nil, err\n" +
-                "        }\n" +
-                "        body.Headers = webResponse.Header()\n" +
-                "        return &body, nil";
+                "\t\tif err := body.parse(webResponse); err != nil {\n" +
+                "\t\t\treturn nil, err\n" +
+                "\t\t}\n" +
+                "\t\tbody.Headers = webResponse.Header()\n" +
+                "\t\treturn &body, nil";
 
         final Ds3ResponseCode responseCode = new Ds3ResponseCode(
                 200,
@@ -267,11 +267,11 @@ public class BaseResponseGenerator_Test {
     public void toResponseCodeList_Test() {
         final ImmutableList<ResponseCode> expectedCodes = ImmutableList.of(
                 new ResponseCode(200, "var body ResponseName\n" +
-                        "        if err := body.parse(webResponse); err != nil {\n" +
-                        "            return nil, err\n" +
-                        "        }\n" +
-                        "        body.Headers = webResponse.Header()\n" +
-                        "        return &body, nil"),
+                        "\t\tif err := body.parse(webResponse); err != nil {\n" +
+                        "\t\t\treturn nil, err\n" +
+                        "\t\t}\n" +
+                        "\t\tbody.Headers = webResponse.Header()\n" +
+                        "\t\treturn &body, nil"),
                 new ResponseCode(204, "return &ResponseName{Headers: webResponse.Header()}, nil")
         );
 
@@ -330,7 +330,7 @@ public class BaseResponseGenerator_Test {
     @Test
     public void toParseResponseMethod_WithDereference_Test() {
         final String expected = "func (modelName *ModelName) parse(webResponse WebResponse) error {\n" +
-                "        return parseResponsePayload(webResponse, &modelName.TestType)\n" +
+                "\treturn parseResponsePayload(webResponse, &modelName.TestType)\n" +
                 "}";
 
         final Ds3ResponseCode responseCode = new Ds3ResponseCode(
@@ -349,7 +349,7 @@ public class BaseResponseGenerator_Test {
     @Test
     public void toParseResponseMethod_WithoutDereference_Test() {
         final String expected = "func (modelName *ModelName) parse(webResponse WebResponse) error {\n" +
-                "        return parseResponsePayload(webResponse, modelName.TestType)\n" +
+                "\treturn parseResponsePayload(webResponse, modelName.TestType)\n" +
                 "}";
 
         final Ds3ResponseCode responseCode = new Ds3ResponseCode(

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/response/GetObjectResponseGenerator_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/response/GetObjectResponseGenerator_Test.java
@@ -31,7 +31,7 @@ public class GetObjectResponseGenerator_Test {
 
     @Test
     public void toResponseCode_200_Test() {
-        final ResponseCode expected = new ResponseCode(200, "return &GetObjectResponse{ Content: webResponse.Body(), Headers: webResponse.Header() }, nil");
+        final ResponseCode expected = new ResponseCode(200, "return &GetObjectResponse{Content: webResponse.Body(), Headers: webResponse.Header()}, nil");
 
         final Ds3ResponseCode code = new Ds3ResponseCode(200,
                 ImmutableList.of(new Ds3ResponseType("null", null)));
@@ -43,7 +43,7 @@ public class GetObjectResponseGenerator_Test {
 
     @Test
     public void toResponseCode_206_Test() {
-        final ResponseCode expected = new ResponseCode(206, "return &GetObjectResponse{ Content: webResponse.Body(), Headers: webResponse.Header() }, nil");
+        final ResponseCode expected = new ResponseCode(206, "return &GetObjectResponse{Content: webResponse.Body(), Headers: webResponse.Header()}, nil");
 
         final Ds3ResponseCode code = new Ds3ResponseCode(206,
                 ImmutableList.of(new Ds3ResponseType("null", null)));

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/response/HeadObjectResponseGenerator_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/generators/response/HeadObjectResponseGenerator_Test.java
@@ -32,7 +32,7 @@ public class HeadObjectResponseGenerator_Test {
     @Test
     public void toResponsePayloadStructTest() {
         final String expected = "BlobChecksumType ChecksumType\n" +
-                "    BlobChecksums map[int64]string";
+                "\tBlobChecksums map[int64]string";
 
         assertThat(generator.toResponsePayloadStruct(getHeadObjectRequest().getDs3ResponseCodes()), is(expected));
     }
@@ -40,14 +40,14 @@ public class HeadObjectResponseGenerator_Test {
     @Test
     public void toResponseCodeTest() {
         final String expected = "checksumType, err := getBlobChecksumType(webResponse.Header())\n" +
-                "        if err != nil {\n" +
-                "            return nil, err\n" +
-                "        }\n" +
-                "        checksumMap, err := getBlobChecksumMap(webResponse.Header())\n" +
-                "        if err != nil {\n" +
-                "            return nil, err\n" +
-                "        }\n" +
-                "        return &HeadObjectResponse{BlobChecksumType: checksumType, BlobChecksums: checksumMap, Headers: webResponse.Header()}, nil";
+                "\t\tif err != nil {\n" +
+                "\t\t\treturn nil, err\n" +
+                "\t\t}\n" +
+                "\t\tchecksumMap, err := getBlobChecksumMap(webResponse.Header())\n" +
+                "\t\tif err != nil {\n" +
+                "\t\t\treturn nil, err\n" +
+                "\t\t}\n" +
+                "\t\treturn &HeadObjectResponse{BlobChecksumType: checksumType, BlobChecksums: checksumMap, Headers: webResponse.Header()}, nil";
 
         final Ds3ResponseCode ds3ResponseCode = new Ds3ResponseCode(200,
                 ImmutableList.of(new Ds3ResponseType("null", null)));

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/models/parser/ParseChildNodeImpls_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/models/parser/ParseChildNodeImpls_Test.java
@@ -69,8 +69,8 @@ public class ParseChildNodeImpls_Test {
     @Test
     public void ParseChildNodeAddToSliceTest() {
         final String expected = String.format("var model %s\n" +
-                "            model.parse(&child, aggErr)\n" +
-                "            %s.%s = append(%s.%s, model)", CHILD_TYPE, MODEL_NAME, PARAM_NAME, MODEL_NAME, PARAM_NAME);
+                "\t\t\tmodel.parse(&child, aggErr)\n" +
+                "\t\t\t%s.%s = append(%s.%s, model)", CHILD_TYPE, MODEL_NAME, PARAM_NAME, MODEL_NAME, PARAM_NAME);
 
         final ParseElement parseElement = new ParseChildNodeAddToSlice(XML_TAG, MODEL_NAME, PARAM_NAME, CHILD_TYPE);
         assertThat(parseElement.getXmlTag(), is(XML_TAG));
@@ -80,8 +80,8 @@ public class ParseChildNodeImpls_Test {
     @Test
     public void ParseChildNodeAddEnumToSliceTest() {
         final String expected = String.format("var model %s\n" +
-                "            parseEnum(child.Content, &model, aggErr)\n" +
-                "            %s.%s = append(%s.%s, model)", CHILD_TYPE, MODEL_NAME, PARAM_NAME, MODEL_NAME, PARAM_NAME);
+                "\t\t\tparseEnum(child.Content, &model, aggErr)\n" +
+                "\t\t\t%s.%s = append(%s.%s, model)", CHILD_TYPE, MODEL_NAME, PARAM_NAME, MODEL_NAME, PARAM_NAME);
 
         final ParseElement parseElement = new ParseChildNodeAddEnumToSlice(XML_TAG, MODEL_NAME, PARAM_NAME, CHILD_TYPE);
         assertThat(parseElement.getXmlTag(), is(XML_TAG));
@@ -91,7 +91,7 @@ public class ParseChildNodeImpls_Test {
     @Test
     public void ParseChildNodeAddStringToSliceTest() {
         final String expected = String.format("var str = parseString(child.Content)\n" +
-                "            %s.%s = append(%s.%s, str)", MODEL_NAME, PARAM_NAME, MODEL_NAME, PARAM_NAME);
+                "\t\t\t%s.%s = append(%s.%s, str)", MODEL_NAME, PARAM_NAME, MODEL_NAME, PARAM_NAME);
 
         final ParseElement parseElement = new ParseChildNodeAddStringToSlice(XML_TAG, MODEL_NAME, PARAM_NAME);
         assertThat(parseElement.getXmlTag(), is(XML_TAG));
@@ -119,8 +119,8 @@ public class ParseChildNodeImpls_Test {
     @Test
     public void ParseChildNodeAsCommonPrefixTest() {
         final String expected = String.format("var prefixes []string\n" +
-                "            prefixes = parseStringSlice(\"Prefix\", child.Children, aggErr)\n" +
-                "            %s.%s = append(%s.%s, prefixes...)", MODEL_NAME, PARAM_NAME, MODEL_NAME, PARAM_NAME);
+                "\t\t\tprefixes = parseStringSlice(\"Prefix\", child.Children, aggErr)\n" +
+                "\t\t\t%s.%s = append(%s.%s, prefixes...)", MODEL_NAME, PARAM_NAME, MODEL_NAME, PARAM_NAME);
 
         final ParseElement parseElement = new ParseChildNodeAsCommonPrefix(MODEL_NAME, PARAM_NAME);
         assertThat(parseElement.getXmlTag(), is("CommonPrefixes"));
@@ -130,8 +130,8 @@ public class ParseChildNodeImpls_Test {
     @Test
     public void ParseChildNodeAsNullableDs3TypeTest() {
         final String expected = String.format("var model %s\n" +
-                "            model.parse(&child, aggErr)\n" +
-                "            %s.%s = &model", CHILD_TYPE, MODEL_NAME, PARAM_NAME);
+                "\t\t\tmodel.parse(&child, aggErr)\n" +
+                "\t\t\t%s.%s = &model", CHILD_TYPE, MODEL_NAME, PARAM_NAME);
 
         final ParseElement parseElement = new ParseChildNodeAsNullableDs3Type(XML_TAG, MODEL_NAME, PARAM_NAME, CHILD_TYPE);
         assertThat(parseElement.getXmlTag(), is(XML_TAG));

--- a/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/utils/GoFormattingUtil_Test.java
+++ b/ds3-autogen-go/src/test/java/com/spectralogic/ds3autogen/go/utils/GoFormattingUtil_Test.java
@@ -26,8 +26,8 @@ public class GoFormattingUtil_Test {
     public void goIndentTest() {
         assertThat(GoFormattingUtilKt.goIndent(-1), is(""));
         assertThat(GoFormattingUtilKt.goIndent(0), is(""));
-        assertThat(GoFormattingUtilKt.goIndent(1), is("    "));
-        assertThat(GoFormattingUtilKt.goIndent(2), is("        "));
-        assertThat(GoFormattingUtilKt.goIndent(3), is("            "));
+        assertThat(GoFormattingUtilKt.goIndent(1), is("\t"));
+        assertThat(GoFormattingUtilKt.goIndent(2), is("\t\t"));
+        assertThat(GoFormattingUtilKt.goIndent(3), is("\t\t\t"));
     }
 }


### PR DESCRIPTION
`gofmt` is now a no-op on the generated SDK with the 5.8 contract.

This is a massive change, most of which being converting spaces to tabs. The following manual tests were done to ensure the newly generated code is correct:
1. Generate the new code. "go fmt" that new code and ensure nothing changes.
2. Generate the new code. "go fmt" what's currently checked into ds3_go_sdk/ds3 (the non-go-fmt'd code that has spaces instead of tabs and whatnot). Diff those two sets of code. They are almost exactly the same. The only differences is the latter included a few unnecessary newlines that the new version doesn't generate. This is fine.